### PR TITLE
Race condition fix in MessageFormatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Install-Package MessageFormat
 ## Features
 
 * **It's fast.** Everything is hand-written; no parser-generators, *not even regular expressions*.
-* **It's portable.** The library is a PCL, and has no dependencies - the only reference is the standard `.NET` in PCL's.
+* **It's portable.** The library is a PCL, and has just a single dependency ([Portable.ConcurrentDictionary](https://www.nuget.org/packages/Portable.ConcurrentDictionary/) for thread safety) - other than that the only reference is the standard `.NET` in PCL's.
 * **It's compatible with other implementations.** I've been peeking a bit at the [MessageFormat.js][0] library to make sure
   the results would be the same.
 * **It's (relatively) small**. For a .NET library, ~25kb is not a lot.

--- a/src/Jeffijoe.MessageFormat/Jeffijoe.MessageFormat.csproj
+++ b/src/Jeffijoe.MessageFormat/Jeffijoe.MessageFormat.csproj
@@ -74,6 +74,12 @@
   <ItemGroup>
     <None Include="MessageFormat.snk" />
   </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Portable.ConcurrentDictionary, Version=1.0.3.0, Culture=neutral, PublicKeyToken=8b3524163ea7a2b3, processorArchitecture=MSIL">
+      <HintPath>..\packages\Portable.ConcurrentDictionary.1.0.3\lib\portable45-net45+win8+wp8+wpa81\Portable.ConcurrentDictionary.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Jeffijoe.MessageFormat/Jeffijoe.MessageFormat.csproj
+++ b/src/Jeffijoe.MessageFormat/Jeffijoe.MessageFormat.csproj
@@ -73,6 +73,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="MessageFormat.snk" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Portable.ConcurrentDictionary, Version=1.0.3.0, Culture=neutral, PublicKeyToken=8b3524163ea7a2b3, processorArchitecture=MSIL">

--- a/src/Jeffijoe.MessageFormat/MessageFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/MessageFormatter.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Linq;
 using System.Text;
 
@@ -40,7 +41,7 @@ namespace Jeffijoe.MessageFormat
         ///     Pattern cache. If enabled, should speed up formatting the same pattern multiple times,
         ///     regardless of arguments.
         /// </summary>
-        private readonly Dictionary<string, IFormatterRequestCollection> cache;
+        private readonly ConcurrentDictionary<string, IFormatterRequestCollection> cache;
 
         /// <summary>
         ///     The formatter library.
@@ -106,7 +107,7 @@ namespace Jeffijoe.MessageFormat
             this.Locale = locale;
             if (useCache)
             {
-                this.cache = new Dictionary<string, IFormatterRequestCollection>();
+                this.cache = new ConcurrentDictionary<string, IFormatterRequestCollection>();
             }
         }
 
@@ -384,7 +385,7 @@ namespace Jeffijoe.MessageFormat
             var requests = this.patternParser.Parse(sourceBuilder);
             if (this.cache != null)
             {
-                this.cache.Add(pattern, requests.Clone());
+                this.cache.TryAdd(pattern, requests.Clone());
             }
 
             return requests;

--- a/src/Jeffijoe.MessageFormat/Properties/AssemblyInfo.cs
+++ b/src/Jeffijoe.MessageFormat/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.CompilerServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.2.*")]
-[assembly: AssemblyFileVersion("1.0.2.*")]
+[assembly: AssemblyVersion("1.1.0.*")]
+[assembly: AssemblyFileVersion("1.1.0.*")]

--- a/src/Jeffijoe.MessageFormat/packages.config
+++ b/src/Jeffijoe.MessageFormat/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Portable.ConcurrentDictionary" version="1.0.3" targetFramework="portable45-net45+win8+wp8+wpa81" />
+</packages>


### PR DESCRIPTION
This resolves the exception listed https://github.com/jeffijoe/messageformat.net/issues/9

### Overview 
In addition to the notes listed in the above issue. I would like _in the future_ to come back and propose some changes with MessageFormatter around standardizing the way we get instances of that class. 

Today you can use the factory method (where the locks play a part) or you create instances via new but if client code shares those you will get the issue this PR is trying to solve. 

I want to stress that this PR is geared towards preventing the exception I listed in the issue above only. 

### Code review consideration 
* Is the minor version release ok?
* Are you ok with the new dependency added. I originally tried System.Collections.Concurrent.4.3.0 but got the old 
```
Install-Package : Could not install package 'System.Collections.Concurrent 4.3.0'. You are trying to install this package into a project that targets '.NETPortable,Version=v4.5,Profile=Profile259', but the package does 
not contain any assembly references or content files that are compatible with that framework
```

### Testing consideration 
* [x] Running Unit test with success 