### PR TITLE
Change escaping to follow the ICU 4.8 rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ Install-Package MessageFormat
   take advantage of the code in my base classes to help you parse patterns. Look at the source, this is how I implemented the built-in formatters.
 * **Exceptions make atleast a little sense.** When exceptions are thrown due to a bad pattern, the exception should include useful information.
 * **There are unit tests.** Run them yourself if you want, they're using XUnit.
-* **Built-in cache.** If you are formatting messages in a tight loop, with different data for each iteration, 
+* **Built-in cache.** If you are formatting messages in a tight loop, with different data for each iteration,
   and if you are reusing the same instance of `MessageFormatter`, the formatter will cache the tokens of each pattern (nested, too),
-  so it won't have to spend CPU time to parse out literals every time. I benchmarked it, and on my monster machine, 
+  so it won't have to spend CPU time to parse out literals every time. I benchmarked it, and on my monster machine,
   it didn't make much of a difference (10000 iterations).
 
 ## Performance
@@ -89,7 +89,7 @@ Basically, it should be able to do anything that [MessageFormat.js][0] can do.
 * Select Format: `{gender, select, male{He likes} female{She likes} other{They like}} cheeseburgers`
 * Plural Format: `There {msgCount, plural, zero {are no unread messages} one {is 1 unread message} other{are # unread messages}}.` (where `#` is the actual number, with the offset (if any) subtracted).
 * Simple variable replacement: `Your name is {name}`
- 
+
 ## Adding your own pluralizer functions
 
 Same thing as with [MessageFormat.js][0], you can add your own pluralizer function.
@@ -132,14 +132,16 @@ mf.FormatMessage("You have {number, plural, thatsalot {a shitload of notificatio
 
 ## Escaping literals
 
-Simple - the literals are `{`, `}` and `#` (in a plural block). 
-To escape a literal, use a `\` - e.g. `\{`.
-  
+Simple - the literals are `{`, `}` and `#` (in a plural block).
+If literals occur in the text portions, then they need to be quoted by enclosing them in pairs of single quotes (`'`).
+A pair of single quotes always represents one single quote (`''` -> `'`), which still applies inside quoted text.
+(`This '{isn''t}' obvious` → `This {isn't} obvious`)
+
 # Anything else?
 
-There's not a lot - Alex Sexton of [MessageFormat.js][0] did a great 
+There's not a lot - Alex Sexton of [MessageFormat.js][0] did a great
 job documenting his library, and like I said,
-I wrote my implementation so it would 
+I wrote my implementation so it would
 be (somewhat) compatible with his.
 
 # Bugs / issues

--- a/src/Jeffijoe.MessageFormat.Tests/Formatting/BaseFormatterTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Formatting/BaseFormatterTests.cs
@@ -1,6 +1,6 @@
 ﻿// MessageFormat for .NET
 // - BaseFormatterTests.cs
-// 
+//
 // Author: Jeff Hansen <jeff@jeffijoe.com>
 // Copyright (C) Jeff Hansen 2015. All rights reserved.
 
@@ -58,20 +58,20 @@ namespace Jeffijoe.MessageFormat.Tests.Formatting
                 yield return
                     new object[]
                     {
-                        "offset:1 test:1337 one {programmer}   other{programmers}", 
-                        new[] { "offset", "test" }, 
-                        new[] { "1", "1337" }, 
-                        new[] { "one", "other" }, 
+                        "offset:1 test:1337 one {programmer}   other{programmers}",
+                        new[] { "offset", "test" },
+                        new[] { "1", "1337" },
+                        new[] { "one", "other" },
                         new[] { "programmer", "programmers" }
                     };
 
                 yield return
                     new object[]
                     {
-                        "offset:1 test:1337 one\\123 {programmer}   other{programmers}", 
-                        new[] { "offset", "test" }, 
-                        new[] { "1", "1337" }, 
-                        new[] { "one\\123", "other" }, 
+                        "offset:1 test:1337 one\\123 {programmer}   other{programmers}",
+                        new[] { "offset", "test" },
+                        new[] { "1", "1337" },
+                        new[] { "one\\123", "other" },
                         new[] { "programmer", "programmers" }
                     };
             }
@@ -87,15 +87,15 @@ namespace Jeffijoe.MessageFormat.Tests.Formatting
                 yield return
                     new object[]
                     {
-                        "male {he} female {she}unknown{they}", 
-                        new[] { "male", "female", "unknown" }, 
+                        "male {he} female {she}unknown{they}",
+                        new[] { "male", "female", "unknown" },
                         new[] { "he", "she", "they" }
                     };
                 yield return
                     new object[]
                     {
-                        "zero {} other {wee}", 
-                        new[] { "zero", "other" }, 
+                        "zero {} other {wee}",
+                        new[] { "zero", "other" },
                         new[] { string.Empty, "wee" }
                     };
                 yield return new object[] { @"
@@ -108,8 +108,8 @@ unknown
                         male {he} 
                         female {she{dawg}}
 unknown
-    {they\{dawg\}}
-", new[] { "male", "female", "unknown" }, new[] { "he", "she{dawg}", @"they\{dawg\}" } };
+    {they'{dawg}'}
+", new[] { "male", "female", "unknown" }, new[] { "he", "she{dawg}", @"they'{dawg}'" } };
             }
         }
 
@@ -138,10 +138,10 @@ unknown
         [Theory]
         [MemberData("ParseArguments_tests")]
         public void ParseArguments(
-            string args, 
-            string[] extensionKeys, 
-            string[] extensionValues, 
-            string[] keys, 
+            string args,
+            string[] extensionKeys,
+            string[] extensionValues,
+            string[] keys,
             string[] blocks)
         {
             var subject = new BaseFormatterImpl();
@@ -175,11 +175,11 @@ unknown
         [Theory]
         [InlineData("hello {{dawg}")]
         [InlineData("hello {dawg}}")]
-        [InlineData("hello \\{dawg}")]
-        [InlineData("hello {dawg\\}")]
+        [InlineData("hello '{dawg}")]
+        [InlineData("hello {dawg'}")]
         [InlineData("hello {dawg} {sweet}")]
         [InlineData("hello {dawg} test{sweet}}")]
-        [InlineData("hello \\{{dawg\\}} test{sweet}")]
+        [InlineData("hello '{{dawg'}} test{sweet}")]
         public void ParseArguments_invalid(string args)
         {
             var subject = new BaseFormatterImpl();

--- a/src/Jeffijoe.MessageFormat.Tests/Formatting/BaseFormatterTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Formatting/BaseFormatterTests.cs
@@ -304,6 +304,23 @@ unknown
             }
         }
 
+        /// <summary>
+        /// The parse keyed blocks unclosed_escape_sequence.
+        /// </summary>
+        /// <param name="args">
+        /// The args.
+        /// </param>
+        [Theory]
+        [InlineData("male {he} other {'{they}")]
+        [InlineData("male {he} other {'# they}")]
+        public void ParseKeyedBlocks_unclosed_escape_sequence(string args)
+        {
+            var subject = new BaseFormatterImpl();
+            var req = new FormatterRequest(new Literal(1, 1, 1, 1, new StringBuilder()), null, null, args);
+
+            Assert.Throws<MalformedLiteralException>(() => subject.ParseKeyedBlocks(req, 0));
+        }
+
         #endregion
 
         /// <summary>

--- a/src/Jeffijoe.MessageFormat.Tests/MessageFormatterCachingTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/MessageFormatterCachingTests.cs
@@ -1,6 +1,6 @@
 ﻿// MessageFormat for .NET
 // - MessageFormatter_caching_tests.cs
-// 
+//
 // Author: Jeff Hansen <jeff@jeffijoe.com>
 // Copyright (C) Jeff Hansen 2015. All rights reserved.
 
@@ -114,11 +114,11 @@ namespace Jeffijoe.MessageFormat.Tests
         private void Benchmark(MessageFormatter subject)
         {
             var pattern = "\r\n----\r\nOh {name}? And if we were " + "to surround {gender, select, " + "male {his} "
-                          + "female {her}" + "} name with \\{ and \\}, it would look "
-                          + "like \\{{name}\\}? Yeah, I know {gender, select, " + "male {him} " + "female {her}"
+                          + "female {her}" + "} name with '{' and '}', it would look "
+                          + "like '{'{name}'}'? Yeah, I know {gender, select, " + "male {him} " + "female {her}"
                           + "}. {gender, select, " + "male {He's}" + "female {She's}" + "} got {messageCount, plural, "
                           + "zero {no messages}" + "one {just one message}" + "=42 {a universal amount of messages}"
-                          + "other {uuhm... let's see.. Oh yeah, # messages - and here's a pound: \\#}" + "}!";
+                          + "other {uuhm... let's see.. Oh yeah, # messages - and here's a pound: '#'}" + "}!";
             int iterations = 100000;
             var args = new Dictionary<string, object>[iterations];
             var rnd = new Random();
@@ -128,8 +128,8 @@ namespace Jeffijoe.MessageFormat.Tests
                 args[i] =
                     new
                     {
-                        gender = val % 2 == 0 ? "male" : "female", 
-                        name = val % 2 == 0 ? "Jeff" : "Amanda", 
+                        gender = val % 2 == 0 ? "male" : "female",
+                        name = val % 2 == 0 ? "Jeff" : "Amanda",
                         messageCount = val
                     }.ToDictionary();
             }

--- a/src/Jeffijoe.MessageFormat.Tests/MessageFormatterFullIntegrationTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/MessageFormatterFullIntegrationTests.cs
@@ -1,6 +1,6 @@
 ﻿// MessageFormat for .NET
 // - MessageFormatter_full_integration_tests.cs
-// 
+//
 // Author: Jeff Hansen <jeff@jeffijoe.com>
 // Copyright (C) Jeff Hansen 2015. All rights reserved.
 
@@ -45,6 +45,62 @@ namespace Jeffijoe.MessageFormat.Tests
 
         #region Public Properties
 
+        public static IEnumerable<object[]> EscapingTests
+        {
+            get
+            {
+                yield return
+                    new object[]
+                    {
+                        "This '{isn''t}' obvious",
+                        new Dictionary<string, object>(),
+                        "This {isn't} obvious"
+                    };
+                yield return
+                    new object[]
+                    {
+                        "Anna's house has '{0} and # in the roof' and {NUM_COWS} cows.",
+                        new Dictionary<string, object> { { "NUM_COWS", 5 } },
+                        "Anna's house has {0} and # in the roof and 5 cows."
+                    };
+                yield return
+                    new object[]
+                    {
+                        "Anna's house has '{'0'} and # in the roof' and {NUM_COWS} cows.",
+                        new Dictionary<string, object> { { "NUM_COWS", 5 } },
+                        "Anna's house has {0} and # in the roof and 5 cows."
+                    };
+                yield return
+                    new object[]
+                    {
+                        "Anna's house has '{0}' and '# in the roof' and {NUM_COWS} cows.",
+                        new Dictionary<string, object> { { "NUM_COWS", 5 } },
+                        "Anna's house has {0} and # in the roof and 5 cows."
+                    };
+                yield return
+                    new object[]
+                    {
+                        "Anna's house 'has {NUM_COWS} cows'.",
+                        new Dictionary<string, object> { { "NUM_COWS", 5 } },
+                        "Anna's house 'has 5 cows'."
+                    };
+                yield return
+                    new object[]
+                    {
+                        "Anna''s house a'{''''b'",
+                        new Dictionary<string, object>(),
+                        "Anna's house a{''b"
+                    };
+                yield return
+                    new object[]
+                    {
+                        "a''{NUM_COWS}'b",
+                        new Dictionary<string, object> { { "NUM_COWS", 5 } },
+                        "a'5'b"
+                    };
+            }
+        }
+
         /// <summary>
         /// Gets the tests.
         /// </summary>
@@ -53,13 +109,13 @@ namespace Jeffijoe.MessageFormat.Tests
             get
             {
                 const string Case1 = @"{gender, select, 
-                           male {He - \{{name}\} -}
-                           female {She - \{{name}\} -}
+                           male {He - '{'{name}'}' -}
+                           female {She - '{'{name}'}' -}
                            other {They}
                       } said: You're pretty cool!";
                 const string Case2 = @"{gender, select, 
-                           male {He - \{{name}\} -}
-                           female {She - \{{name}\} -}
+                           male {He - '{'{name}'}' -}
+                           female {She - '{'{name}'}' -}
                            other {They}
                       } said: You have {count, plural, 
                             zero {no notifications}
@@ -116,92 +172,92 @@ namespace Jeffijoe.MessageFormat.Tests
                 yield return
                     new object[]
                     {
-                        Case1, 
-                        new Dictionary<string, object> { { "gender", "male" }, { "name", "Jeff" } }, 
+                        Case1,
+                        new Dictionary<string, object> { { "gender", "male" }, { "name", "Jeff" } },
                         "He - {Jeff} - said: You're pretty cool!"
                     };
                 yield return
                     new object[]
                     {
-                        Case2, 
-                        new Dictionary<string, object> { { "gender", "male" }, { "name", "Jeff" }, { "count", 0 } }, 
+                        Case2,
+                        new Dictionary<string, object> { { "gender", "male" }, { "name", "Jeff" }, { "count", 0 } },
                         "He - {Jeff} - said: You have no notifications. Have a nice day!"
                     };
                 yield return
                     new object[]
                     {
-                        Case2, 
-                        new Dictionary<string, object> { { "gender", "female" }, { "name", "Amanda" }, { "count", 1 } }, 
+                        Case2,
+                        new Dictionary<string, object> { { "gender", "female" }, { "name", "Amanda" }, { "count", 1 } },
                         "She - {Amanda} - said: You have just one notification. Have a nice day!"
                     };
                 yield return
                     new object[]
                     {
-                        Case2, 
-                        new Dictionary<string, object> { { "gender", "uni" }, { "count", 42 } }, 
+                        Case2,
+                        new Dictionary<string, object> { { "gender", "uni" }, { "count", 42 } },
                         "They said: You have a universal amount of notifications. Have a nice day!"
                     };
                 yield return
                     new object[]
                     {
-                        Case3, 
-                        new Dictionary<string, object> { { "count", 5 } }, 
+                        Case3,
+                        new Dictionary<string, object> { { "count", 5 } },
                         "You have 5 notifications. Have a nice day!"
                     };
                 yield return
                     new object[]
                     {
-                        Case4, 
-                        new Dictionary<string, object> { { "count", 5 }, { "gender", "male" } }, 
+                        Case4,
+                        new Dictionary<string, object> { { "count", 5 }, { "gender", "male" } },
                         "He said: You have 5 notifications. Have a nice day!"
                     };
                 yield return
                     new object[]
                     {
-                        Case5, 
-                        new Dictionary<string, object> { { "count", 5 }, { "gender", "male" }, { "genitals", 0 } }, 
+                        Case5,
+                        new Dictionary<string, object> { { "count", 5 }, { "gender", "male" }, { "genitals", 0 } },
                         "He (who has no testicles) said: You have 5 notifications. Have a nice day!"
                     };
                 yield return
                     new object[]
                     {
-                        Case5, 
-                        new Dictionary<string, object> { { "count", 5 }, { "gender", "female" }, { "genitals", 0 } }, 
+                        Case5,
+                        new Dictionary<string, object> { { "count", 5 }, { "gender", "female" }, { "genitals", 0 } },
                         "She (who has no boobies) said: You have 5 notifications. Have a nice day!"
                     };
                 yield return
                     new object[]
                     {
-                        Case5, 
-                        new Dictionary<string, object> { { "count", 0 }, { "gender", "female" }, { "genitals", 1 } }, 
+                        Case5,
+                        new Dictionary<string, object> { { "count", 0 }, { "gender", "female" }, { "genitals", 1 } },
                         "She (who has just one boob) said: You have no notifications. Have a nice day!"
                     };
                 yield return
                     new object[]
                     {
-                        Case5, 
-                        new Dictionary<string, object> { { "count", 0 }, { "gender", "female" }, { "genitals", 2 } }, 
+                        Case5,
+                        new Dictionary<string, object> { { "count", 0 }, { "gender", "female" }, { "genitals", 2 } },
                         "She (who has a pair of lovelies) said: You have no notifications. Have a nice day!"
                     };
                 yield return
                     new object[]
                     {
-                        Case5, 
-                        new Dictionary<string, object> { { "count", 0 }, { "gender", "female" }, { "genitals", 102 } }, 
+                        Case5,
+                        new Dictionary<string, object> { { "count", 0 }, { "gender", "female" }, { "genitals", 102 } },
                         "She (who has the freakish amount of 102 boobies) said: You have no notifications. Have a nice day!"
                     };
                 yield return
                     new object[]
                     {
-                        Case5, 
-                        new Dictionary<string, object> { { "count", 42 }, { "gender", "female" }, { "genitals", 102 } }, 
+                        Case5,
+                        new Dictionary<string, object> { { "count", 42 }, { "gender", "female" }, { "genitals", 102 } },
                         "She (who has the freakish amount of 102 boobies) said: You have a universal amount of notifications. Have a nice day!"
                     };
                 yield return
                     new object[]
                     {
-                        Case5, 
-                        new Dictionary<string, object> { { "count", 1 }, { "gender", "male" }, { "genitals", 102 } }, 
+                        Case5,
+                        new Dictionary<string, object> { { "count", 1 }, { "gender", "male" }, { "genitals", 102 } },
                         "He (who has the insane amount of 102 testicles) said: You have just one notification. Have a nice day!"
                     };
 
@@ -209,8 +265,8 @@ namespace Jeffijoe.MessageFormat.Tests
                 yield return
                     new object[]
                     {
-                        "{nbrAttachments, plural, zero {} one {{nbrAttachmentsFmt} attachment} other {{nbrAttachmentsFmt} attachments}}", 
-                        new Dictionary<string, object> { { "nbrAttachments", 0 }, { "nbrAttachmentsFmt", "wut" } }, 
+                        "{nbrAttachments, plural, zero {} one {{nbrAttachmentsFmt} attachment} other {{nbrAttachmentsFmt} attachments}}",
+                        new Dictionary<string, object> { { "nbrAttachments", 0 }, { "nbrAttachmentsFmt", "wut" } },
                         string.Empty
                     };
 
@@ -218,43 +274,43 @@ namespace Jeffijoe.MessageFormat.Tests
                 yield return
                     new object[]
                     {
-                        "{maybeCount}", 
-                        new Dictionary<string, object> { { "maybeCount", null } }, 
+                        "{maybeCount}",
+                        new Dictionary<string, object> { { "maybeCount", null } },
                         string.Empty
                     };
                 yield return
                     new object[]
                     {
-                        "{maybeCount}", 
-                        new Dictionary<string, object> { { "maybeCount", (int?)2 } }, 
+                        "{maybeCount}",
+                        new Dictionary<string, object> { { "maybeCount", (int?)2 } },
                         "2"
                     };
                 yield return
                     new object[]
                     {
-                        Case6, 
-                        new Dictionary<string, object> { { "count", 0 } }, 
+                        Case6,
+                        new Dictionary<string, object> { { "count", 0 } },
                         "You didn't add this to your profile."
                     };
                 yield return
                     new object[]
                     {
-                        Case6, 
-                        new Dictionary<string, object> { { "count", 1 } }, 
+                        Case6,
+                        new Dictionary<string, object> { { "count", 1 } },
                         "You added this to your profile."
                     };
                 yield return
                     new object[]
                     {
-                        Case6, 
-                        new Dictionary<string, object> { { "count", 2 } }, 
+                        Case6,
+                        new Dictionary<string, object> { { "count", 2 } },
                         "You and one other person added this to their profile."
                     };
                 yield return
                     new object[]
                     {
-                        Case6, 
-                        new Dictionary<string, object> { { "count", 3 } }, 
+                        Case6,
+                        new Dictionary<string, object> { { "count", 3 } },
                         "You and 2 others added this to their profiles."
                     };
             }
@@ -289,6 +345,19 @@ namespace Jeffijoe.MessageFormat.Tests
             Benchmark.End(this.outputHelper);
             Assert.Equal(expected, result);
             this.outputHelper.WriteLine(result);
+        }
+
+        /// <summary>
+        /// The format message_debug.
+        /// </summary>
+        [Theory]
+        [MemberData("EscapingTests")]
+        public void FormatMessage_escaping(string source, Dictionary<string, object> args, string expected)
+        {
+            var subject = new MessageFormatter(false);
+
+            string result = subject.FormatMessage(source, args);
+            Assert.Equal(expected, result);
         }
 
         /// <summary>
@@ -336,7 +405,7 @@ namespace Jeffijoe.MessageFormat.Tests
             var subject = new MessageFormatter(false);
             const string Pattern = @"{s1, select, 
                                 1 {{s2, select, 
-                                   2 {\{}
+                                   2 {'{'}
                                 }}
                             }";
             var actual = subject.FormatMessage(Pattern, new { s1 = 1, s2 = 2 });
@@ -385,7 +454,7 @@ namespace Jeffijoe.MessageFormat.Tests
                               other {# notifications}
                             }. Have a nice day, {name}!";
                 var formatted = mf.FormatMessage(
-                    Str, 
+                    Str,
                     new Dictionary<string, object> { { "notifications", 4 }, { "name", "Jeff" } });
                 Assert.Equal("You have 4 notifications. Have a nice day, Jeff!", formatted);
             }
@@ -425,31 +494,31 @@ namespace Jeffijoe.MessageFormat.Tests
                                             other {# categories}
                                          }.";
                 var formatted = mf.FormatMessage(
-                    Str, 
+                    Str,
                     new Dictionary<string, object>
                     {
-                        { "GENDER", "male" }, 
-                        { "NUM_RESULTS", 1 }, 
+                        { "GENDER", "male" },
+                        { "NUM_RESULTS", 1 },
                         { "NUM_CATEGORIES", 2 }
                     });
                 Assert.Equal(formatted, "He found 1 result in 2 categories.");
 
                 formatted = mf.FormatMessage(
-                    Str, 
+                    Str,
                     new Dictionary<string, object>
                     {
-                        { "GENDER", "male" }, 
-                        { "NUM_RESULTS", 1 }, 
+                        { "GENDER", "male" },
+                        { "NUM_RESULTS", 1 },
                         { "NUM_CATEGORIES", 1 }
                     });
                 Assert.Equal(formatted, "He found 1 result in 1 category.");
 
                 formatted = mf.FormatMessage(
-                    Str, 
+                    Str,
                     new Dictionary<string, object>
                     {
-                        { "GENDER", "female" }, 
-                        { "NUM_RESULTS", 2 }, 
+                        { "GENDER", "female" },
+                        { "NUM_RESULTS", 2 },
                         { "NUM_CATEGORIES", 1 }
                     });
                 Assert.Equal(formatted, "She found 2 results in 1 category.");
@@ -469,7 +538,7 @@ namespace Jeffijoe.MessageFormat.Tests
                 var mf = new MessageFormatter(false);
                 const string Str = @"His name is {LAST_NAME}... {FIRST_NAME} {LAST_NAME}";
                 var formatted = mf.FormatMessage(
-                    Str, 
+                    Str,
                     new Dictionary<string, object> { { "FIRST_NAME", "James" }, { "LAST_NAME", "Bond" } });
                 Assert.Equal(formatted, "His name is Bond... James Bond");
             }
@@ -515,7 +584,7 @@ namespace Jeffijoe.MessageFormat.Tests
 
                 var actual =
                     mf.FormatMessage(
-                        "You have {number, plural, thatsalot {a shitload of notifications} other {# notifications}}", 
+                        "You have {number, plural, thatsalot {a shitload of notifications} other {# notifications}}",
                         new Dictionary<string, object> { { "number", 1001 } });
                 Assert.Equal("You have a shitload of notifications", actual);
             }

--- a/src/Jeffijoe.MessageFormat.Tests/MessageFormatterFullIntegrationTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/MessageFormatterFullIntegrationTests.cs
@@ -98,6 +98,13 @@ namespace Jeffijoe.MessageFormat.Tests
                         new Dictionary<string, object> { { "NUM_COWS", 5 } },
                         "a'5'b"
                     };
+                yield return
+                    new object[]
+                    {
+                        "a'{NUM_COWS}'b'",
+                        new Dictionary<string, object> { { "NUM_COWS", 5 } },
+                        "a{NUM_COWS}b'"
+                    };
             }
         }
 

--- a/src/Jeffijoe.MessageFormat.Tests/MessageFormatterTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/MessageFormatterTests.cs
@@ -1,6 +1,6 @@
 ﻿// MessageFormat for .NET
 // - MessageFormatterTests.cs
-// 
+//
 // Author: Jeff Hansen <jeff@jeffijoe.com>
 // Copyright (C) Jeff Hansen 2015. All rights reserved.
 
@@ -87,14 +87,14 @@ namespace Jeffijoe.MessageFormat.Tests
             var requests = new[]
             {
                 new FormatterRequest(
-                    new Literal(0, 5, 1, 7, new StringBuilder("name")), 
-                    "name", 
-                    null, 
-                    null), 
+                    new Literal(0, 5, 1, 7, new StringBuilder("name")),
+                    "name",
+                    null,
+                    null),
                 new FormatterRequest(
-                    new Literal(11, 33, 1, 7, new StringBuilder("messages, plural, 123")), 
-                    "messages", 
-                    "plural", 
+                    new Literal(11, 33, 1, 7, new StringBuilder("messages, plural, 123")),
+                    "messages",
+                    "plural",
                     " 123")
             };
 
@@ -130,8 +130,8 @@ namespace Jeffijoe.MessageFormat.Tests
         /// The expected.
         /// </param>
         [Theory]
-        [InlineData(@"Hello \{buddy\}, how are you \{doing\}?", "Hello {buddy}, how are you {doing}?")]
-        [InlineData(@"Hello \\{buddy\\}, how are you \{doing\}?", @"Hello \{buddy\}, how are you {doing}?")]
+        [InlineData(@"Hello '{buddy}', how are you '{doing}'?", "Hello {buddy}, how are you {doing}?")]
+        [InlineData(@"Hello ''{buddy}'', how are you '{doing}'?", @"Hello '{buddy}', how are you {doing}?")]
         public void UnescapeLiterals(string source, string expected)
         {
             var actual = this.subject.UnescapeLiterals(new StringBuilder(source)).ToString();
@@ -151,14 +151,14 @@ namespace Jeffijoe.MessageFormat.Tests
             var requests = new[]
             {
                 new FormatterRequest(
-                    new Literal(0, 5, 1, 7, new StringBuilder("name")), 
-                    "name", 
-                    null, 
-                    null), 
+                    new Literal(0, 5, 1, 7, new StringBuilder("name")),
+                    "name",
+                    null,
+                    null),
                 new FormatterRequest(
-                    new Literal(11, 33, 1, 7, new StringBuilder("messages, plural, 123")), 
-                    "messages", 
-                    "plural", 
+                    new Literal(11, 33, 1, 7, new StringBuilder("messages, plural, 123")),
+                    "messages",
+                    "plural",
                     " 123")
             };
 
@@ -172,7 +172,7 @@ namespace Jeffijoe.MessageFormat.Tests
                 (int index, int length) => requests[1].SourceLiteral.ShiftIndices(length - 2, requests[0].SourceLiteral));
 
             var ex = Assert.Throws<VariableNotFoundException>(() => this.subject.FormatMessage(Pattern, args));
-            Assert.Equal("name", ex.MissingVariable);    
+            Assert.Equal("name", ex.MissingVariable);
         }
 
         #endregion

--- a/src/Jeffijoe.MessageFormat.Tests/Parsing/LiteralParserTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Parsing/LiteralParserTests.cs
@@ -75,6 +75,36 @@ namespace Jeffijoe.MessageFormat.Tests.Parsing
         }
 
         /// <summary>
+        /// The parse unclosed_escape_sequence.
+        /// </summary>
+        /// <param name="source">
+        /// The source.
+        /// </param>
+        /// <param name="expectedLineNumber">
+        /// The expected line number.
+        /// </param>
+        /// <param name="expectedColumnNumber">
+        /// The expected column number.
+        /// </param>
+        [Theory]
+        [InlineData("'{", 1, 1)]
+        [InlineData("'}", 1, 1)]
+        [InlineData("a {b {c} d}, '{open escape sequence}", 1, 14)]
+        [InlineData(@"Hello,
+'{World}", 2, 1)]
+        public void ParseLiterals_unclosed_escape_sequence(
+            string source,
+            int expectedLineNumber,
+            int expectedColumnNumber)
+        {
+            var sb = new StringBuilder(source);
+            var subject = new LiteralParser();
+            var ex = Assert.Throws<MalformedLiteralException>(() => subject.ParseLiterals(sb));
+            Assert.Equal(expectedLineNumber, ex.LineNumber);
+            Assert.Equal(expectedColumnNumber, ex.ColumnNumber);
+        }
+
+        /// <summary>
         /// The parse literals_position_and_inner_text.
         /// </summary>
         /// <param name="source">

--- a/src/Jeffijoe.MessageFormat.Tests/Parsing/LiteralParserTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Parsing/LiteralParserTests.cs
@@ -1,6 +1,6 @@
 ﻿// MessageFormat for .NET
 // - LiteralParserTests.cs
-// 
+//
 // Author: Jeff Hansen <jeff@jeffijoe.com>
 // Copyright (C) Jeff Hansen 2015. All rights reserved.
 
@@ -39,11 +39,11 @@ namespace Jeffijoe.MessageFormat.Tests.Parsing
         [InlineData("An ending }", 0, 1)]
         [InlineData("One { and multiple }}", 1, 2)]
         [InlineData("A few {{{{ and one }", 4, 1)]
-        [InlineData("A few {{{{ and one \\}}", 4, 1)]
-        [InlineData("A few \\{{{{{ and one \\}}", 4, 1)]
+        [InlineData("A few {{{{ and one '}'}", 4, 1)]
+        [InlineData("A few '{'{{{{ and one '}'}", 4, 1)]
         public void ParseLiterals_bracket_mismatch(
-            string source, 
-            int expectedOpenBraceCount, 
+            string source,
+            int expectedOpenBraceCount,
             int expectedCloseBraceCount)
         {
             var sb = new StringBuilder(source);
@@ -65,7 +65,7 @@ namespace Jeffijoe.MessageFormat.Tests.Parsing
         [Theory]
         [InlineData("Hello, {something smells {really} weird.}", 1)]
         [InlineData("Hello, {something smells {really} weird.}, {Hi}", 2)]
-        [InlineData("Hello, {something smells {really} weird.}, \\{Hi\\}", 1)]
+        [InlineData("Hello, {something smells {really} weird.}, '{Hi}'", 1)]
         public void ParseLiterals_count(string source, int expectedMatchCount)
         {
             var sb = new StringBuilder(source);
@@ -94,9 +94,9 @@ sweet
 
 }, right?", new[] { 0, 9 }, @"sweet")]
         [InlineData(@"{
-\{sweet\}
+'{sweet}'
 
-}, right?", new[] { 0, 13 }, @"\{sweet\}")]
+}, right?", new[] { 0, 13 }, @"'{sweet}'")]
         public void ParseLiterals_position_and_inner_text(string source, int[] position, string expectedInnerText)
         {
             var sb = new StringBuilder(source);

--- a/src/Jeffijoe.MessageFormat.Tests/Parsing/PatternParser/PatternParserParseTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Parsing/PatternParser/PatternParserParseTests.cs
@@ -1,6 +1,6 @@
 ﻿// MessageFormat for .NET
 // - PatternParser_Parse_Tests.cs
-// 
+//
 // Author: Jeff Hansen <jeff@jeffijoe.com>
 // Copyright (C) Jeff Hansen 2015. All rights reserved.
 
@@ -66,9 +66,11 @@ namespace Jeffijoe.MessageFormat.Tests.Parsing
         [Theory]
         [InlineData("test, select, args", "test", "select", "args")]
         [InlineData("test, select, stuff {dawg}", "test", "select", "stuff {dawg}")]
-        [InlineData("test, select, stuff \\{{dawg}\\}", "test", "select", "stuff \\{{dawg}\\}")]
-        [InlineData("test, select, stuff {dawg, select, {name is \\{{name}\\}}}", "test", "select", 
-            "stuff {dawg, select, {name is \\{{name}\\}}}")]
+        [InlineData("test, select, stuff {dawg's}", "test", "select", "stuff {dawg's}")]
+        [InlineData("test, select, stuff {dawg''s}", "test", "select", "stuff {dawg''s}")]
+        [InlineData("test, select, stuff '{{dawg}}'", "test", "select", "stuff '{{dawg}}'")]
+        [InlineData("test, select, stuff {dawg, select, {name is '{'{name}'}'}}", "test", "select",
+            "stuff {dawg, select, {name is '{'{name}'}'}}")]
         public void Parse(string source, string expectedKey, string expectedFormat, string expectedArgs)
         {
             var literalParserMock = new Mock<ILiteralParser>();

--- a/src/Jeffijoe.MessageFormat/Formatting/BaseFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/BaseFormatter.cs
@@ -151,7 +151,11 @@ namespace Jeffijoe.MessageFormat.Formatting
                         if (!insideEscapeSequence)
                             block.Append(EscapingChar);
 
-                        insideEscapeSequence = !insideEscapeSequence; // TODO: throw if insideEscapeSequence == true at the end
+                        // The last char can't open a new escape sequence, it can only close one
+                        if (insideEscapeSequence)
+                        {
+                            insideEscapeSequence = false;
+                        }
                         continue;
                     }
 
@@ -276,6 +280,15 @@ namespace Jeffijoe.MessageFormat.Formatting
                 {
                     foundWhitespaceAfterKey = true;
                 }
+            }
+
+            if (insideEscapeSequence)
+            {
+                throw new MalformedLiteralException(
+                    "There is an unclosed escape sequence.",
+                    0,
+                    0,
+                    request.FormatterArguments);
             }
 
             if (braceBalance > 0)

--- a/src/Jeffijoe.MessageFormat/Formatting/Formatters/SelectFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/Formatters/SelectFormatter.cs
@@ -45,12 +45,12 @@ namespace Jeffijoe.MessageFormat.Formatting.Formatters
         /// The <see cref="string" />.
         /// </returns>
         /// <exception cref="MessageFormatterException">'other' option not found in pattern, and variable was not present in collection.</exception>
-        [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1126:PrefixCallsCorrectly", 
+        [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1126:PrefixCallsCorrectly",
             Justification = "Reviewed. Suppression is OK here.")]
         public string Format(
-            string locale, 
+            string locale,
             FormatterRequest request,
-            IDictionary<string, object> args, 
+            IDictionary<string, object> args,
             object value,
             IMessageFormatter messageFormatter)
         {
@@ -63,7 +63,7 @@ namespace Jeffijoe.MessageFormat.Formatting.Formatters
                 {
                     return messageFormatter.FormatMessage(keyedBlock.BlockText, args);
                 }
-                
+
                 if (keyedBlock.Key == OtherKey)
                 {
                     other = keyedBlock;

--- a/src/Jeffijoe.MessageFormat/MessageFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/MessageFormatter.cs
@@ -335,8 +335,6 @@ namespace Jeffijoe.MessageFormat
                         {
                             if (!insideEscapeSequence)
                                 dest.Append(EscapingChar);
-
-                            insideEscapeSequence = !insideEscapeSequence; // TODO: throw if insideEscapeSequence == true at the end
                             continue;
                         }
 


### PR DESCRIPTION
This commit changes the quoting to the rules described by the icu-project here: [http://userguide.icu-project.org/formatparse/messages](http://userguide.icu-project.org/formatparse/messages)

This also makes it more compatible with MessageFormat.js

