### PR TITLE
Add Russian and Ukrainian pluralizer languages

### DIFF
--- a/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/PluralFormatterTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/PluralFormatterTests.cs
@@ -74,6 +74,56 @@ namespace Jeffijoe.MessageFormat.Tests.Formatting.Formatters
             var actual = subject.ReplaceNumberLiterals(new StringBuilder(input), 1337);
             Assert.Equal(expected, actual);
         }
+        
+        [Theory]
+        [InlineData(0, "днів")]
+        [InlineData(101, "день")]
+        [InlineData(102, "дні")]
+        [InlineData(105, "днів")]
+        public void Uk_PluralizerTests(double n, string expected)
+        {
+            var subject = new PluralFormatter();
+            var args = new Dictionary<string, object> { { "test", n } };
+            var arguments =
+                new ParsedArguments(
+                    new[]
+                    {
+                        new KeyedBlock("zero", "днів"),
+                        new KeyedBlock("one", "день"),
+                        new KeyedBlock("few", "дні"),
+                        new KeyedBlock("many", "днів"),
+                        new KeyedBlock("other", "дня")
+                    },
+                    new FormatterExtension[0]);
+            var request = new FormatterRequest(new Literal(1, 1, 1, 1, new StringBuilder()), "test", "plural", null);
+            var actual = subject.Pluralize("uk", arguments, Convert.ToDouble(args[request.Variable]), 0);
+            Assert.Equal(expected, actual);
+        }
+        
+        [Theory]
+        [InlineData(0, "дней")]
+        [InlineData(101, "день")]
+        [InlineData(102, "дня")]
+        [InlineData(105, "дней")]
+        public void Ru_PluralizerTests(double n, string expected)
+        {
+            var subject = new PluralFormatter();
+            var args = new Dictionary<string, object> { { "test", n } };
+            var arguments =
+                new ParsedArguments(
+                    new[]
+                    {
+                        new KeyedBlock("zero", "дней"),
+                        new KeyedBlock("one", "день"),
+                        new KeyedBlock("few", "дня"),
+                        new KeyedBlock("many", "дней"),
+                        new KeyedBlock("other", "дня")
+                    },
+                    new FormatterExtension[0]);
+            var request = new FormatterRequest(new Literal(1, 1, 1, 1, new StringBuilder()), "test", "plural", null);
+            var actual = subject.Pluralize("ru", arguments, Convert.ToDouble(args[request.Variable]), 0);
+            Assert.Equal(expected, actual);
+        }
 
         #endregion
     }

--- a/src/Jeffijoe.MessageFormat/Formatting/Formatters/PluralFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/Formatters/PluralFormatter.cs
@@ -293,6 +293,70 @@ namespace Jeffijoe.MessageFormat.Formatting.Formatters
                     // ReSharper restore CompareOfFloatsByEqualityOperator
                     return "other";
                 });
+            
+            this.Pluralizers.Add(
+                "ru",
+                n =>
+                {
+                    // ReSharper disable CompareOfFloatsByEqualityOperator
+                    if (n == (int) n) 
+                    // ReSharper restore CompareOfFloatsByEqualityOperator
+                    {
+                        var integer = (int) n;
+                        var remainderTen = integer % 10;
+                        var remainderHundred = integer % 100;
+
+                        if (remainderTen == 1 && remainderHundred != 11)
+                        {
+                            return "one";
+                        }
+
+                        if (remainderTen >= 2 && remainderTen <= 4 && (remainderHundred < 12 || remainderHundred > 14))
+                        {
+                            return "few";
+                        }
+
+                        if (remainderTen == 0 || (remainderTen >= 5 && remainderTen <= 9) ||
+                            (remainderHundred >= 11 && remainderHundred <= 14))
+                        {
+                            return "many";
+                        }
+                    }
+
+                    return "other";
+                });
+            
+            this.Pluralizers.Add(
+                "uk",
+                n =>
+                {
+                    // ReSharper disable CompareOfFloatsByEqualityOperator
+                    if (n == (int) n) 
+                    // ReSharper restore CompareOfFloatsByEqualityOperator
+                    {
+                        var integer = (int) n;
+                        var remainderTen = integer % 10;
+                        var remainderHundred = integer % 100;
+
+                        if (remainderTen == 1 && remainderHundred != 11)
+                        {
+                            return "one";
+                        }
+
+                        if (remainderTen >= 2 && remainderTen <= 4 && (remainderHundred < 12 || remainderHundred > 14))
+                        {
+                            return "few";
+                        }
+
+                        if (remainderTen == 0 || (remainderTen >= 5 && remainderTen <= 9) ||
+                            (remainderHundred >= 11 && remainderHundred <= 14))
+                        {
+                            return "many";
+                        }
+                    }
+
+                    return "other";
+                });
         }
 
         #endregion


### PR DESCRIPTION
Adding Ukrainian and Russian pluralizer languages. The rules were taken from this table https://unicode-org.github.io/cldr-staging/charts/37/supplemental/language_plural_rules.html

Added tests.