### PR TITLE
Fix `IDictionary` support

### DIFF
--- a/src/Jeffijoe.MessageFormat.Tests/MessageFormatterIssues.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/MessageFormatterIssues.cs
@@ -4,6 +4,7 @@
 // Author: Jeff Hansen <jeff@jeffijoe.com>
 // Copyright (C) Jeff Hansen 2015. All rights reserved.
 
+using System.Collections.Generic;
 using Xunit;
 
 namespace Jeffijoe.MessageFormat.Tests
@@ -35,6 +36,25 @@ namespace Jeffijoe.MessageFormat.Tests
             });
 
             Assert.Equal("2 things", result);
+        }
+
+        [Fact]
+        public void Issue31_IDictionary_interface_support()
+        {
+            var subject = new MessageFormatter(locale: "en-US");
+
+            IDictionary<string, object> idict = new Dictionary<string, object>
+            {
+                ["string"] = "value"
+            };
+            
+            IDictionary<string, object?> idictNullable = new Dictionary<string, object?>
+            {
+                ["string"] = "value"
+            };
+
+            Assert.Equal("value", subject.FormatMessage("{string}", idict));
+            Assert.Equal("value", subject.FormatMessage("{string}", idictNullable!));
         }
     }
 }

--- a/src/Jeffijoe.MessageFormat/IMessageFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/IMessageFormatter.cs
@@ -28,20 +28,6 @@ namespace Jeffijoe.MessageFormat
         /// </returns>
         string FormatMessage(string pattern, IReadOnlyDictionary<string, object?> argsMap);
 
-        /// <summary>
-        ///     Formats the message, and uses reflection to create a dictionary of property values from the specified object.
-        /// </summary>
-        /// <param name="pattern">
-        ///     The pattern.
-        /// </param>
-        /// <param name="args">
-        ///     The arguments.
-        /// </param>
-        /// <returns>
-        ///     The <see cref="string" />.
-        /// </returns>
-        string FormatMessage(string pattern, object args);
-
         #endregion
     }
 }

--- a/src/Jeffijoe.MessageFormat/MessageFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/MessageFormatter.cs
@@ -171,7 +171,7 @@ namespace Jeffijoe.MessageFormat
         ///     Formats the specified pattern with the specified data.
         /// </summary>
         /// This method calls
-        /// <see cref="FormatMessage(string, object)" />
+        /// <see cref="MessageFormatterExtensions.FormatMessage(Jeffijoe.MessageFormat.IMessageFormatter,string,object)" />
         /// on a singleton instance using a lock.
         /// Do not use in a tight loop, as a lock is being used to ensure thread safety.
         /// <param name="pattern">
@@ -251,23 +251,6 @@ namespace Jeffijoe.MessageFormat
             {
                 StringBuilderPool.Return(sourceBuilder);
             }
-        }
-
-        /// <summary>
-        ///     Formats the message, and uses reflection to create a dictionary of property values from the specified object.
-        /// </summary>
-        /// <param name="pattern">
-        ///     The pattern.
-        /// </param>
-        /// <param name="args">
-        ///     The arguments.
-        /// </param>
-        /// <returns>
-        ///     The <see cref="string" />.
-        /// </returns>
-        public string FormatMessage(string pattern, object args)
-        {
-            return this.FormatMessage(pattern, args.ToDictionary());
         }
 
         #endregion

--- a/src/Jeffijoe.MessageFormat/MessageFormatterExtensions.cs
+++ b/src/Jeffijoe.MessageFormat/MessageFormatterExtensions.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using Jeffijoe.MessageFormat.Helpers;
+
+namespace Jeffijoe.MessageFormat;
+
+/// <summary>
+///     Extensions for <see cref="IMessageFormatter"/>.
+/// </summary>
+public static class MessageFormatterExtensions
+{
+    /// <summary>
+    ///     Formats the message using the specified <paramref name="args"/>.
+    /// </summary>
+    /// <param name="formatter">
+    ///     The formatter.
+    /// </param>
+    /// <param name="pattern">
+    ///     The pattern.
+    /// </param>
+    /// <param name="args">
+    ///     The arguments.
+    /// </param>
+    /// <returns>
+    ///     The <see cref="string" />.
+    /// </returns>
+    public static string FormatMessage(
+        this IMessageFormatter formatter,
+        string pattern,
+        IDictionary<string, object> args)
+    {
+        return formatter.FormatMessage(pattern, (IReadOnlyDictionary<string, object?>)args);
+    }
+
+    /// <summary>
+    ///     Formats the message, and uses reflection to create a dictionary of property values from the specified object.
+    /// </summary>
+    /// <param name="formatter">
+    ///     The formatter.
+    /// </param>
+    /// <param name="pattern">
+    ///     The pattern.
+    /// </param>
+    /// <param name="args">
+    ///     The arguments.
+    /// </param>
+    /// <returns>
+    ///     The <see cref="string" />.
+    /// </returns>
+    public static string FormatMessage(this IMessageFormatter formatter, string pattern, object args)
+    {
+        return formatter.FormatMessage(pattern, args.ToDictionary());
+    }
+}


### PR DESCRIPTION
Moved the overloads to extension methods for `IMessageFormatter`.

Closes #31