### PR TITLE
Reduce allocations

### DIFF
--- a/src/Jeffijoe.MessageFormat.Tests/Formatting/BaseFormatterTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Formatting/BaseFormatterTests.cs
@@ -145,7 +145,7 @@ unknown
             string[] blocks)
         {
             var subject = new BaseFormatterImpl();
-            var req = new FormatterRequest(new Literal(1, 1, 1, 1, new StringBuilder()), string.Empty, null, args);
+            var req = new FormatterRequest(new Literal(1, 1, 1, 1, ""), string.Empty, null, args);
             var actual = subject.ParseArguments(req);
 
             Assert.Equal(extensionKeys.Length, actual.Extensions.Count());
@@ -183,7 +183,7 @@ unknown
         public void ParseArguments_invalid(string args)
         {
             var subject = new BaseFormatterImpl();
-            var req = new FormatterRequest(new Literal(1, 1, 1, 1, new StringBuilder()), string.Empty, null, args);
+            var req = new FormatterRequest(new Literal(1, 1, 1, 1, ""), string.Empty, null, args);
             var ex = Assert.Throws<MalformedLiteralException>(() => subject.ParseArguments(req));
             this.outputHelper.WriteLine(ex.Message);
         }
@@ -210,7 +210,7 @@ unknown
         {
             var subject = new BaseFormatterImpl();
             int index;
-            var req = new FormatterRequest(new Literal(1, 1, 1, 1, new StringBuilder()), string.Empty, null, args);
+            var req = new FormatterRequest(new Literal(1, 1, 1, 1, ""), string.Empty, null, args);
 
             // Warmup
             subject.ParseExtensions(req, out index);
@@ -242,7 +242,7 @@ unknown
             var args = " offset:2 code:js ";
             var expectedIndex = 17;
 
-            var req = new FormatterRequest(new Literal(1, 1, 1, 1, new StringBuilder()), string.Empty, null, args);
+            var req = new FormatterRequest(new Literal(1, 1, 1, 1, ""), string.Empty, null, args);
 
             var actual = subject.ParseExtensions(req, out index);
             Assert.NotEmpty(actual);
@@ -274,7 +274,7 @@ unknown
         public void ParseKeyedBlocks(string args, string[] keys, string[] values)
         {
             var subject = new BaseFormatterImpl();
-            var req = new FormatterRequest(new Literal(1, 1, 1, 1, new StringBuilder()), string.Empty, null, args);
+            var req = new FormatterRequest(new Literal(1, 1, 1, 1, ""), string.Empty, null, args);
 
             // Warm-up
             subject.ParseKeyedBlocks(req, 0);
@@ -316,7 +316,7 @@ unknown
         public void ParseKeyedBlocks_unclosed_escape_sequence(string args)
         {
             var subject = new BaseFormatterImpl();
-            var req = new FormatterRequest(new Literal(1, 1, 1, 1, new StringBuilder()), string.Empty, null, args);
+            var req = new FormatterRequest(new Literal(1, 1, 1, 1, ""), string.Empty, null, args);
 
             Assert.Throws<MalformedLiteralException>(() => subject.ParseKeyedBlocks(req, 0));
         }

--- a/src/Jeffijoe.MessageFormat.Tests/Formatting/FormatterLibraryTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Formatting/FormatterLibraryTests.cs
@@ -32,7 +32,7 @@ namespace Jeffijoe.MessageFormat.Tests.Formatting
             var mock1 = new Mock<IFormatter>();
             var mock2 = new Mock<IFormatter>();
 
-            var req = new FormatterRequest(new Literal(1, 1, 1, 1, new StringBuilder()), "test", "dawg", null);
+            var req = new FormatterRequest(new Literal(1, 1, 1, 1, ""), "test", "dawg", null);
             subject.Add(mock1.Object);
             subject.Add(mock2.Object);
 

--- a/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/PluralFormatterTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/PluralFormatterTests.cs
@@ -49,7 +49,7 @@ namespace Jeffijoe.MessageFormat.Tests.Formatting.Formatters
                         new KeyedBlock("other", "wow")
                     },
                     new FormatterExtension[0]);
-            var request = new FormatterRequest(new Literal(1, 1, 1, 1, new StringBuilder()), "test", "plural", null);
+            var request = new FormatterRequest(new Literal(1, 1, 1, 1, ""), "test", "plural", null);
             var actual = subject.Pluralize("en", arguments, new PluralContext(Convert.ToDecimal(Convert.ToDouble(args[request.Variable]))), 0);
             Assert.Equal(expected, actual);
         }

--- a/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/PluralFormatterTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/PluralFormatterTests.cs
@@ -71,7 +71,7 @@ namespace Jeffijoe.MessageFormat.Tests.Formatting.Formatters
         public void ReplaceNumberLiterals(string input, string expected)
         {
             var subject = new PluralFormatter();
-            var actual = subject.ReplaceNumberLiterals(new StringBuilder(input), 1337);
+            var actual = subject.ReplaceNumberLiterals(input, 1337);
             Assert.Equal(expected, actual);
         }
 

--- a/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/SelectFormatterTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/SelectFormatterTests.cs
@@ -62,7 +62,7 @@ namespace Jeffijoe.MessageFormat.Tests.Formatting.Formatters
             messageFormatterMock.Setup(x => x.FormatMessage(It.IsAny<string>(), It.IsAny<Dictionary<string, object?>>()))
                                 .Returns((string input, Dictionary<string, object> a) => input);
             var req = new FormatterRequest(
-                new Literal(1, 1, 1, 1, new StringBuilder()), 
+                new Literal(1, 1, 1, 1, ""), 
                 "gender", 
                 "select", 
                 formatterArgs);

--- a/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/VariableFormatterTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/VariableFormatterTests.cs
@@ -87,7 +87,7 @@ namespace Jeffijoe.MessageFormat.Tests.Formatting.Formatters
         /// </returns>
         private static FormatterRequest CreateRequest()
         {
-            var req = new FormatterRequest(new Literal(1, 10, 1, 1, new StringBuilder()), "test", null, null);
+            var req = new FormatterRequest(new Literal(1, 10, 1, 1, ""), "test", null, null);
             return req;
         }
 

--- a/src/Jeffijoe.MessageFormat.Tests/MessageFormatterTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/MessageFormatterTests.cs
@@ -87,12 +87,12 @@ namespace Jeffijoe.MessageFormat.Tests
             var requests = new[]
             {
                 new FormatterRequest(
-                    new Literal(0, 5, 1, 7, new StringBuilder("name")),
+                    new Literal(0, 5, 1, 7, "name"),
                     "name",
                     null,
                     null),
                 new FormatterRequest(
-                    new Literal(11, 33, 1, 7, new StringBuilder("messages, plural, 123")),
+                    new Literal(11, 33, 1, 7, "messages, plural, 123"),
                     "messages",
                     "plural",
                     " 123")
@@ -153,12 +153,12 @@ namespace Jeffijoe.MessageFormat.Tests
             var requests = new[]
             {
                 new FormatterRequest(
-                    new Literal(0, 5, 1, 7, new StringBuilder("name")),
+                    new Literal(0, 5, 1, 7, "name"),
                     "name",
                     null,
                     null),
                 new FormatterRequest(
-                    new Literal(11, 33, 1, 7, new StringBuilder("messages, plural, 123")),
+                    new Literal(11, 33, 1, 7, "messages, plural, 123"),
                     "messages",
                     "plural",
                     " 123")
@@ -194,7 +194,7 @@ namespace Jeffijoe.MessageFormat.Tests
             var requests = new[]
             {
                 new FormatterRequest(
-                    new Literal(0, 5, 1, 7, new StringBuilder("name")),
+                    new Literal(0, 5, 1, 7, "name"),
                     "name",
                     null,
                     null),

--- a/src/Jeffijoe.MessageFormat.Tests/MessageFormatterTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/MessageFormatterTests.cs
@@ -101,6 +101,8 @@ namespace Jeffijoe.MessageFormat.Tests
             this.formatterMock1.Setup(x => x.Format("en", requests[0], args, "Jeff", this.subject)).Returns("Jeff");
             this.formatterMock2.Setup(x => x.Format("en", requests[1], args, 1, this.subject)).Returns("123 messages");
             this.collectionMock.Setup(x => x.GetEnumerator()).Returns(requests.AsEnumerable().GetEnumerator());
+            this.collectionMock.Setup(x => x.Count).Returns(requests.Length);
+            this.collectionMock.Setup(x => x[It.IsAny<int>()]).Returns((int i) => requests[i]);
             this.libraryMock.Setup(x => x.GetFormatter(requests[0])).Returns(this.formatterMock1.Object);
             this.libraryMock.Setup(x => x.GetFormatter(requests[1])).Returns(this.formatterMock2.Object);
             this.patternParserMock.Setup(x => x.Parse(It.IsAny<StringBuilder>())).Returns(this.collectionMock.Object);
@@ -163,6 +165,8 @@ namespace Jeffijoe.MessageFormat.Tests
             };
 
             this.collectionMock.Setup(x => x.GetEnumerator()).Returns(() => requests.AsEnumerable().GetEnumerator());
+            this.collectionMock.Setup(x => x.Count).Returns(requests.Length);
+            this.collectionMock.Setup(x => x[It.IsAny<int>()]).Returns((int i) => requests[i]);
             this.patternParserMock.Setup(x => x.Parse(It.IsAny<StringBuilder>())).Returns(this.collectionMock.Object);
             this.formatterMock1.SetupGet(x => x.VariableMustExist).Returns(true);
             this.libraryMock.Setup(x => x.GetFormatter(It.IsAny<FormatterRequest>())).Returns(formatterMock1.Object);
@@ -197,6 +201,8 @@ namespace Jeffijoe.MessageFormat.Tests
             };
 
             this.collectionMock.Setup(x => x.GetEnumerator()).Returns(() => requests.AsEnumerable().GetEnumerator());
+            this.collectionMock.Setup(x => x.Count).Returns(requests.Length);
+            this.collectionMock.Setup(x => x[It.IsAny<int>()]).Returns((int i) => requests[i]);
             this.patternParserMock.Setup(x => x.Parse(It.IsAny<StringBuilder>())).Returns(this.collectionMock.Object);
             this.libraryMock.Setup(x => x.GetFormatter(It.IsAny<FormatterRequest>())).Returns(formatterMock2.Object);
             this.formatterMock2.SetupGet(x => x.VariableMustExist).Returns(false);

--- a/src/Jeffijoe.MessageFormat.Tests/MetadataGenerator/GeneratedPluralRulesTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/MetadataGenerator/GeneratedPluralRulesTests.cs
@@ -30,7 +30,7 @@ namespace Jeffijoe.MessageFormat.Tests.MetadataGenerator
                         new KeyedBlock("other", "дня")
                     },
                     new FormatterExtension[0]);
-            var request = new FormatterRequest(new Literal(1, 1, 1, 1, new StringBuilder()), "test", "plural", null);
+            var request = new FormatterRequest(new Literal(1, 1, 1, 1, ""), "test", "plural", null);
             var actual = subject.Pluralize("uk", arguments, new PluralContext(Convert.ToDecimal(Convert.ToDouble(args[request.Variable]))), 0);
             Assert.Equal(expected, actual);
         }
@@ -55,7 +55,7 @@ namespace Jeffijoe.MessageFormat.Tests.MetadataGenerator
                         new KeyedBlock("other", "дня")
                     },
                     new FormatterExtension[0]);
-            var request = new FormatterRequest(new Literal(1, 1, 1, 1, new StringBuilder()), "test", "plural", null);
+            var request = new FormatterRequest(new Literal(1, 1, 1, 1, ""), "test", "plural", null);
             var actual = subject.Pluralize("ru", arguments, new PluralContext(Convert.ToDecimal(args[request.Variable])), 0);
             Assert.Equal(expected, actual);
         }
@@ -78,7 +78,7 @@ namespace Jeffijoe.MessageFormat.Tests.MetadataGenerator
                         new KeyedBlock("other", "days")
                     },
                     new FormatterExtension[0]);
-            var request = new FormatterRequest(new Literal(1, 1, 1, 1, new StringBuilder()), "test", "plural", null);
+            var request = new FormatterRequest(new Literal(1, 1, 1, 1, ""), "test", "plural", null);
             var actual = subject.Pluralize("en", arguments, new PluralContext(Convert.ToDecimal(args[request.Variable])), 0);
             Assert.Equal(expected, actual);
         }

--- a/src/Jeffijoe.MessageFormat.Tests/Parsing/FormatterRequestCollectionTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Parsing/FormatterRequestCollectionTests.cs
@@ -30,19 +30,19 @@ namespace Jeffijoe.MessageFormat.Tests.Parsing
             var subject = new FormatterRequestCollection();
             subject.Add(
                 new FormatterRequest(
-                    new Literal(0, 9, 1, 1, new StringBuilder(new string('a', 10))), 
+                    new Literal(0, 9, 1, 1, new string('a', 10)), 
                     "test", 
                     "test", 
                     "test"));
             subject.Add(
                 new FormatterRequest(
-                    new Literal(10, 19, 1, 1, new StringBuilder(new string('a', 10))), 
+                    new Literal(10, 19, 1, 1, new string('a', 10)), 
                     "test", 
                     "test", 
                     "test"));
             subject.Add(
                 new FormatterRequest(
-                    new Literal(20, 29, 1, 1, new StringBuilder(new string('a', 10))), 
+                    new Literal(20, 29, 1, 1, new string('a', 10)), 
                     "test", 
                     "test", 
                     "test"));
@@ -67,19 +67,19 @@ namespace Jeffijoe.MessageFormat.Tests.Parsing
             var subject = new FormatterRequestCollection();
             subject.Add(
                 new FormatterRequest(
-                    new Literal(0, 9, 1, 1, new StringBuilder(new string('a', 10))), 
+                    new Literal(0, 9, 1, 1, new string('a', 10)), 
                     "test", 
                     "test", 
                     "test"));
             subject.Add(
                 new FormatterRequest(
-                    new Literal(10, 19, 1, 1, new StringBuilder(new string('a', 10))), 
+                    new Literal(10, 19, 1, 1, new string('a', 10)), 
                     "test", 
                     "test", 
                     "test"));
             subject.Add(
                 new FormatterRequest(
-                    new Literal(20, 29, 1, 1, new StringBuilder(new string('a', 10))), 
+                    new Literal(20, 29, 1, 1, new string('a', 10)), 
                     "test", 
                     "test", 
                     "test"));

--- a/src/Jeffijoe.MessageFormat.Tests/Parsing/LiteralTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Parsing/LiteralTests.cs
@@ -25,8 +25,8 @@ namespace Jeffijoe.MessageFormat.Tests.Parsing
         [Fact]
         public void ShiftIndices()
         {
-            var subject = new Literal(20, 29, 1, 1, new StringBuilder(new string('a', 10)));
-            var other = new Literal(5, 10, 1, 1, new StringBuilder(new string('a', 6)));
+            var subject = new Literal(20, 29, 1, 1, new string('a', 10));
+            var other = new Literal(5, 10, 1, 1, new string('a', 6));
 
             subject.ShiftIndices(2, other);
 

--- a/src/Jeffijoe.MessageFormat.Tests/Parsing/PatternParser/PatternParserGetKeyTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Parsing/PatternParser/PatternParserGetKeyTests.cs
@@ -52,12 +52,12 @@ namespace Jeffijoe.MessageFormat.Tests.Parsing
         {
             get
             {
-                yield return new object[] { new Literal(3, 10, 1, 3, new StringBuilder("Hellåw,")), 1, 8 };
-                yield return new object[] { new Literal(0, 0, 3, 3, new StringBuilder(",")), 3, 4 };
-                yield return new object[] { new Literal(0, 0, 3, 3, new StringBuilder(" hello dawg")), 0, 0 };
-                yield return new object[] { new Literal(0, 0, 3, 3, new StringBuilder("hello dawg ")), 0, 0 };
-                yield return new object[] { new Literal(0, 0, 3, 3, new StringBuilder(" hello dawg")), 0, 0 };
-                yield return new object[] { new Literal(0, 0, 3, 3, new StringBuilder(" hello\r\ndawg")), 0, 0 };
+                yield return new object[] { new Literal(3, 10, 1, 3, "Hellåw,"), 1, 8 };
+                yield return new object[] { new Literal(0, 0, 3, 3, ","), 3, 4 };
+                yield return new object[] { new Literal(0, 0, 3, 3, " hello dawg"), 0, 0 };
+                yield return new object[] { new Literal(0, 0, 3, 3, "hello dawg "), 0, 0 };
+                yield return new object[] { new Literal(0, 0, 3, 3, " hello dawg"), 0, 0 };
+                yield return new object[] { new Literal(0, 0, 3, 3, " hello\r\ndawg"), 0, 0 };
             }
         }
 
@@ -88,7 +88,7 @@ namespace Jeffijoe.MessageFormat.Tests.Parsing
         [InlineData("0", "0", 0)]
         public void ReadLiteralSection(string source, string expected, int expectedLastIndex)
         {
-            var literal = new Literal(10, 10, 1, 1, new StringBuilder(source));
+            var literal = new Literal(10, 10, 1, 1, source);
             int lastIndex;
             Assert.Equal(expected, PatternParser.ReadLiteralSection(literal, 0, false, out lastIndex));
             Assert.Equal(expectedLastIndex, lastIndex);
@@ -142,7 +142,7 @@ namespace Jeffijoe.MessageFormat.Tests.Parsing
         [InlineData("SupDawg,", null, 8)]
         public void ReadLiteralSection_with_offset(string source, string expected, int offset)
         {
-            var literal = new Literal(10, 10, 1, 1, new StringBuilder(source));
+            var literal = new Literal(10, 10, 1, 1, source);
             int lastIndex;
             Assert.Equal(expected, PatternParser.ReadLiteralSection(literal, offset, true, out lastIndex));
         }

--- a/src/Jeffijoe.MessageFormat.Tests/Parsing/PatternParser/PatternParserParseTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Parsing/PatternParser/PatternParserParseTests.cs
@@ -77,7 +77,7 @@ namespace Jeffijoe.MessageFormat.Tests.Parsing
             var sb = new StringBuilder(source);
             literalParserMock.Setup(x => x.ParseLiterals(sb));
             literalParserMock.Setup(x => x.ParseLiterals(sb))
-                             .Returns(new[] { new Literal(0, source.Length, 1, 1, new StringBuilder(source)) });
+                             .Returns(new[] { new Literal(0, source.Length, 1, 1, source) });
 
             var subject = new PatternParser(literalParserMock.Object);
 

--- a/src/Jeffijoe.MessageFormat/Formatting/BaseFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/BaseFormatter.cs
@@ -62,14 +62,13 @@ namespace Jeffijoe.MessageFormat.Formatting
             
             int length = request.FormatterArguments.Length;
             index = 0;
+            const char Colon = ':';
+            bool foundExtension = false;
 
             var extension = StringBuilderPool.Get();
             var value = StringBuilderPool.Get();
-
             try
             {
-                const char Colon = ':';
-                bool foundExtension = false;
                 for (int i = 0; i < length; i++)
                 {
                     var c = request.FormatterArguments[i];

--- a/src/Jeffijoe.MessageFormat/Formatting/FormatterLibrary.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/FormatterLibrary.cs
@@ -45,13 +45,13 @@ namespace Jeffijoe.MessageFormat.Formatting
         /// </exception>
         public IFormatter GetFormatter(FormatterRequest request)
         {
-            var formatter = this.FirstOrDefault(x => x.CanFormat(request));
-            if (formatter == null)
+            foreach (var formatter in this)
             {
-                throw new FormatterNotFoundException(request);
+                if (formatter.CanFormat(request))
+                    return formatter;
             }
 
-            return formatter;
+            throw new FormatterNotFoundException(request);
         }
 
         #endregion

--- a/src/Jeffijoe.MessageFormat/Formatting/FormatterRequest.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/FormatterRequest.cs
@@ -47,7 +47,7 @@ namespace Jeffijoe.MessageFormat.Formatting
         /// <value>
         ///     The formatter arguments.
         /// </value>
-        public string? FormatterArguments { get; private set; }
+        public string? FormatterArguments { get; }
 
         /// <summary>
         ///     Gets the name of the formatter to use . e.g. 'select', 'plural'. Can be null.
@@ -55,7 +55,7 @@ namespace Jeffijoe.MessageFormat.Formatting
         /// <value>
         ///     The name of the formatter.
         /// </value>
-        public string? FormatterName { get; private set; }
+        public string? FormatterName { get; }
 
         /// <summary>
         ///     Gets the source literal.
@@ -63,7 +63,7 @@ namespace Jeffijoe.MessageFormat.Formatting
         /// <value>
         ///     The source literal.
         /// </value>
-        public Literal SourceLiteral { get; private set; }
+        public Literal SourceLiteral { get; }
 
         /// <summary>
         ///     Gets the variable name. Never null.
@@ -71,7 +71,7 @@ namespace Jeffijoe.MessageFormat.Formatting
         /// <value>
         ///     The variable.
         /// </value>
-        public string Variable { get; private set; }
+        public string Variable { get; }
 
         #endregion
 

--- a/src/Jeffijoe.MessageFormat/Formatting/Formatters/PluralContext.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/Formatters/PluralContext.cs
@@ -48,7 +48,7 @@ namespace Jeffijoe.MessageFormat.Formatting.Formatters
             }
             else
             {
-#if NET5_0
+#if NET5_0_OR_GREATER
                 var fractionSpan = number.AsSpan(dotIndex + 1, number.Length - dotIndex - 1);
                 var fractionSpanWithoutZeroes = fractionSpan.TrimEnd('0');
 #else

--- a/src/Jeffijoe.MessageFormat/Formatting/Formatters/VariableFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/Formatters/VariableFormatter.cs
@@ -69,12 +69,10 @@ namespace Jeffijoe.MessageFormat.Formatting.Formatters
         {
             switch (value)
             {
-                case null:
-                    return string.Empty;
                 case IFormattable formattable:
                     return formattable.ToString(null, GetCultureInfo(locale));
                 default:
-                    return value.ToString();
+                    return value?.ToString() ?? string.Empty;
             }
         }
 

--- a/src/Jeffijoe.MessageFormat/Formatting/IFormatterLibrary.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/IFormatterLibrary.cs
@@ -23,7 +23,7 @@ namespace Jeffijoe.MessageFormat.Formatting
         /// <returns>
         ///     The <see cref="IFormatter" />.
         /// </returns>
-        IFormatter? GetFormatter(FormatterRequest request);
+        IFormatter GetFormatter(FormatterRequest request);
 
         #endregion
     }

--- a/src/Jeffijoe.MessageFormat/Helpers/StringBuilderHelper.cs
+++ b/src/Jeffijoe.MessageFormat/Helpers/StringBuilderHelper.cs
@@ -3,6 +3,7 @@
 // Author: Jeff Hansen <jeff@jeffijoe.com>
 // Copyright (C) Jeff Hansen 2014. All rights reserved.
 
+using System;
 using System.Text;
 
 namespace Jeffijoe.MessageFormat.Helpers
@@ -28,6 +29,15 @@ namespace Jeffijoe.MessageFormat.Helpers
         /// </returns>
         internal static bool Contains(this StringBuilder src, params char[] chars)
         {
+#if NET5_0_OR_GREATER
+            foreach (var chunk in src.GetChunks())
+            {
+                if (chunk.Span.IndexOfAny(chars) != -1)
+                {
+                    return true;
+                }
+            }
+#else
             for (int i = 0; i < src.Length; i++)
             {
                 foreach (var c in chars)
@@ -38,6 +48,40 @@ namespace Jeffijoe.MessageFormat.Helpers
                     }
                 }
             }
+#endif
+
+            return false;
+        }
+        
+        /// <summary>
+        ///     Determines whether the specified source contains the specified character.
+        /// </summary>
+        /// <param name="src">
+        ///     The source.
+        /// </param>
+        /// <param name="character">
+        ///     The character.
+        /// </param>
+        /// <returns>
+        ///     The <see cref="bool" />.
+        /// </returns>
+        internal static bool Contains(this StringBuilder src, char character)
+        {
+#if NET5_0_OR_GREATER
+            foreach (var chunk in src.GetChunks())
+            {
+                if (chunk.Span.IndexOf(character) != -1)
+                    return true;
+            }
+#else
+            for (int i = 0; i < src.Length; i++)
+            {
+                if (src[i] == character)
+                {
+                    return true;
+                }
+            }
+#endif
 
             return false;
         }
@@ -105,6 +149,6 @@ namespace Jeffijoe.MessageFormat.Helpers
             return src;
         }
 
-        #endregion
+#endregion
     }
 }

--- a/src/Jeffijoe.MessageFormat/Jeffijoe.MessageFormat.csproj
+++ b/src/Jeffijoe.MessageFormat/Jeffijoe.MessageFormat.csproj
@@ -10,7 +10,7 @@
   	<RepositoryUrl>https://github.com/jeffijoe/messageformat.net</RepositoryUrl>
   	<LangVersion>latest</LangVersion>
   	<Nullable>enable</Nullable>
-  	<TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
+  	<TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Jeffijoe.MessageFormat/Jeffijoe.MessageFormat.csproj
+++ b/src/Jeffijoe.MessageFormat/Jeffijoe.MessageFormat.csproj
@@ -10,7 +10,7 @@
   	<RepositoryUrl>https://github.com/jeffijoe/messageformat.net</RepositoryUrl>
   	<LangVersion>latest</LangVersion>
   	<Nullable>enable</Nullable>
-  	<TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+  	<TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -18,6 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="5.0.5" />
     <PackageReference Include="MinVer" Version="2.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Jeffijoe.MessageFormat/MessageFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/MessageFormatter.cs
@@ -215,17 +215,12 @@ namespace Jeffijoe.MessageFormat
              */
             var sourceBuilder = new StringBuilder(pattern);
             var requests = this.ParseRequests(pattern, sourceBuilder);
-            var requestsEnumerated = requests;
 
-            for (int i = 0; i < requestsEnumerated.Count; i++)
+            for (int i = 0; i < requests.Count; i++)
             {
-                var request = requestsEnumerated[i];
+                var request = requests[i];
 
                 var formatter = this.Formatters.GetFormatter(request);
-                if (formatter == null)
-                {
-                    throw new FormatterNotFoundException(request);
-                }
 
                 if (args.TryGetValue(request.Variable, out var value) == false && formatter.VariableMustExist)
                 {
@@ -298,6 +293,7 @@ namespace Jeffijoe.MessageFormat
             const char EscapingChar = '\'';
             const char OpenBrace = '{';
             const char CloseBrace = '}';
+
             var braceBalance = 0;
             var insideEscapeSequence = false;
 
@@ -397,6 +393,6 @@ namespace Jeffijoe.MessageFormat
             return requests;
         }
 
-        #endregion
+#endregion
     }
 }

--- a/src/Jeffijoe.MessageFormat/MessageFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/MessageFormatter.cs
@@ -215,16 +215,9 @@ namespace Jeffijoe.MessageFormat
              */
             var sourceBuilder = new StringBuilder(pattern);
             var requests = this.ParseRequests(pattern, sourceBuilder);
-            var requestsEnumerated = requests.ToArray();
+            var requestsEnumerated = requests;
 
-            // If we got no formatters, then we only need to unescape the literals.
-            if (requestsEnumerated.Length == 0)
-            {
-                sourceBuilder = this.UnescapeLiterals(sourceBuilder);
-                return sourceBuilder.ToString();
-            }
-
-            for (int i = 0; i < requestsEnumerated.Length; i++)
+            for (int i = 0; i < requestsEnumerated.Count; i++)
             {
                 var request = requestsEnumerated[i];
 
@@ -297,7 +290,7 @@ namespace Jeffijoe.MessageFormat
             // If the block is empty, do nothing.
             if (sourceBuilder.Length == 0)
             {
-                return new StringBuilder();
+                return sourceBuilder;
             }
 
             var dest = new StringBuilder(sourceBuilder.Length, sourceBuilder.Length);
@@ -307,6 +300,7 @@ namespace Jeffijoe.MessageFormat
             const char CloseBrace = '}';
             var braceBalance = 0;
             var insideEscapeSequence = false;
+
             for (int i = 0; i < length; i++)
             {
                 var c = sourceBuilder[i];

--- a/src/Jeffijoe.MessageFormat/MessageFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/MessageFormatter.cs
@@ -210,7 +210,7 @@ namespace Jeffijoe.MessageFormat
         public string FormatMessage(string pattern, IDictionary<string, object?> args)
         {
             /*
-             * We are asuming the formatters are ordered correctly
+             * We are assuming the formatters are ordered correctly
              * - that is, from left to right, string-wise.
              */
             var sourceBuilder = StringBuilderPool.Get();
@@ -295,18 +295,18 @@ namespace Jeffijoe.MessageFormat
                 return string.Empty;
             }
 
+            var length = sourceBuilder.Length;
+            const char EscapingChar = '\'';
+            const char OpenBrace = '{';
+            const char CloseBrace = '}';
+
+            var braceBalance = 0;
+            var insideEscapeSequence = false;
+
             var dest = StringBuilderPool.Get();
 
             try
             {
-                int length = sourceBuilder.Length;
-                const char EscapingChar = '\'';
-                const char OpenBrace = '{';
-                const char CloseBrace = '}';
-
-                var braceBalance = 0;
-                var insideEscapeSequence = false;
-
                 for (int i = 0; i < length; i++)
                 {
                     var c = sourceBuilder[i];
@@ -393,17 +393,13 @@ namespace Jeffijoe.MessageFormat
             }
 
             // If we have a cached result from this pattern, clone it and return the clone.
-            IFormatterRequestCollection cached;
-            if (this.cache.TryGetValue(pattern, out cached))
+            if (this.cache.TryGetValue(pattern, out var cached))
             {
                 return cached.Clone();
             }
 
             var requests = this.patternParser.Parse(sourceBuilder);
-            if (this.cache != null)
-            {
-                this.cache.TryAdd(pattern, requests.Clone());
-            }
+            this.cache?.TryAdd(pattern, requests.Clone());
 
             return requests;
         }

--- a/src/Jeffijoe.MessageFormat/MessageFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/MessageFormatter.cs
@@ -295,11 +295,16 @@ namespace Jeffijoe.MessageFormat
                 return string.Empty;
             }
 
-            var length = sourceBuilder.Length;
             const char EscapingChar = '\'';
             const char OpenBrace = '{';
             const char CloseBrace = '}';
 
+            if (!sourceBuilder.Contains(EscapingChar))
+            {
+                return sourceBuilder.ToString();
+            }
+
+            var length = sourceBuilder.Length;
             var braceBalance = 0;
             var insideEscapeSequence = false;
 

--- a/src/Jeffijoe.MessageFormat/Parsing/IFormatterRequestCollection.cs
+++ b/src/Jeffijoe.MessageFormat/Parsing/IFormatterRequestCollection.cs
@@ -12,7 +12,7 @@ namespace Jeffijoe.MessageFormat.Parsing
     /// <summary>
     ///     Formatter requests collection.
     /// </summary>
-    public interface IFormatterRequestCollection : IEnumerable<FormatterRequest>
+    public interface IFormatterRequestCollection : IReadOnlyList<FormatterRequest>
     {
         #region Public Methods and Operators
 

--- a/src/Jeffijoe.MessageFormat/Parsing/Literal.cs
+++ b/src/Jeffijoe.MessageFormat/Parsing/Literal.cs
@@ -37,7 +37,7 @@ namespace Jeffijoe.MessageFormat.Parsing
             int endIndex, 
             int sourceLineNumber, 
             int sourceColumnNumber, 
-            StringBuilder innerText)
+            string innerText)
         {
             this.StartIndex = startIndex;
             this.EndIndex = endIndex;
@@ -64,7 +64,7 @@ namespace Jeffijoe.MessageFormat.Parsing
         /// <value>
         ///     The inner text.
         /// </value>
-        public StringBuilder InnerText { get; private set; }
+        public string InnerText { get; private set; }
 
         /// <summary>
         ///     Gets the source column number.

--- a/src/Jeffijoe.MessageFormat/Parsing/LiteralParser.cs
+++ b/src/Jeffijoe.MessageFormat/Parsing/LiteralParser.cs
@@ -158,7 +158,6 @@ namespace Jeffijoe.MessageFormat.Parsing
                         continue;
                     }
 
-                    // Passing in the text buffer instead of the actual string to avoid allocating a new string.
                     result.Add(new Literal(start, i, startLineNumber, startColumnNumber, matchTextBuf.ToString()));
                     matchTextBuf.Clear();
                     start = 0;

--- a/src/Jeffijoe.MessageFormat/Parsing/LiteralParser.cs
+++ b/src/Jeffijoe.MessageFormat/Parsing/LiteralParser.cs
@@ -36,7 +36,6 @@ namespace Jeffijoe.MessageFormat.Parsing
             var closeBraces = 0;
             var start = 0;
             var braceBalance = 0;
-            var matchTextBuf = new StringBuilder();
             var lineNumber = 1;
             var startLineNumber = 1;
             var startColumnNumber = 0;
@@ -46,135 +45,145 @@ namespace Jeffijoe.MessageFormat.Parsing
             var currentEscapeSequenceColumnNumber = 0;
             const char Cr = '\r'; // Carriage return
             const char Lf = '\n'; // Line feed
-            for (var i = 0; i < sb.Length; i++)
+
+            var matchTextBuf = StringBuilderPool.Get();
+            try
             {
-                var c = sb[i];
-                if (c == Lf)
+                for (var i = 0; i < sb.Length; i++)
                 {
-                    lineNumber++;
-                    columnNumber = 0;
-                    continue;
-                }
-
-                if (c == Cr)
-                {
-                    continue;
-                }
-
-                columnNumber++;
-
-                if (c == EscapingChar)
-                {
-                    if (i == sb.Length - 1)
+                    var c = sb[i];
+                    if (c == Lf)
                     {
-                        if (!insideEscapeSequence)
-                            matchTextBuf.Append(EscapingChar);
-
-                        // The last char can't open a new escape sequence, it can only close one
-                        if (insideEscapeSequence)
-                        {
-                            insideEscapeSequence = false;
-                        }
+                        lineNumber++;
+                        columnNumber = 0;
                         continue;
                     }
 
-                    matchTextBuf.Append(EscapingChar);
-
-                    var nextChar = sb[i + 1];
-                    if (nextChar == EscapingChar)
+                    if (c == Cr)
                     {
+                        continue;
+                    }
+
+                    columnNumber++;
+
+                    if (c == EscapingChar)
+                    {
+                        if (i == sb.Length - 1)
+                        {
+                            if (!insideEscapeSequence)
+                                matchTextBuf.Append(EscapingChar);
+
+                            // The last char can't open a new escape sequence, it can only close one
+                            if (insideEscapeSequence)
+                            {
+                                insideEscapeSequence = false;
+                            }
+
+                            continue;
+                        }
+
                         matchTextBuf.Append(EscapingChar);
-                        ++i;
+
+                        var nextChar = sb[i + 1];
+                        if (nextChar == EscapingChar)
+                        {
+                            matchTextBuf.Append(EscapingChar);
+                            ++i;
+                            continue;
+                        }
+
+                        if (insideEscapeSequence)
+                        {
+                            insideEscapeSequence = false;
+                            continue;
+                        }
+
+                        if (nextChar == '{' || nextChar == '}' || nextChar == '#')
+                        {
+                            matchTextBuf.Append(nextChar);
+                            insideEscapeSequence = true;
+                            currentEscapeSequenceLineNumber = lineNumber;
+                            currentEscapeSequenceColumnNumber = columnNumber;
+                            ++i;
+                        }
+
                         continue;
                     }
 
                     if (insideEscapeSequence)
                     {
-                        insideEscapeSequence = false;
+                        matchTextBuf.Append(c);
                         continue;
                     }
 
-                    if (nextChar == '{' || nextChar == '}' || nextChar == '#')
+                    if (c == OpenBrace)
                     {
-                        matchTextBuf.Append(nextChar);
-                        insideEscapeSequence = true;
-                        currentEscapeSequenceLineNumber = lineNumber;
-                        currentEscapeSequenceColumnNumber = columnNumber;
-                        ++i;
+                        openBraces++;
+                        braceBalance++;
+
+                        // Record starting position of possible new brace match.
+                        if (braceBalance == 1)
+                        {
+                            start = i;
+                            startColumnNumber = columnNumber;
+                            startLineNumber = lineNumber;
+                            matchTextBuf.Clear();
+                        }
                     }
 
-                    continue;
+                    if (c == CloseBrace)
+                    {
+                        closeBraces++;
+                        braceBalance--;
+
+                        // Write the brace to the match buffer if it's not the closing brace
+                        // we are looking for.
+                        if (braceBalance > 0)
+                        {
+                            matchTextBuf.Append(c);
+                        }
+                    }
+                    else
+                    {
+                        if (i > start && braceBalance > 0)
+                        {
+                            matchTextBuf.Append(c);
+                        }
+
+                        continue;
+                    }
+
+                    if (openBraces != closeBraces)
+                    {
+                        continue;
+                    }
+
+                    // Passing in the text buffer instead of the actual string to avoid allocating a new string.
+                    result.Add(new Literal(start, i, startLineNumber, startColumnNumber, matchTextBuf.ToString()));
+                    matchTextBuf.Clear();
+                    start = 0;
                 }
 
                 if (insideEscapeSequence)
                 {
-                    matchTextBuf.Append(c);
-                    continue;
-                }
-
-                if (c == OpenBrace)
-                {
-                    openBraces++;
-                    braceBalance++;
-
-                    // Record starting position of possible new brace match.
-                    if (braceBalance == 1)
-                    {
-                        start = i;
-                        startColumnNumber = columnNumber;
-                        startLineNumber = lineNumber;
-                        matchTextBuf.Clear();
-                    }
-                }
-
-                if (c == CloseBrace)
-                {
-                    closeBraces++;
-                    braceBalance--;
-
-                    // Write the brace to the match buffer if it's not the closing brace
-                    // we are looking for.
-                    if (braceBalance > 0)
-                    {
-                        matchTextBuf.Append(c);
-                    }
-                }
-                else
-                {
-                    if (i > start && braceBalance > 0)
-                    {
-                        matchTextBuf.Append(c);
-                    }
-
-                    continue;
+                    throw new MalformedLiteralException(
+                        "There is an unclosed escape sequence.",
+                        currentEscapeSequenceLineNumber,
+                        currentEscapeSequenceColumnNumber,
+                        matchTextBuf.ToString());
                 }
 
                 if (openBraces != closeBraces)
                 {
-                    continue;
+                    throw new UnbalancedBracesException(openBraces, closeBraces);
                 }
 
-                // Passing in the text buffer instead of the actual string to avoid allocating a new string.
-                result.Add(new Literal(start, i, startLineNumber, startColumnNumber, matchTextBuf));
-                matchTextBuf = new StringBuilder();
-                start = 0;
+                return result;
             }
-
-            if (insideEscapeSequence)
+            finally
             {
-                throw new MalformedLiteralException(
-                    "There is an unclosed escape sequence.",
-                    currentEscapeSequenceLineNumber,
-                    currentEscapeSequenceColumnNumber,
-                    matchTextBuf.ToString());
+                StringBuilderPool.Return(matchTextBuf);
             }
-
-            if (openBraces != closeBraces)
-            {
-                throw new UnbalancedBracesException(openBraces, closeBraces);
-            }
-
-            return result;
         }
 
         #endregion

--- a/src/Jeffijoe.MessageFormat/Parsing/PatternParser.cs
+++ b/src/Jeffijoe.MessageFormat/Parsing/PatternParser.cs
@@ -82,7 +82,7 @@ namespace Jeffijoe.MessageFormat.Parsing
                     if (formatterKey != null)
                     {
                         formatterArgs =
-                            literal.InnerText.ToString(lastIndex + 1, literal.InnerText.Length - lastIndex - 1).Trim();
+                            literal.InnerText.Substring(lastIndex + 1, literal.InnerText.Length - lastIndex - 1).Trim();
                     }
                 }
 

--- a/src/Jeffijoe.MessageFormat/Parsing/PatternParser.cs
+++ b/src/Jeffijoe.MessageFormat/Parsing/PatternParser.cs
@@ -122,85 +122,93 @@ namespace Jeffijoe.MessageFormat.Parsing
             out int lastIndex)
         {
             const char Comma = ',';
-            var sb = new StringBuilder();
-            var innerText = literal.InnerText;
-            var column = literal.SourceColumnNumber;
-            var foundWhitespace = false;
-            lastIndex = 0;
-            for (var i = offset; i < innerText.Length; i++)
-            {
-                var c = innerText[i];
-                column++;
-                lastIndex = i;
-                if (c == Comma)
-                {
-                    break;
-                }
+            var sb = StringBuilderPool.Get();
 
-                // Disregard whitespace.
-                var whitespace = c == ' ' || c == '\r' || c == '\n' || c == '\t';
-                if (!whitespace)
+            try
+            {
+                var innerText = literal.InnerText;
+                var column = literal.SourceColumnNumber;
+                var foundWhitespace = false;
+                lastIndex = 0;
+                for (var i = offset; i < innerText.Length; i++)
                 {
-                    if (c.IsAlphaNumeric() == false)
+                    var c = innerText[i];
+                    column++;
+                    lastIndex = i;
+                    if (c == Comma)
                     {
-                        var msg = string.Format("Invalid literal character '{0}'.", c);
-
-                        // Line number can't have changed.
-                        throw new MalformedLiteralException(msg, literal.SourceLineNumber, column,
-                            innerText.ToString());
+                        break;
                     }
-                }
-                else
-                {
-                    foundWhitespace = true;
+
+                    // Disregard whitespace.
+                    var whitespace = c == ' ' || c == '\r' || c == '\n' || c == '\t';
+                    if (!whitespace)
+                    {
+                        if (c.IsAlphaNumeric() == false)
+                        {
+                            var msg = string.Format("Invalid literal character '{0}'.", c);
+
+                            // Line number can't have changed.
+                            throw new MalformedLiteralException(msg, literal.SourceLineNumber, column,
+                                innerText.ToString());
+                        }
+                    }
+                    else
+                    {
+                        foundWhitespace = true;
+                    }
+
+                    sb.Append(c);
                 }
 
-                sb.Append(c);
-            }
-
-            if (sb.Length != 0)
-            {
-                // Trim whitespace from beginning and end of the string, if necessary.
-                if (!foundWhitespace)
+                if (sb.Length != 0)
                 {
+                    // Trim whitespace from beginning and end of the string, if necessary.
+                    if (!foundWhitespace)
+                    {
+                        return sb.ToString();
+                    }
+
+                    StringBuilder trimmed = sb.TrimWhitespace();
+                    if (trimmed.Length == 0)
+                    {
+                        if (allowEmptyResult)
+                        {
+                            return null;
+                        }
+
+                        throw new MalformedLiteralException(
+                            "Parsing the literal yielded a string that was pure whitespace.",
+                            literal.SourceLineNumber,
+                            column);
+                    }
+
+                    if (trimmed.ContainsWhitespace())
+                    {
+                        throw new MalformedLiteralException(
+                            "Parsed literal must not contain whitespace.",
+                            0,
+                            0,
+                            trimmed.ToString());
+                    }
+
                     return sb.ToString();
                 }
 
-                StringBuilder trimmed = sb.TrimWhitespace();
-                if (trimmed.Length == 0)
+                if (allowEmptyResult)
                 {
-                    if (allowEmptyResult)
-                    {
-                        return null;
-                    }
-
-                    throw new MalformedLiteralException(
-                        "Parsing the literal yielded a string that was pure whitespace.",
-                        literal.SourceLineNumber,
-                        column);
+                    return null;
                 }
 
-                if (trimmed.ContainsWhitespace())
-                {
-                    throw new MalformedLiteralException(
-                        "Parsed literal must not contain whitespace.",
-                        0,
-                        0,
-                        trimmed.ToString());
-                }
-
-                return sb.ToString();
+                throw new MalformedLiteralException(
+                    "Parsing the literal yielded an empty string.",
+                    literal.SourceLineNumber,
+                    column);
             }
-
-            if (allowEmptyResult)
+            finally
             {
-                return null;
+                StringBuilderPool.Return(sb);
             }
-
-            throw new MalformedLiteralException(
-                "Parsing the literal yielded an empty string.",
-                literal.SourceLineNumber,
-                column);
         }
 
         #endregion

--- a/src/Jeffijoe.MessageFormat/Parsing/PatternParser.cs
+++ b/src/Jeffijoe.MessageFormat/Parsing/PatternParser.cs
@@ -81,8 +81,13 @@ namespace Jeffijoe.MessageFormat.Parsing
                     formatterKey = ReadLiteralSection(literal, variableName.Length + 1, true, out lastIndex);
                     if (formatterKey != null)
                     {
+#if NET5_0_OR_GREATER
+                        formatterArgs =
+                            literal.InnerText.AsSpan(lastIndex + 1, literal.InnerText.Length - lastIndex - 1).Trim().ToString();
+#else
                         formatterArgs =
                             literal.InnerText.Substring(lastIndex + 1, literal.InnerText.Length - lastIndex - 1).Trim();
+#endif
                     }
                 }
 

--- a/src/Jeffijoe.MessageFormat/Parsing/PatternParser.cs
+++ b/src/Jeffijoe.MessageFormat/Parsing/PatternParser.cs
@@ -127,14 +127,14 @@ namespace Jeffijoe.MessageFormat.Parsing
             out int lastIndex)
         {
             const char Comma = ',';
-            var sb = StringBuilderPool.Get();
 
+            var innerText = literal.InnerText;
+            var column = literal.SourceColumnNumber;
+            var foundWhitespace = false;
+            lastIndex = 0;
+            var sb = StringBuilderPool.Get();
             try
             {
-                var innerText = literal.InnerText;
-                var column = literal.SourceColumnNumber;
-                var foundWhitespace = false;
-                lastIndex = 0;
                 for (var i = offset; i < innerText.Length; i++)
                 {
                     var c = innerText[i];

--- a/src/Jeffijoe.MessageFormat/StringBuilderPool.cs
+++ b/src/Jeffijoe.MessageFormat/StringBuilderPool.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Text;
+using Microsoft.Extensions.ObjectPool;
+
+namespace Jeffijoe.MessageFormat
+{
+    internal static class StringBuilderPool
+    {
+        private static readonly ObjectPool<StringBuilder> SbPool;
+
+        static StringBuilderPool()
+        {
+            var shared = new DefaultObjectPoolProvider();
+            SbPool = shared.CreateStringBuilderPool();
+        }
+
+        public static StringBuilder Get()
+        {
+            return SbPool.Get();
+        }
+
+        public static void Return(StringBuilder sb)
+        {
+            SbPool.Return(sb);
+        }
+    }
+}


### PR DESCRIPTION
Noticed some low-hanging fruit when working on parsing CLDR.

- Use StringBuilderPool via [Microsoft.Extensions.ObjectPool](https://www.nuget.org/packages/Microsoft.Extensions.ObjectPool/)
- Add some net5.0+ specific optimizations
- Do not go through with unescaping if there is nothing to unescape
- Store Literal InnerText as string

Method | Perf Improvement | Memory Improvement |
|------------------------- |---------:|----------:|
FormatWithCache | 19% | 54%
FormatWithCacheEscaped | 8% | 46%
FormatWithoutCache | 15% | 54%
FormatWithoutCacheEscaped | 8% | 52%



Before
|                   Method |Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------- |---------:|----------:|----------:|-------:|------:|------:|----------:|
|          FormatWithCache | 3.956 us | 0.0553 us | 0.0517 us | 1.1444 |     - |     - |   3.52 KB |
|    FormatWithCacheEscaped| 3.127 us | 0.0619 us | 0.0662 us | 0.9308 |     - |     - |   2.85 KB |
|       FormatWithoutCache | 7.657 us | 0.1434 us | 0.1535 us | 2.1210 |     - |     - |   6.52 KB |
| FormatWithoutCacheEscaped | 5.133 us | 0.0398 us | 0.0372 us | 1.3809 |     - |     - |   4.25 KB |

After
|                   Method |     Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------- |--------:|----------:|----------:|-------:|------:|------:|----------:|
|          FormatWithCache | 3.196 us | 0.0185 us | 0.0173 us | 0.5226 |     - |     - |    1.6 KB |
|    FormatWithCacheEscaped | 2.883 us | 0.0132 us | 0.0123 us | 0.4959 |     - |     - |   1.52 KB |
|       FormatWithoutCache | 6.473 us | 0.0375 us | 0.0351 us | 0.9537 |     - |     - |   2.95 KB |
| FormatWithoutCacheEscaped | 4.710 us | 0.0182 us | 0.0161 us | 0.6561 |     - |     - |   2.02 KB |

Benchmark code
```csharp
    class Program
    {
        static void Main(string[] args)
        {
            BenchmarkRunner.Run<MessageFormatBenchmark>();
        }
    }

    [MemoryDiagnoser]
    [HtmlExporter]
    [CsvExporter]
    public class MessageFormatBenchmark
    {
        private readonly Dictionary<string, object> _params;
        private readonly string _text;
        private readonly string _textEscaped;
        private readonly MessageFormatter _cacheFormatter;
        private readonly MessageFormatter _noCacheFormatter;

        public MessageFormatBenchmark()
        {
            _textEscaped =
                "These '{'count'}' and thoses '{count}' ain''t not escaped, which makes a total of {count, plural, one {a single pair} other {'#'# (=#) pairs}} of escaped braces.";
            _text =
                @"You have {count, plural, 
                            zero {no notifications}
                            one {just one notification}
                            =42 {a universal amount of notifications}
                            other {# notifications}
                      }. Have a nice day!"; ;
            _params = new Dictionary<string, object> { { "count", 2 } };
            _cacheFormatter = new MessageFormatter(true, "ru");
            _noCacheFormatter = new MessageFormatter(false, "ru");
        }

        [GlobalSetup]
        public void SetUp()
        {
            _cacheFormatter.FormatMessage(_text, _params);
            _cacheFormatter.FormatMessage(_textEscaped, _params);
        }

        [Benchmark]
        public string FormatWithCache()
        {
            return _cacheFormatter.FormatMessage(_text, _params);
        }

        [Benchmark]
        public string FormatWithCacheEscaped()
        {
            return _cacheFormatter.FormatMessage(_textEscaped, _params);
        }

        [Benchmark]
        public string FormatWithoutCache()
        {
            return _noCacheFormatter.FormatMessage(_text, _params);
        }

        [Benchmark]
        public string FormatWithoutCacheEscaped()
        {
            return _noCacheFormatter.FormatMessage(_textEscaped, _params);
        }
    }
```