### PR TITLE
Value formatters for `number`, `date`, and `time`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         fetch-depth: 100
         
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 7.0.x
         

--- a/src/Jeffijoe.MessageFormat.MetadataGenerator/data/plurals.xml
+++ b/src/Jeffijoe.MessageFormat.MetadataGenerator/data/plurals.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE supplementalData SYSTEM "../../common/dtd/ldmlSupplemental.dtd">
 <!--
-Copyright © 1991-2015 Unicode, Inc.
-CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+Copyright © 1991-2022 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
+SPDX-License-Identifier: Unicode-DFS-2016
+CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
 -->
 <supplementalData>
     <version number="$Revision$"/>
@@ -12,7 +13,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 
         <!-- 1: other -->
 
-        <pluralRules locales="bm bo dz id ig ii in ja jbo jv jw kde kea km ko lkt lo ms my nqo osa root sah ses sg su th to vi wo yo yue zh">
+        <pluralRules locales="bm bo dz hnj id ig ii in ja jbo jv jw kde kea km ko lkt lo ms my nqo osa root sah ses sg su th to tpi vi wo yo yue zh">
             <pluralRule count="other"> @integer 0~15, 100, 1000, 10000, 100000, 1000000, … @decimal 0.0~1.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
         </pluralRules>
 
@@ -26,11 +27,7 @@ For terms of use, see http://www.unicode.org/copyright.html
             <pluralRule count="one">i = 0,1 @integer 0, 1 @decimal 0.0~1.5</pluralRule>
             <pluralRule count="other"> @integer 2~17, 100, 1000, 10000, 100000, 1000000, … @decimal 2.0~3.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
         </pluralRules>
-        <pluralRules locales="pt">
-            <pluralRule count="one">i = 0..1 @integer 0, 1 @decimal 0.0~1.5</pluralRule>
-            <pluralRule count="other"> @integer 2~17, 100, 1000, 10000, 100000, 1000000, … @decimal 2.0~3.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
-        </pluralRules>
-        <pluralRules locales="ast ca de en et fi fy gl ia io it ji lij nl pt_PT sc scn sv sw ur yi">
+        <pluralRules locales="ast de en et fi fy gl ia io ji lij nl sc scn sv sw ur yi">
             <pluralRule count="one">i = 1 and v = 0 @integer 1</pluralRule>
             <pluralRule count="other"> @integer 0, 2~16, 100, 1000, 10000, 100000, 1000000, … @decimal 0.0~1.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
         </pluralRules>
@@ -46,7 +43,7 @@ For terms of use, see http://www.unicode.org/copyright.html
             <pluralRule count="one">n = 0..1 or n = 11..99 @integer 0, 1, 11~24 @decimal 0.0, 1.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0</pluralRule>
             <pluralRule count="other"> @integer 2~10, 100~106, 1000, 10000, 100000, 1000000, … @decimal 0.1~0.9, 1.1~1.7, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
         </pluralRules>
-        <pluralRules locales="af an asa az bem bez bg brx ce cgg chr ckb dv ee el eo es eu fo fur gsw ha haw hu jgo jmc ka kaj kcg kk kkj kl ks ksb ku ky lb lg mas mgo ml mn mr nah nb nd ne nn nnh no nr ny nyn om or os pap ps rm rof rwk saq sd sdh seh sn so sq ss ssy st syr ta te teo tig tk tn tr ts ug uz ve vo vun wae xh xog">
+        <pluralRules locales="af an asa az bal bem bez bg brx ce cgg chr ckb dv ee el eo eu fo fur gsw ha haw hu jgo jmc ka kaj kcg kk kkj kl ks ksb ku ky lb lg mas mgo ml mn mr nah nb nd ne nn nnh no nr ny nyn om or os pap ps rm rof rwk saq sd sdh seh sn so sq ss ssy st syr ta te teo tig tk tn tr ts ug uz ve vo vun wae xh xog">
             <pluralRule count="one">n = 1 @integer 1 @decimal 1.0, 1.00, 1.000, 1.0000</pluralRule>
             <pluralRule count="other"> @integer 0, 2~16, 100, 1000, 10000, 100000, 1000000, … @decimal 0.0~0.9, 1.1~1.6, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
         </pluralRules>
@@ -55,8 +52,8 @@ For terms of use, see http://www.unicode.org/copyright.html
             <pluralRule count="other"> @integer 0, 2~16, 100, 1000, 10000, 100000, 1000000, … @decimal 0.0, 2.0~3.4, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
         </pluralRules>
         <pluralRules locales="is">
-            <pluralRule count="one">t = 0 and i % 10 = 1 and i % 100 != 11 or t != 0 @integer 1, 21, 31, 41, 51, 61, 71, 81, 101, 1001, … @decimal 0.1~1.6, 10.1, 100.1, 1000.1, …</pluralRule>
-            <pluralRule count="other"> @integer 0, 2~16, 100, 1000, 10000, 100000, 1000000, … @decimal 0.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
+            <pluralRule count="one">t = 0 and i % 10 = 1 and i % 100 != 11 or t % 10 = 1 and t % 100 != 11 @integer 1, 21, 31, 41, 51, 61, 71, 81, 101, 1001, … @decimal 0.1, 1.0, 1.1, 2.1, 3.1, 4.1, 5.1, 6.1, 7.1, 10.1, 100.1, 1000.1, …</pluralRule>
+            <pluralRule count="other"> @integer 0, 2~16, 100, 1000, 10000, 100000, 1000000, … @decimal 0.0, 0.2~0.9, 1.2~1.8, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
         </pluralRules>
         <pluralRules locales="mk">
             <pluralRule count="one">v = 0 and i % 10 = 1 and i % 100 != 11 or f % 10 = 1 and f % 100 != 11 @integer 1, 21, 31, 41, 51, 61, 71, 81, 101, 1001, … @decimal 0.1, 1.1, 2.1, 3.1, 4.1, 5.1, 6.1, 7.1, 10.1, 100.1, 1000.1, …</pluralRule>
@@ -87,6 +84,11 @@ For terms of use, see http://www.unicode.org/copyright.html
 
         <!-- 3: one,two,other -->
 
+        <pluralRules locales="he iw">
+            <pluralRule count="one">i = 1 and v = 0 or i = 0 and v != 0 @integer 1 @decimal 0.0~0.9, 0.00~0.05</pluralRule>
+            <pluralRule count="two">i = 2 and v = 0 @integer 2</pluralRule>
+            <pluralRule count="other"> @integer 0, 3~17, 100, 1000, 10000, 100000, 1000000, … @decimal 1.0~2.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
+        </pluralRules>
         <pluralRules locales="iu naq sat se sma smi smj smn sms">
             <pluralRule count="one">n = 1 @integer 1 @decimal 1.0, 1.00, 1.000, 1.0000</pluralRule>
             <pluralRule count="two">n = 2 @integer 2 @decimal 2.0, 2.00, 2.000, 2.0000</pluralRule>
@@ -102,7 +104,7 @@ For terms of use, see http://www.unicode.org/copyright.html
         </pluralRules>
         <pluralRules locales="mo ro">
             <pluralRule count="one">i = 1 and v = 0 @integer 1</pluralRule>
-            <pluralRule count="few">v != 0 or n = 0 or n % 100 = 2..19 @integer 0, 2~16, 102, 1002, … @decimal 0.0~1.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
+            <pluralRule count="few">v != 0 or n = 0 or n != 1 and n % 100 = 1..19 @integer 0, 2~16, 101, 1001, … @decimal 0.0~1.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
             <pluralRule count="other"> @integer 20~35, 100, 1000, 10000, 100000, 1000000, …</pluralRule>
         </pluralRules>
         <pluralRules locales="bs hr sh sr">
@@ -115,8 +117,23 @@ For terms of use, see http://www.unicode.org/copyright.html
 
         <pluralRules locales="fr">
             <pluralRule count="one">i = 0,1 @integer 0, 1 @decimal 0.0~1.5</pluralRule>
-            <pluralRule count="many">e = 0 and i != 0 and i % 1000000 = 0 and v = 0 or e != 0..5 @integer 1000000, 1e6, 2e6, 3e6, 4e6, 5e6, 6e6, … @decimal 1.0000001e6, 1.1e6, 2.0000001e6, 2.1e6, 3.0000001e6, 3.1e6, …</pluralRule>
-            <pluralRule count="other"> @integer 2~17, 100, 1000, 10000, 100000, 1e3, 2e3, 3e3, 4e3, 5e3, 6e3, … @decimal 2.0~3.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, 1.0001e3, 1.1e3, 2.0001e3, 2.1e3, 3.0001e3, 3.1e3, …</pluralRule>
+            <pluralRule count="many">e = 0 and i != 0 and i % 1000000 = 0 and v = 0 or e != 0..5 @integer 1000000, 1c6, 2c6, 3c6, 4c6, 5c6, 6c6, … @decimal 1.0000001c6, 1.1c6, 2.0000001c6, 2.1c6, 3.0000001c6, 3.1c6, …</pluralRule>
+            <pluralRule count="other"> @integer 2~17, 100, 1000, 10000, 100000, 1c3, 2c3, 3c3, 4c3, 5c3, 6c3, … @decimal 2.0~3.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, 1.0001c3, 1.1c3, 2.0001c3, 2.1c3, 3.0001c3, 3.1c3, …</pluralRule>
+        </pluralRules>
+        <pluralRules locales="pt">
+            <pluralRule count="one">i = 0..1 @integer 0, 1 @decimal 0.0~1.5</pluralRule>
+            <pluralRule count="many">e = 0 and i != 0 and i % 1000000 = 0 and v = 0 or e != 0..5 @integer 1000000, 1c6, 2c6, 3c6, 4c6, 5c6, 6c6, … @decimal 1.0000001c6, 1.1c6, 2.0000001c6, 2.1c6, 3.0000001c6, 3.1c6, …</pluralRule>
+            <pluralRule count="other"> @integer 2~17, 100, 1000, 10000, 100000, 1c3, 2c3, 3c3, 4c3, 5c3, 6c3, … @decimal 2.0~3.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, 1.0001c3, 1.1c3, 2.0001c3, 2.1c3, 3.0001c3, 3.1c3, …</pluralRule>
+        </pluralRules>
+        <pluralRules locales="ca it pt_PT vec">
+            <pluralRule count="one">i = 1 and v = 0 @integer 1</pluralRule>
+            <pluralRule count="many">e = 0 and i != 0 and i % 1000000 = 0 and v = 0 or e != 0..5 @integer 1000000, 1c6, 2c6, 3c6, 4c6, 5c6, 6c6, … @decimal 1.0000001c6, 1.1c6, 2.0000001c6, 2.1c6, 3.0000001c6, 3.1c6, …</pluralRule>
+            <pluralRule count="other"> @integer 0, 2~16, 100, 1000, 10000, 100000, 1c3, 2c3, 3c3, 4c3, 5c3, 6c3, … @decimal 0.0~1.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, 1.0001c3, 1.1c3, 2.0001c3, 2.1c3, 3.0001c3, 3.1c3, …</pluralRule>
+        </pluralRules>
+        <pluralRules locales="es">
+            <pluralRule count="one">n = 1 @integer 1 @decimal 1.0, 1.00, 1.000, 1.0000</pluralRule>
+            <pluralRule count="many">e = 0 and i != 0 and i % 1000000 = 0 and v = 0 or e != 0..5 @integer 1000000, 1c6, 2c6, 3c6, 4c6, 5c6, 6c6, … @decimal 1.0000001c6, 1.1c6, 2.0000001c6, 2.1c6, 3.0000001c6, 3.1c6, …</pluralRule>
+            <pluralRule count="other"> @integer 0, 2~16, 100, 1000, 10000, 100000, 1c3, 2c3, 3c3, 4c3, 5c3, 6c3, … @decimal 0.0~0.9, 1.1~1.6, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, 1.0001c3, 1.1c3, 2.0001c3, 2.1c3, 3.0001c3, 3.1c3, …</pluralRule>
         </pluralRules>
 
         <!-- 4: one,two,few,other -->
@@ -138,15 +155,6 @@ For terms of use, see http://www.unicode.org/copyright.html
             <pluralRule count="two">v = 0 and i % 100 = 2 or f % 100 = 2 @integer 2, 102, 202, 302, 402, 502, 602, 702, 1002, … @decimal 0.2, 1.2, 2.2, 3.2, 4.2, 5.2, 6.2, 7.2, 10.2, 100.2, 1000.2, …</pluralRule>
             <pluralRule count="few">v = 0 and i % 100 = 3..4 or f % 100 = 3..4 @integer 3, 4, 103, 104, 203, 204, 303, 304, 403, 404, 503, 504, 603, 604, 703, 704, 1003, … @decimal 0.3, 0.4, 1.3, 1.4, 2.3, 2.4, 3.3, 3.4, 4.3, 4.4, 5.3, 5.4, 6.3, 6.4, 7.3, 7.4, 10.3, 100.3, 1000.3, …</pluralRule>
             <pluralRule count="other"> @integer 0, 5~19, 100, 1000, 10000, 100000, 1000000, … @decimal 0.0, 0.5~1.0, 1.5~2.0, 2.5~2.7, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
-        </pluralRules>
-
-        <!-- 4: one,two,many,other -->
-
-        <pluralRules locales="he iw">
-            <pluralRule count="one">i = 1 and v = 0 @integer 1</pluralRule>
-            <pluralRule count="two">i = 2 and v = 0 @integer 2</pluralRule>
-            <pluralRule count="many">v = 0 and n != 0..10 and n % 10 = 0 @integer 20, 30, 40, 50, 60, 70, 80, 90, 100, 1000, 10000, 100000, 1000000, …</pluralRule>
-            <pluralRule count="other"> @integer 0, 3~17, 101, 1001, … @decimal 0.0~1.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
         </pluralRules>
 
         <!-- 4: one,few,many,other -->
@@ -175,12 +183,6 @@ For terms of use, see http://www.unicode.org/copyright.html
             <pluralRule count="many">f != 0   @decimal 0.1~0.9, 1.1~1.7, 10.1, 100.1, 1000.1, …</pluralRule>
             <pluralRule count="other"> @integer 0, 10~20, 30, 40, 50, 60, 100, 1000, 10000, 100000, 1000000, … @decimal 0.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
         </pluralRules>
-        <pluralRules locales="mt">
-            <pluralRule count="one">n = 1 @integer 1 @decimal 1.0, 1.00, 1.000, 1.0000</pluralRule>
-            <pluralRule count="few">n = 0 or n % 100 = 2..10 @integer 0, 2~10, 102~107, 1002, … @decimal 0.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 10.0, 102.0, 1002.0, …</pluralRule>
-            <pluralRule count="many">n % 100 = 11..19 @integer 11~19, 111~117, 1011, … @decimal 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 111.0, 1011.0, …</pluralRule>
-            <pluralRule count="other"> @integer 20~35, 100, 1000, 10000, 100000, 1000000, … @decimal 0.1~0.9, 1.1~1.7, 10.1, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
-        </pluralRules>
         <pluralRules locales="ru uk">
             <pluralRule count="one">v = 0 and i % 10 = 1 and i % 100 != 11 @integer 1, 21, 31, 41, 51, 61, 71, 81, 101, 1001, …</pluralRule>
             <pluralRule count="few">v = 0 and i % 10 = 2..4 and i % 100 != 12..14 @integer 2~4, 22~24, 32~34, 42~44, 52~54, 62, 102, 1002, …</pluralRule>
@@ -196,6 +198,13 @@ For terms of use, see http://www.unicode.org/copyright.html
             <pluralRule count="few">n % 10 = 3..4,9 and n % 100 != 10..19,70..79,90..99 @integer 3, 4, 9, 23, 24, 29, 33, 34, 39, 43, 44, 49, 103, 1003, … @decimal 3.0, 4.0, 9.0, 23.0, 24.0, 29.0, 33.0, 34.0, 103.0, 1003.0, …</pluralRule>
             <pluralRule count="many">n != 0 and n % 1000000 = 0 @integer 1000000, … @decimal 1000000.0, 1000000.00, 1000000.000, 1000000.0000, …</pluralRule>
             <pluralRule count="other"> @integer 0, 5~8, 10~20, 100, 1000, 10000, 100000, … @decimal 0.0~0.9, 1.1~1.6, 10.0, 100.0, 1000.0, 10000.0, 100000.0, …</pluralRule>
+        </pluralRules>
+        <pluralRules locales="mt">
+            <pluralRule count="one">n = 1 @integer 1 @decimal 1.0, 1.00, 1.000, 1.0000</pluralRule>
+            <pluralRule count="two">n = 2 @integer 2 @decimal 2.0, 2.00, 2.000, 2.0000</pluralRule>
+            <pluralRule count="few">n = 0 or n % 100 = 3..10 @integer 0, 3~10, 103~109, 1003, … @decimal 0.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 103.0, 1003.0, …</pluralRule>
+            <pluralRule count="many">n % 100 = 11..19 @integer 11~19, 111~117, 1011, … @decimal 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 111.0, 1011.0, …</pluralRule>
+            <pluralRule count="other"> @integer 20~35, 100, 1000, 10000, 100000, 1000000, … @decimal 0.1~0.9, 1.1~1.7, 10.1, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
         </pluralRules>
         <pluralRules locales="ga">
             <pluralRule count="one">n = 1 @integer 1 @decimal 1.0, 1.00, 1.000, 1.0000</pluralRule>

--- a/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/DateFormatterTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/DateFormatterTests.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Globalization;
+using Jeffijoe.MessageFormat.Formatting;
+using Xunit;
+
+namespace Jeffijoe.MessageFormat.Tests.Formatting.Formatters
+{
+    public class DateFormatterTests
+    {
+        [Theory]
+        [InlineData("en-US", "1994-09-06T15:00:00Z", "9/6/1994")]
+        [InlineData("da-DK", "1994-09-06T15:00:00Z", "06.09.1994")]
+        public void DateFormatter_Short(string locale, string dateStr, string expected)
+        {
+            var mf = new MessageFormatter(locale: locale);
+            var actual = mf.FormatMessage("{value, date}", new
+            {
+                value = DateTimeOffset.Parse(dateStr)
+            });
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData("en-US", "1994-09-06T15:00:00Z", "Tuesday, September 6, 1994")]
+        [InlineData("da-DK", "1994-09-06T15:00:00Z", "tirsdag den 6. september 1994")]
+        public void DateFormatter_Full(string locale, string dateStr, string expected)
+        {
+            var mf = new MessageFormatter(locale: locale);
+            var actual = mf.FormatMessage("{value, date, full}", new
+            {
+                value = DateTimeOffset.Parse(dateStr)
+            });
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void DateFormatter_UnsupportedStyle()
+        {
+            var mf = new MessageFormatter();
+            Assert.Throws<UnsupportedFormatStyleException>(
+                () => mf.FormatMessage("{value, date, long}", new
+                {
+                    value = DateTimeOffset.UtcNow
+                }));
+        }
+        
+        [Fact]
+        public void DateFormatter_Custom()
+        {
+            var formatter = new CustomValueFormatters
+            {
+                Date = (CultureInfo _, object? value, string? _, out string? formatted) =>
+                {
+                    // This is just a test, you probably shouldn't be doing this in real workloads.
+                    formatted = $"{value:MMMM d 'in the year' yyyy}";
+                    return true;
+                }
+            };
+            var mf = new MessageFormatter(locale: "en-US", customValueFormatter: formatter);
+            var actual = mf.FormatMessage("{value, date, long}", new
+            {
+                value = DateTimeOffset.Parse("1994-09-06T15:00:00Z")
+            });
+
+            Assert.Equal("September 6 in the year 1994", actual);
+        }
+    }
+}

--- a/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/NumberFormatterTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/NumberFormatterTests.cs
@@ -1,0 +1,150 @@
+using System.Globalization;
+using Jeffijoe.MessageFormat.Formatting;
+using Xunit;
+
+namespace Jeffijoe.MessageFormat.Tests.Formatting.Formatters
+{
+    public class NumberFormatterTests
+    {
+        [Theory]
+        [InlineData(69, "69")]
+        [InlineData(69.420, "69.42")]
+        [InlineData(123_456.789, "123,456.789")]
+        [InlineData(1234567.1234567, "1,234,567.123")]
+        public void NumberFormatter_Default(decimal number, string expected)
+        {
+            var mf = new MessageFormatter(locale: "en-US");
+            // NOTE: The whitespace at the end is on purpose to cover whitespace tolerance in parsing.
+            var actual = mf.FormatMessage("{value, number }", new
+            {
+                value = number
+            });
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(69, "69.0000")]
+        [InlineData(69.420, "69.4200")]
+        public void NumberFormatter_Decimal_CustomFormat(decimal number, string expected)
+        {
+            var formatters = new CustomValueFormatters
+            {
+                Number = (CultureInfo _, object? value, string? style, out string? formatted) =>
+                {
+                    formatted = string.Format($"{{0:{style}}}", value);
+                    return true;
+                }
+            };
+            var mf = new MessageFormatter(locale: "en-US", customValueFormatter: formatters);
+
+            var actual = mf.FormatMessage("{value, number, 0.0000}", new
+            {
+                value = number
+            });
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(0.2, "20%")]
+        [InlineData(1.2, "120%")]
+        [InlineData(1234567.1234567, "123,456,712%")]
+        public void NumberFormatter_Percent(decimal number, string expected)
+        {
+            var mf = new MessageFormatter(locale: "en-US");
+            
+            // NOTE: The inconsistent whitespace in the pattern is to cover whitespace tolerance in parsing.
+            var actual = mf.FormatMessage("{value, number,percent}", new
+            {
+                value = number
+            });
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(0.2, "0")]
+        [InlineData(1.2, "1")]
+        [InlineData(2.7, "3")]
+        [InlineData("2.7", "3")]
+        [InlineData("a string", "a string")]
+        [InlineData(true, "True")]
+        public void NumberFormatter_Integer(object? value, string expected)
+        {
+            var mf = new MessageFormatter(locale: "en-US");
+            var actual = mf.FormatMessage("{value, number, integer}", new
+            {
+                value
+            });
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData("en-US", 20, "$20.00")]
+        [InlineData("en-US", 99.99, "$99.99")]
+        [InlineData("da-DK", 99.99, "99,99 kr.")]
+        public void NumberFormatter_Currency(string locale, decimal number, string expected)
+        {
+            var mf = new MessageFormatter(locale: locale);
+
+            // NOTE: The inconsistent whitespace in the pattern is to cover whitespace tolerance in parsing.
+            var actual = mf.FormatMessage("{value, number, currency }", new
+            {
+                value = number
+            });
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void NumberFormatter_ThrowsIfStyleIsNotSupported()
+        {
+            const decimal Number = 12.34m;
+            var mf = new MessageFormatter(locale: "en-US");
+            var ex = Assert.Throws<UnsupportedFormatStyleException>(() =>
+                mf.FormatMessage($"{{value, number, wow}}",
+                    new
+                    {
+                        value = Number
+                    }));
+            Assert.Equal("value", ex.Variable);
+            Assert.Equal("number", ex.Format);
+            Assert.Equal("wow", ex.Style);
+        }
+
+        [Fact]
+        public void NumberFormatter_BadInput_FallsBackToRegularFormat()
+        {
+            var mf = new MessageFormatter(locale: "en-US");
+
+            {
+                var actual = mf.FormatMessage($"{{value, number, currency}}", new
+                {
+                    value = "a lot of money"
+                });
+
+                Assert.Equal("a lot of money", actual);
+            }
+
+            {
+                var actual = mf.FormatMessage($"{{value, number, integer}}", new
+                {
+                    value = "a lot of money"
+                });
+
+                Assert.Equal("a lot of money", actual);
+            }
+
+            {
+                var actual = mf.FormatMessage($"{{value, number, integer}}", new
+                {
+                    value = true
+                });
+
+                Assert.Equal("True", actual);
+            }
+        }
+    }
+}

--- a/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/TimeFormatterTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/TimeFormatterTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Globalization;
+using Jeffijoe.MessageFormat.Formatting;
+using Xunit;
+
+namespace Jeffijoe.MessageFormat.Tests.Formatting.Formatters
+{
+    public class TimeFormatterTests
+    {
+        [Theory]
+        [InlineData("en-US", "1994-09-06T15:01:23Z", "3:01 PM")]
+        [InlineData("da-DK", "1994-09-06T15:01:23Z", "15.01")]
+        public void TimeFormatter_Short(string locale, string dateStr, string expected)
+        {
+            var mf = new MessageFormatter(locale: locale);
+            var actual = mf.FormatMessage("{value, time, short}", new
+            {
+                value = DateTimeOffset.Parse(dateStr)
+            });
+
+            // Replacing all whitespace due to a difference in formatting on macOS vs Linux.
+            expected = expected.Replace(" ", "");
+            actual = actual.Replace(" ", "");
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData("en-US", "1994-09-06T15:01:23Z", "3:01:23 PM")]
+        [InlineData("da-DK", "1994-09-06T15:01:23Z", "15.01.23")]
+        public void TimeFormatter_Default(string locale, string dateStr, string expected)
+        {
+            var mf = new MessageFormatter(locale: locale);
+            var actual = mf.FormatMessage("{value, time}", new
+            {
+                value = DateTimeOffset.Parse(dateStr)
+            });
+
+            // Replacing all whitespace due to a difference in formatting on macOS vs Linux.
+            expected = expected.Replace(" ", "");
+            actual = actual.Replace(" ", "");
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TimeFormatter_UnsupportedStyle()
+        {
+            var mf = new MessageFormatter();
+            Assert.Throws<UnsupportedFormatStyleException>(
+                () => mf.FormatMessage("{value, time, lol}", new
+                {
+                    value = DateTimeOffset.UtcNow
+                }));
+        }
+        
+        [Fact]
+        public void TimeFormatter_Custom()
+        {
+            var formatter = new CustomValueFormatters
+            {
+                Time = (CultureInfo _, object? value, string? _, out string? formatted) =>
+                {
+                    formatted = $"{value:hmm} nice";
+                    return true;
+                }
+            };
+            var mf = new MessageFormatter(locale: "en-US", customValueFormatter: formatter);
+            var actual = mf.FormatMessage("{value, time, long}", new
+            {
+                value = DateTimeOffset.Parse("1994-09-06T16:20:09Z")
+            });
+
+            Assert.Equal("420 nice", actual);
+        }
+    }
+}

--- a/src/Jeffijoe.MessageFormat.Tests/TestHelpers/FakeMessageFormatter.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/TestHelpers/FakeMessageFormatter.cs
@@ -7,6 +7,8 @@ namespace Jeffijoe.MessageFormat.Tests.TestHelpers
     /// </summary>
     internal class FakeMessageFormatter : IMessageFormatter
     {
+        public CustomValueFormatter? CustomValueFormatter { get; set; }
+
         public string FormatMessage(string pattern, IReadOnlyDictionary<string, object?> argsMap) => pattern;
 
         public string FormatMessage(string pattern, object args) => pattern;

--- a/src/Jeffijoe.MessageFormat/CustomValueFormatters.cs
+++ b/src/Jeffijoe.MessageFormat/CustomValueFormatters.cs
@@ -1,0 +1,209 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+
+namespace Jeffijoe.MessageFormat;
+
+/// <summary>
+///     Attempts to format a date.
+/// </summary>
+/// <param name="culture">
+///     The culture.
+/// </param>
+/// <param name="value">
+///     The value to format.
+/// </param>
+/// <param name="style">
+///     The requested style, if any.
+/// </param>
+/// <param name="formatted">
+///     Output for setting the formatted result.
+/// </param>
+/// <returns>
+///     <value>true</value> if able to format the value; <value>false</value> otherwise.
+/// </returns>
+public delegate bool TryFormatDate(
+    CultureInfo culture,
+    object? value,
+    string? style,
+    out string? formatted);
+
+/// <summary>
+///     Attempts to format a time.
+/// </summary>
+/// <param name="culture">
+///     The culture.
+/// </param>
+/// <param name="value">
+///     The value to format.
+/// </param>
+/// <param name="style">
+///     The requested style, if any.
+/// </param>
+/// <param name="formatted">
+///     Output for setting the formatted result.
+/// </param>
+/// <returns>
+///     <value>true</value> if able to format the value; <value>false</value> otherwise.
+/// </returns>
+public delegate bool TryFormatTime(
+    CultureInfo culture,
+    object? value,
+    string? style,
+    out string? formatted);
+
+/// <summary>
+///     Attempts to format a number.
+/// </summary>
+/// <param name="culture">
+///     The culture.
+/// </param>
+/// <param name="value">
+///     The value to format.
+/// </param>
+/// <param name="style">
+///     The requested style, if any.
+/// </param>
+/// <param name="formatted">
+///     Output for setting the formatted result.
+/// </param>
+/// <returns>
+///     <value>true</value> if able to format the value; <value>false</value> otherwise.
+/// </returns>
+public delegate bool TryFormatNumber(
+    CultureInfo culture,
+    object? value,
+    string? style,
+    out string? formatted);
+
+/// <summary>
+///     Base class that can be extended to provide custom formatting
+///     for values.
+/// </summary>
+public abstract class CustomValueFormatter
+{
+    /// <summary>
+    ///     Attempts to format a date.
+    /// </summary>
+    /// <param name="culture">
+    ///     The culture.
+    /// </param>
+    /// <param name="value">
+    ///     The value to format.
+    /// </param>
+    /// <param name="style">
+    ///     The requested style, if any.
+    /// </param>
+    /// <param name="formatted">
+    ///     Output for setting the formatted result.
+    /// </param>
+    /// <returns>
+    ///     <value>true</value> if able to format the value; <value>false</value> otherwise.
+    /// </returns>
+    [ExcludeFromCodeCoverage]
+    public virtual bool TryFormatDate(
+        CultureInfo culture,
+        object? value,
+        string? style,
+        out string? formatted)
+    {
+        formatted = null;
+        return false;
+    }
+
+    /// <summary>
+    ///     Attempts to format a time.
+    /// </summary>
+    /// <param name="culture">
+    ///     The culture.
+    /// </param>
+    /// <param name="value">
+    ///     The value to format.
+    /// </param>
+    /// <param name="style">
+    ///     The requested style, if any.
+    /// </param>
+    /// <param name="formatted">
+    ///     Output for setting the formatted result.
+    /// </param>
+    /// <returns>
+    ///     <value>true</value> if able to format the value; <value>false</value> otherwise.
+    /// </returns>
+    [ExcludeFromCodeCoverage]
+    public virtual bool TryFormatTime(
+        CultureInfo culture,
+        object? value,
+        string? style,
+        out string? formatted)
+    {
+        formatted = null;
+        return false;
+    }
+
+    /// <summary>
+    ///     Attempts to format a number.
+    /// </summary>
+    /// <param name="culture">
+    ///     The culture.
+    /// </param>
+    /// <param name="value">
+    ///     The value to format.
+    /// </param>
+    /// <param name="style">
+    ///     The requested style, if any.
+    /// </param>
+    /// <param name="formatted">
+    ///     Output for setting the formatted result.
+    /// </param>
+    /// <returns>
+    ///     <value>true</value> if able to format the value; <value>false</value> otherwise.
+    /// </returns>
+    [ExcludeFromCodeCoverage]
+    public virtual bool TryFormatNumber(
+        CultureInfo culture,
+        object? value,
+        string? style,
+        out string? formatted)
+    {
+        formatted = null;
+        return false;
+    }
+}
+
+/// <summary>
+///     Delegates the formatting calls to the configured function properties.
+/// </summary>
+public sealed class CustomValueFormatters : CustomValueFormatter
+{
+    /// <summary>
+    ///     Formatter for dates.
+    /// </summary>
+    public TryFormatDate? Date { get; set; }
+
+    /// <summary>
+    ///     Formatter for times.
+    /// </summary>
+    public TryFormatDate? Time { get; set; }
+
+    /// <summary>
+    ///     Formatter for numbers.
+    /// </summary>
+    public TryFormatNumber? Number { get; set; }
+
+    /// <inheritdoc />
+    public override bool TryFormatDate(CultureInfo culture, object? value, string? style,
+        out string? formatted) =>
+        this.Date?.Invoke(culture, value, style, out formatted) ??
+        base.TryFormatDate(culture, value, style, out formatted);
+
+    /// <inheritdoc />
+    public override bool TryFormatTime(CultureInfo culture, object? value, string? style,
+        out string? formatted) =>
+        this.Time?.Invoke(culture, value, style, out formatted) ??
+        base.TryFormatTime(culture, value, style, out formatted);
+
+    /// <inheritdoc />
+    public override bool TryFormatNumber(CultureInfo culture, object? value, string? style,
+        out string? formatted) =>
+        this.Number?.Invoke(culture, value, style, out formatted) ??
+        base.TryFormatNumber(culture, value, style, out formatted);
+}

--- a/src/Jeffijoe.MessageFormat/Formatting/FormatterLibrary.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/FormatterLibrary.cs
@@ -23,6 +23,9 @@ namespace Jeffijoe.MessageFormat.Formatting
             this.Add(new VariableFormatter());
             this.Add(new SelectFormatter());
             this.Add(new PluralFormatter());
+            this.Add(new NumberFormatter());
+            this.Add(new DateFormatter());
+            this.Add(new TimeFormatter());
         }
 
         #endregion

--- a/src/Jeffijoe.MessageFormat/Formatting/Formatters/BaseValueFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/Formatters/BaseValueFormatter.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+
+namespace Jeffijoe.MessageFormat.Formatting.Formatters;
+
+/// <summary>
+///     Base formatter for values such as numbers, dates, times, etc.
+/// </summary>
+public abstract class BaseValueFormatter : BaseFormatter, IFormatter
+{
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="BaseValueFormatter" /> class.
+    /// </summary>
+    protected BaseValueFormatter()
+    {
+    }
+
+    /// <inheritdoc />
+    [ExcludeFromCodeCoverage]
+    public bool VariableMustExist => true;
+
+    /// <inheritdoc />
+    public abstract bool CanFormat(FormatterRequest request);
+
+    /// <summary>
+    ///     Formats the value using the given style.
+    /// </summary>
+    /// <param name="culture"></param>
+    /// <param name="customValueFormatter"></param>
+    /// <param name="variable"></param>
+    /// <param name="style"></param>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    protected abstract string FormatValue(CultureInfo culture, CustomValueFormatter? customValueFormatter,
+        string variable, string style, object? value);
+
+    /// <inheritdoc />
+    public string Format(
+        string locale,
+        FormatterRequest request,
+        IReadOnlyDictionary<string, object?> args,
+        object? value,
+        IMessageFormatter messageFormatter)
+    {
+        var formatterArgs = request.FormatterArguments!;
+        var culture = CultureInfo.GetCultureInfo(locale);
+        return FormatValue(
+            culture: culture,
+            customValueFormatter: messageFormatter.CustomValueFormatter,
+            variable: request.Variable,
+            style: formatterArgs,
+            value: value);
+    }
+}

--- a/src/Jeffijoe.MessageFormat/Formatting/Formatters/DateFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/Formatters/DateFormatter.cs
@@ -1,0 +1,43 @@
+using System.Globalization;
+
+namespace Jeffijoe.MessageFormat.Formatting.Formatters;
+
+/// <summary>
+///     Formatter for dates.
+/// </summary>
+public class DateFormatter : BaseValueFormatter, IFormatter
+{
+    /// <summary>
+    ///     Name of this formatter.
+    /// </summary>
+    private const string FormatterName = "date";
+
+    /// <inheritdoc />
+    public override bool CanFormat(FormatterRequest request) =>
+        request.FormatterName == FormatterName;
+
+    /// <inheritdoc />
+    protected override string FormatValue(
+        CultureInfo culture,
+        CustomValueFormatter? customValueFormatter,
+        string variable,
+        string style,
+        object? value)
+    {
+        if (customValueFormatter?.TryFormatDate(culture, value, style, out var formatted) == true)
+        {
+            // When the formatter returns `true`, the string will be set.
+            return formatted!;
+        }
+
+        return style switch
+        {
+            "" or "short" => string.Format(culture, "{0:d}", value),
+            "full" => string.Format(culture, "{0:D}", value),
+            _ => throw new UnsupportedFormatStyleException(
+                variable: variable,
+                format: FormatterName,
+                style: style)
+        };
+    }
+}

--- a/src/Jeffijoe.MessageFormat/Formatting/Formatters/NumberFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/Formatters/NumberFormatter.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Globalization;
+
+namespace Jeffijoe.MessageFormat.Formatting.Formatters;
+
+/// <summary>
+///     Formatter for numbers.
+/// </summary>
+public class NumberFormatter : BaseValueFormatter, IFormatter
+{
+    /// <summary>
+    ///     Name of this formatter.
+    /// </summary>
+    private const string FormatterName = "number";
+
+    /// <inheritdoc />
+    public override bool CanFormat(FormatterRequest request) =>
+        request.FormatterName == FormatterName;
+
+    /// <inheritdoc />
+    protected override string FormatValue(
+        CultureInfo culture,
+        CustomValueFormatter? customValueFormatter,
+        string variable,
+        string style,
+        object? value)
+    {
+        if (customValueFormatter?.TryFormatNumber(culture, value, style, out var formatted) == true)
+        {
+            // When the formatter returns `true`, the string will be set.
+            return formatted!;
+        }
+
+        return style switch
+        {
+            "" => string.Format(culture, "{0:#,##0.###}", value),
+            "integer" => FormatInteger(culture, value),
+            "currency" => string.Format(culture, "{0:C}", value),
+            "percent" => string.Format(culture, "{0:P0}", value),
+            _ => throw new UnsupportedFormatStyleException(
+                variable: variable,
+                format: FormatterName,
+                style: style)
+        };
+    }
+
+    /// <summary>
+    ///     Attempts to format as an integer by first converting the value to
+    ///     an integer. Otherwise prints the value as-is.
+    /// </summary>
+    /// <param name="cultureInfo"></param>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    private static string FormatInteger(IFormatProvider cultureInfo, object? value) =>
+        value switch
+        {
+            decimal or float or double => string.Format(cultureInfo, "{0}", Convert.ToInt64(value)),
+            string s => decimal.TryParse(s, out var parsed) ? FormatInteger(cultureInfo, parsed) : s,
+            _ => string.Format(cultureInfo, "{0}", value)
+        };
+}

--- a/src/Jeffijoe.MessageFormat/Formatting/Formatters/SelectFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/Formatters/SelectFormatter.cs
@@ -46,7 +46,7 @@ namespace Jeffijoe.MessageFormat.Formatting.Formatters
         /// Using the specified parameters and arguments, a formatted string shall be returned.
         /// The <see cref="IMessageFormatter" /> is being provided as well, to enable
         /// nested formatting. This is only called if <see cref="CanFormat" /> returns true.
-        /// The argswill always contain the <see cref="FormatterRequest.Variable" />.
+        /// The args will always contain the <see cref="FormatterRequest.Variable" />.
         /// </summary>
         /// <param name="locale">The locale being used. It is up to the formatter what they do with this information.</param>
         /// <param name="request">The parameters.</param>

--- a/src/Jeffijoe.MessageFormat/Formatting/Formatters/TimeFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/Formatters/TimeFormatter.cs
@@ -1,0 +1,43 @@
+using System.Globalization;
+
+namespace Jeffijoe.MessageFormat.Formatting.Formatters;
+
+/// <summary>
+///     Formatter for times.
+/// </summary>
+public class TimeFormatter : BaseValueFormatter, IFormatter
+{
+    /// <summary>
+    ///     Name of this formatter.
+    /// </summary>
+    private const string FormatterName = "time";
+
+    /// <inheritdoc />
+    public override bool CanFormat(FormatterRequest request) =>
+        request.FormatterName == FormatterName;
+
+    /// <inheritdoc />
+    protected override string FormatValue(
+        CultureInfo culture,
+        CustomValueFormatter? customValueFormatter,
+        string variable,
+        string style,
+        object? value)
+    {
+        if (customValueFormatter?.TryFormatTime(culture, value, style, out var formatted) == true)
+        {
+            // When the formatter returns `true`, the string will be set.
+            return formatted!;
+        }
+
+        return style switch
+        {
+            "" or "medium" => string.Format(culture, "{0:T}", value),
+            "short" => string.Format(culture, "{0:t}", value),
+            _ => throw new UnsupportedFormatStyleException(
+                variable: variable,
+                format: FormatterName,
+                style: style)
+        };
+    }
+}

--- a/src/Jeffijoe.MessageFormat/Formatting/UnsupportedFormatStyleException.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/UnsupportedFormatStyleException.cs
@@ -1,0 +1,87 @@
+namespace Jeffijoe.MessageFormat.Formatting;
+
+/// <summary>
+///     Thrown when formatter is unable to apply the given style.
+/// </summary>
+public class UnsupportedFormatStyleException : MessageFormatterException
+{
+    #region Constructors and Destructors
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="UnsupportedFormatStyleException"/> class.
+    /// </summary>
+    /// <param name="variable">
+    ///     The variable.
+    /// </param>
+    /// <param name="format">
+    ///     The format.
+    /// </param>
+    /// <param name="style">
+    ///     The style that was not supported.
+    /// </param>
+    public UnsupportedFormatStyleException(
+        string variable,
+        string format,
+        string style)
+        : base(BuildMessage(variable, format, style))
+    {
+        this.Variable = variable;
+        this.Format = format;
+        this.Style = style;
+    }
+
+    #endregion
+
+    #region Public Properties
+
+    /// <summary>
+    ///     Gets the name of the missing variable.
+    /// </summary>
+    /// <value>
+    ///     The missing variable.
+    /// </value>
+    public string Variable { get; private set; }
+
+    /// <summary>
+    ///     Gets the format that attempted to apply the style.
+    /// </summary>
+    /// <value>
+    ///     The format.
+    /// </value>
+    public string Format { get; private set; }
+
+    /// <summary>
+    ///     Gets the style that could not be applied.
+    /// </summary>
+    /// <value>
+    ///     The style.
+    /// </value>
+    public string Style { get; private set; }
+
+    #endregion
+
+    #region Methods
+
+    /// <summary>
+    ///     Builds the message.
+    /// </summary>
+    /// <param name="variable">
+    ///     The variable.
+    /// </param>
+    /// <param name="format">
+    ///     The format.
+    /// </param>
+    /// <param name="style">
+    ///     The style that was not supported.
+    /// </param>
+    /// <returns>
+    /// The <see cref="string"/>.
+    /// </returns>
+    private static string BuildMessage(
+        string variable,
+        string format,
+        string style) =>
+        $"The variable '{variable}' could not be formatted as a '{format}' because the style '{style}' is not supported.";
+
+    #endregion
+}

--- a/src/Jeffijoe.MessageFormat/IMessageFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/IMessageFormatter.cs
@@ -12,6 +12,15 @@ namespace Jeffijoe.MessageFormat
     /// </summary>
     public interface IMessageFormatter
     {
+        #region Public properties
+
+        /// <summary>
+        ///     The custom value formatter to use for formats like `number`, `date`, `time` etc.
+        /// </summary>
+        CustomValueFormatter? CustomValueFormatter { get; }
+
+        #endregion
+
         #region Public Methods and Operators
 
         /// <summary>

--- a/src/Jeffijoe.MessageFormat/MessageFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/MessageFormatter.cs
@@ -13,363 +13,381 @@ using Jeffijoe.MessageFormat.Formatting.Formatters;
 using Jeffijoe.MessageFormat.Helpers;
 using Jeffijoe.MessageFormat.Parsing;
 
-namespace Jeffijoe.MessageFormat
+namespace Jeffijoe.MessageFormat;
+
+/// <summary>
+///     The magical Message Formatter.
+/// </summary>
+public class MessageFormatter : IMessageFormatter
 {
+    #region Static Fields
+
     /// <summary>
-    ///     The magical Message Formatter.
+    ///     The instance of MessageFormatter, with the default locale + cache settings.
     /// </summary>
-    public class MessageFormatter : IMessageFormatter
+    private static readonly IMessageFormatter Instance = new MessageFormatter();
+
+    /// <summary>
+    ///     The lock object.
+    /// </summary>
+    private static readonly object Lock = new object();
+
+    #endregion
+
+    #region Fields
+
+    /// <summary>
+    ///     Pattern cache. If enabled, should speed up formatting the same pattern multiple times,
+    ///     regardless of arguments.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, IFormatterRequestCollection>? cache;
+
+    /// <summary>
+    ///     The formatter library.
+    /// </summary>
+    private readonly IFormatterLibrary library;
+
+    /// <summary>
+    ///     The pattern parser
+    /// </summary>
+    private readonly IPatternParser patternParser;
+
+    #endregion
+
+    #region Constructors and Destructors
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="MessageFormatter" /> class.
+    /// </summary>
+    /// <param name="useCache">
+    ///     The use Cache.
+    /// </param>
+    /// <param name="locale">
+    ///     The locale.
+    /// </param>
+    /// <param name="customValueFormatter">
+    ///     The custom value formatter to use. Can be <c>null</c>.
+    /// </param>
+    public MessageFormatter(bool useCache = true, string locale = "en",
+        CustomValueFormatter? customValueFormatter = null)
+        : this(
+            patternParser: new PatternParser(new LiteralParser()),
+            library: new FormatterLibrary(),
+            useCache: useCache,
+            locale: locale,
+            customValueFormatter: customValueFormatter)
     {
-        #region Static Fields
+    }
 
-        /// <summary>
-        ///     The instance of MessageFormatter, with the default locale + cache settings.
-        /// </summary>
-        private static readonly IMessageFormatter Instance = new MessageFormatter();
-
-        /// <summary>
-        ///     The lock object.
-        /// </summary>
-        private static readonly object Lock = new object();
-
-        #endregion
-
-        #region Fields
-
-        /// <summary>
-        ///     Pattern cache. If enabled, should speed up formatting the same pattern multiple times,
-        ///     regardless of arguments.
-        /// </summary>
-        private readonly ConcurrentDictionary<string, IFormatterRequestCollection>? cache;
-
-        /// <summary>
-        ///     The formatter library.
-        /// </summary>
-        private readonly IFormatterLibrary library;
-
-        /// <summary>
-        ///     The pattern parser
-        /// </summary>
-        private readonly IPatternParser patternParser;
-
-        #endregion
-
-        #region Constructors and Destructors
-
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="MessageFormatter" /> class.
-        /// </summary>
-        /// <param name="useCache">
-        ///     The use Cache.
-        /// </param>
-        /// <param name="locale">
-        ///     The locale.
-        /// </param>
-        public MessageFormatter(bool useCache = true, string locale = "en")
-            : this(new PatternParser(new LiteralParser()), new FormatterLibrary(), useCache, locale)
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="MessageFormatter" /> class.
+    /// </summary>
+    /// <param name="patternParser">
+    ///     The pattern parser.
+    /// </param>
+    /// <param name="library">
+    ///     The library.
+    /// </param>
+    /// <param name="useCache">
+    ///     if set to <c>true</c> uses the cache.
+    /// </param>
+    /// <param name="locale">
+    ///     The locale to use. Formatters may need this.
+    /// </param>
+    /// <param name="customValueFormatter">
+    ///     The custom value formatter to use. Can be <c>null</c>.
+    /// </param>
+    internal MessageFormatter(
+        IPatternParser patternParser,
+        IFormatterLibrary library,
+        bool useCache,
+        string locale = "en",
+        CustomValueFormatter? customValueFormatter = null)
+    {
+        this.patternParser = patternParser ?? throw new ArgumentNullException("patternParser");
+        this.library = library ?? throw new ArgumentNullException("library");
+        this.CustomValueFormatter = customValueFormatter;
+        this.Locale = locale;
+        if (useCache)
         {
+            this.cache = new ConcurrentDictionary<string, IFormatterRequestCollection>();
         }
+    }
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="MessageFormatter" /> class.
-        /// </summary>
-        /// <param name="patternParser">
-        ///     The pattern parser.
-        /// </param>
-        /// <param name="library">
-        ///     The library.
-        /// </param>
-        /// <param name="useCache">
-        ///     if set to <c>true</c> uses the cache.
-        /// </param>
-        /// <param name="locale">
-        ///     The locale to use. Formatters may need this.
-        /// </param>
-        internal MessageFormatter(
-            IPatternParser patternParser,
-            IFormatterLibrary library,
-            bool useCache,
-            string locale = "en")
+    #endregion
+
+    #region Public Properties
+
+    /// <summary>
+    ///     The custom value formatter to use for formats like `number`, `date`, `time` etc.
+    /// </summary>
+    public CustomValueFormatter? CustomValueFormatter { get; private set; }
+
+    /// <summary>
+    ///     Gets the formatters library, where you can add your own formatters if you want.
+    /// </summary>
+    /// <value>
+    ///     The formatters.
+    /// </value>
+    public IFormatterLibrary Formatters
+    {
+        get { return this.library; }
+    }
+
+    /// <summary>
+    ///     Gets or sets the locale.
+    /// </summary>
+    /// <value>
+    ///     The locale.
+    /// </value>
+    public string Locale { get; set; }
+
+    /// <summary>
+    ///     Gets the pluralizers dictionary from the <see cref="PluralFormatter" />, if set. Key is the locale.
+    /// </summary>
+    /// <value>
+    ///     The pluralizers, or <c>null</c> if the plural formatter has not been added.
+    /// </value>
+    public IDictionary<string, Pluralizer>? Pluralizers
+    {
+        get
         {
-            this.patternParser = patternParser ?? throw new ArgumentNullException("patternParser");
-            this.library = library ?? throw new ArgumentNullException("library");
-            this.Locale = locale;
-            if (useCache)
+            var pluralFormatter = this.Formatters.OfType<PluralFormatter>().FirstOrDefault();
+            return pluralFormatter?.Pluralizers;
+        }
+    }
+
+    #endregion
+
+    #region Public Methods and Operators
+
+    /// <summary>
+    ///     Formats the specified pattern with the specified data.
+    /// </summary>
+    /// <remarks>
+    ///     This method calls <see cref="Format(string, IReadOnlyDictionary{string, object})"/>
+    ///     on a singleton instance using a lock.
+    ///     Do not use in a tight loop, as a lock is being used to ensure thread safety.
+    /// </remarks>
+    /// <param name="pattern">
+    ///     The pattern.
+    /// </param>
+    /// <param name="data">
+    ///     The data.
+    /// </param>
+    /// <returns>
+    ///     The formatted message.
+    /// </returns>
+    public static string Format(string pattern, IReadOnlyDictionary<string, object?> data)
+    {
+        lock (Lock)
+        {
+            return Instance.FormatMessage(pattern, data);
+        }
+    }
+
+    /// <summary>
+    ///     Formats the specified pattern with the specified data.
+    /// </summary>
+    /// This method calls
+    /// <see cref="MessageFormatterExtensions.FormatMessage(Jeffijoe.MessageFormat.IMessageFormatter,string,object)" />
+    /// on a singleton instance using a lock.
+    /// Do not use in a tight loop, as a lock is being used to ensure thread safety.
+    /// <param name="pattern">
+    ///     The pattern.
+    /// </param>
+    /// <param name="data">
+    ///     The data.
+    /// </param>
+    /// <returns>
+    ///     The formatted message.
+    /// </returns>
+    public static string Format(string pattern, object data)
+    {
+        lock (Lock)
+        {
+            return Instance.FormatMessage(pattern, data);
+        }
+    }
+
+    /// <summary>
+    ///     Formats the message with the specified arguments. It's so magical.
+    /// </summary>
+    /// <param name="pattern">
+    ///     The pattern.
+    /// </param>
+    /// <param name="args">
+    ///     The arguments.
+    /// </param>
+    /// <returns>
+    ///     The <see cref="string" />.
+    /// </returns>
+    public string FormatMessage(string pattern, IReadOnlyDictionary<string, object?> args)
+    {
+        /*
+         * We are assuming the formatters are ordered correctly
+         * - that is, from left to right, string-wise.
+         */
+        var sourceBuilder = StringBuilderPool.Get();
+
+        try
+        {
+            sourceBuilder.Append(pattern);
+            var requests = this.ParseRequests(pattern, sourceBuilder);
+
+            for (int i = 0; i < requests.Count; i++)
             {
-                this.cache = new ConcurrentDictionary<string, IFormatterRequestCollection>();
-            }
-        }
+                var request = requests[i];
 
-        #endregion
+                var formatter = this.Formatters.GetFormatter(request);
 
-        #region Public Properties
-
-        /// <summary>
-        ///     Gets the formatters library, where you can add your own formatters if you want.
-        /// </summary>
-        /// <value>
-        ///     The formatters.
-        /// </value>
-        public IFormatterLibrary Formatters
-        {
-            get { return this.library; }
-        }
-
-        /// <summary>
-        ///     Gets or sets the locale.
-        /// </summary>
-        /// <value>
-        ///     The locale.
-        /// </value>
-        public string Locale { get; set; }
-
-        /// <summary>
-        ///     Gets the pluralizers dictionary from the <see cref="PluralFormatter" />, if set. Key is the locale.
-        /// </summary>
-        /// <value>
-        ///     The pluralizers, or <c>null</c> if the plural formatter has not been added.
-        /// </value>
-        public IDictionary<string, Pluralizer>? Pluralizers
-        {
-            get
-            {
-                var pluralFormatter = this.Formatters.OfType<PluralFormatter>().FirstOrDefault();
-                return pluralFormatter?.Pluralizers;
-            }
-        }
-
-        #endregion
-
-        #region Public Methods and Operators
-
-        /// <summary>
-        ///     Formats the specified pattern with the specified data.
-        /// </summary>
-        /// <remarks>
-        ///     This method calls <see cref="Format(string, IReadOnlyDictionary{string, object})"/>
-        ///     on a singleton instance using a lock.
-        ///     Do not use in a tight loop, as a lock is being used to ensure thread safety.
-        /// </remarks>
-        /// <param name="pattern">
-        ///     The pattern.
-        /// </param>
-        /// <param name="data">
-        ///     The data.
-        /// </param>
-        /// <returns>
-        ///     The formatted message.
-        /// </returns>
-        public static string Format(string pattern, IReadOnlyDictionary<string, object?> data)
-        {
-            lock (Lock)
-            {
-                return Instance.FormatMessage(pattern, data);
-            }
-        }
-
-        /// <summary>
-        ///     Formats the specified pattern with the specified data.
-        /// </summary>
-        /// This method calls
-        /// <see cref="MessageFormatterExtensions.FormatMessage(Jeffijoe.MessageFormat.IMessageFormatter,string,object)" />
-        /// on a singleton instance using a lock.
-        /// Do not use in a tight loop, as a lock is being used to ensure thread safety.
-        /// <param name="pattern">
-        ///     The pattern.
-        /// </param>
-        /// <param name="data">
-        ///     The data.
-        /// </param>
-        /// <returns>
-        ///     The formatted message.
-        /// </returns>
-        public static string Format(string pattern, object data)
-        {
-            lock (Lock)
-            {
-                return Instance.FormatMessage(pattern, data);
-            }
-        }
-
-        /// <summary>
-        ///     Formats the message with the specified arguments. It's so magical.
-        /// </summary>
-        /// <param name="pattern">
-        ///     The pattern.
-        /// </param>
-        /// <param name="args">
-        ///     The arguments.
-        /// </param>
-        /// <returns>
-        ///     The <see cref="string" />.
-        /// </returns>
-        public string FormatMessage(string pattern, IReadOnlyDictionary<string, object?> args)
-        {
-            /*
-             * We are assuming the formatters are ordered correctly
-             * - that is, from left to right, string-wise.
-             */
-            var sourceBuilder = StringBuilderPool.Get();
-
-            try
-            {
-                sourceBuilder.Append(pattern);
-                var requests = this.ParseRequests(pattern, sourceBuilder);
-
-                for (int i = 0; i < requests.Count; i++)
+                if (args.TryGetValue(request.Variable, out var value) == false && formatter.VariableMustExist)
                 {
-                    var request = requests[i];
-
-                    var formatter = this.Formatters.GetFormatter(request);
-
-                    if (args.TryGetValue(request.Variable, out var value) == false && formatter.VariableMustExist)
-                    {
-                        throw new VariableNotFoundException(request.Variable);
-                    }
-
-                    // Double dispatch, yeah!
-                    var result = formatter.Format(this.Locale, request, args, value, this);
-
-                    // First, we remove the literal from the source.
-                    var sourceLiteral = request.SourceLiteral;
-
-                    // +1 because we want to include the last index.
-                    var length = (sourceLiteral.EndIndex - sourceLiteral.StartIndex) + 1;
-                    sourceBuilder.Remove(sourceLiteral.StartIndex, length);
-
-                    // Now, we inject the result.
-                    sourceBuilder.Insert(sourceLiteral.StartIndex, result);
-
-                    // The next requests will want to know what happened.
-                    requests.ShiftIndices(i, result.Length);
+                    throw new VariableNotFoundException(request.Variable);
                 }
 
-                // And we're done.
-                return MessageFormatter.UnescapeLiterals(sourceBuilder);
+                // Double dispatch, yeah!
+                var result = formatter.Format(this.Locale, request, args, value, this);
+
+                // First, we remove the literal from the source.
+                var sourceLiteral = request.SourceLiteral;
+
+                // +1 because we want to include the last index.
+                var length = (sourceLiteral.EndIndex - sourceLiteral.StartIndex) + 1;
+                sourceBuilder.Remove(sourceLiteral.StartIndex, length);
+
+                // Now, we inject the result.
+                sourceBuilder.Insert(sourceLiteral.StartIndex, result);
+
+                // The next requests will want to know what happened.
+                requests.ShiftIndices(i, result.Length);
             }
-            finally
-            {
-                StringBuilderPool.Return(sourceBuilder);
-            }
+
+            // And we're done.
+            return MessageFormatter.UnescapeLiterals(sourceBuilder);
+        }
+        finally
+        {
+            StringBuilderPool.Return(sourceBuilder);
+        }
+    }
+
+    #endregion
+
+    #region Methods
+
+    /// <summary>
+    ///     Unescapes the literals from the source builder, and returns a new instance with literals unescaped.
+    /// </summary>
+    /// <param name="sourceBuilder">
+    ///     The source builder.
+    /// </param>
+    /// <returns>
+    ///     The <see cref="StringBuilder" />.
+    /// </returns>
+    internal static string UnescapeLiterals(StringBuilder sourceBuilder)
+    {
+        // If the block is empty, do nothing.
+        if (sourceBuilder.Length == 0)
+        {
+            return string.Empty;
         }
 
-        #endregion
+        const char EscapingChar = '\'';
 
-        #region Methods
-
-        /// <summary>
-        ///     Unescapes the literals from the source builder, and returns a new instance with literals unescaped.
-        /// </summary>
-        /// <param name="sourceBuilder">
-        ///     The source builder.
-        /// </param>
-        /// <returns>
-        ///     The <see cref="StringBuilder" />.
-        /// </returns>
-        internal static string UnescapeLiterals(StringBuilder sourceBuilder)
+        if (!sourceBuilder.Contains(EscapingChar))
         {
-            // If the block is empty, do nothing.
-            if (sourceBuilder.Length == 0)
+            return sourceBuilder.ToString();
+        }
+
+        var length = sourceBuilder.Length;
+        var insideEscapeSequence = false;
+
+        var dest = StringBuilderPool.Get();
+
+        try
+        {
+            for (int i = 0; i < length; i++)
             {
-                return string.Empty;
-            }
+                var c = sourceBuilder[i];
 
-            const char EscapingChar = '\'';
-
-            if (!sourceBuilder.Contains(EscapingChar))
-            {
-                return sourceBuilder.ToString();
-            }
-
-            var length = sourceBuilder.Length;
-            var insideEscapeSequence = false;
-
-            var dest = StringBuilderPool.Get();
-
-            try
-            {
-                for (int i = 0; i < length; i++)
+                if (c == EscapingChar)
                 {
-                    var c = sourceBuilder[i];
-
-                    if (c == EscapingChar)
+                    if (i == length - 1)
                     {
-                        if (i == length - 1)
-                        {
-                            if (!insideEscapeSequence)
-                                dest.Append(EscapingChar);
-                            continue;
-                        }
-
-                        var nextChar = sourceBuilder[i + 1];
-                        if (nextChar == EscapingChar)
-                        {
+                        if (!insideEscapeSequence)
                             dest.Append(EscapingChar);
-                            ++i;
-                            continue;
-                        }
-
-                        if (insideEscapeSequence)
-                        {
-                            insideEscapeSequence = false;
-                            continue;
-                        }
-
-                        if (nextChar == '{' || nextChar == '}' || nextChar == '#')
-                        {
-                            dest.Append(nextChar);
-                            insideEscapeSequence = true;
-                            ++i;
-                            continue;
-                        }
-
-                        dest.Append(EscapingChar);
                         continue;
                     }
 
-                    dest.Append(c);
+                    var nextChar = sourceBuilder[i + 1];
+                    if (nextChar == EscapingChar)
+                    {
+                        dest.Append(EscapingChar);
+                        ++i;
+                        continue;
+                    }
+
+                    if (insideEscapeSequence)
+                    {
+                        insideEscapeSequence = false;
+                        continue;
+                    }
+
+                    if (nextChar == '{' || nextChar == '}' || nextChar == '#')
+                    {
+                        dest.Append(nextChar);
+                        insideEscapeSequence = true;
+                        ++i;
+                        continue;
+                    }
+
+                    dest.Append(EscapingChar);
+                    continue;
                 }
 
-                return dest.ToString();
+                dest.Append(c);
             }
-            finally
-            {
-                StringBuilderPool.Return(dest);
-            }
-        }
 
-        /// <summary>
-        ///     Parses the requests, using the cache if enabled and applicable.
-        /// </summary>
-        /// <param name="pattern">
-        ///     The pattern.
-        /// </param>
-        /// <param name="sourceBuilder">
-        ///     The source builder.
-        /// </param>
-        /// <returns>
-        ///     The <see cref="IFormatterRequestCollection" />.
-        /// </returns>
-        private IFormatterRequestCollection ParseRequests(string pattern, StringBuilder sourceBuilder)
+            return dest.ToString();
+        }
+        finally
         {
-            // If we are not using the cache, just parse them straight away.
-            if (this.cache == null)
-            {
-                return this.patternParser.Parse(sourceBuilder);
-            }
+            StringBuilderPool.Return(dest);
+        }
+    }
 
-            // If we have a cached result from this pattern, clone it and return the clone.
-            if (this.cache.TryGetValue(pattern, out var cached))
-            {
-                return cached.Clone();
-            }
-
-            var requests = this.patternParser.Parse(sourceBuilder);
-            this.cache?.TryAdd(pattern, requests.Clone());
-
-            return requests;
+    /// <summary>
+    ///     Parses the requests, using the cache if enabled and applicable.
+    /// </summary>
+    /// <param name="pattern">
+    ///     The pattern.
+    /// </param>
+    /// <param name="sourceBuilder">
+    ///     The source builder.
+    /// </param>
+    /// <returns>
+    ///     The <see cref="IFormatterRequestCollection" />.
+    /// </returns>
+    private IFormatterRequestCollection ParseRequests(string pattern, StringBuilder sourceBuilder)
+    {
+        // If we are not using the cache, just parse them straight away.
+        if (this.cache == null)
+        {
+            return this.patternParser.Parse(sourceBuilder);
         }
 
-        #endregion
+        // If we have a cached result from this pattern, clone it and return the clone.
+        if (this.cache.TryGetValue(pattern, out var cached))
+        {
+            return cached.Clone();
+        }
+
+        var requests = this.patternParser.Parse(sourceBuilder);
+        this.cache?.TryAdd(pattern, requests.Clone());
+
+        return requests;
     }
+
+    #endregion
 }


### PR DESCRIPTION
Implement basic formatting of `number`, `date` and `time` formats with support for some predefined styles as discussed in #17.

See the `README` updates for which styles are supported. There is also an API for supplying your own formatter for each of these to allow the user to override how the values are formatted.