### PR TITLE
Fix issue where newlines were being trimmed

### DIFF
--- a/src/Jeffijoe.MessageFormat.Tests/Jeffijoe.MessageFormat.Tests.csproj
+++ b/src/Jeffijoe.MessageFormat.Tests/Jeffijoe.MessageFormat.Tests.csproj
@@ -11,13 +11,13 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
+    <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
-    <PackageReference Include="xunit.assert" Version="2.4.1" />
-    <PackageReference Include="xunit.core" Version="2.4.1" />
-    <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.assert" Version="2.5.0" />
+    <PackageReference Include="xunit.core" Version="2.5.0" />
+    <PackageReference Include="xunit.extensibility.core" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Jeffijoe.MessageFormat.Tests/MessageFormatterIssues.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/MessageFormatterIssues.cs
@@ -56,5 +56,21 @@ namespace Jeffijoe.MessageFormat.Tests
             Assert.Equal("value", subject.FormatMessage("{string}", idict));
             Assert.Equal("value", subject.FormatMessage("{string}", idictNullable!));
         }
+        
+        [Fact]
+        public void Issue34_Newlines_are_stripped()
+        {
+            var subject = new MessageFormatter(locale: "en-US");
+
+            const string Expected = "Single text which will not change.\nSummary:\nAccepted\nData:\n-X\n-Y\n-Z";
+            
+            var result = subject.FormatMessage(
+                "Single text which will not change.\nSummary:{acceptedData, select, NONE {} other {\nAccepted\nData:{acceptedData}}}",
+                new
+                {
+                    acceptedData = "\n-X\n-Y\n-Z"
+                });
+            Assert.Equal(Expected, result);
+        }
     }
 }

--- a/src/Jeffijoe.MessageFormat.Tests/Parsing/LiteralParserTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Parsing/LiteralParserTests.cs
@@ -122,11 +122,17 @@ namespace Jeffijoe.MessageFormat.Tests.Parsing
         [InlineData(@"{
 sweet
 
-}, right?", new[] { 0, 9 }, @"sweet")]
+}, right?", new[] { 0, 9 }, @"
+sweet
+
+")]
         [InlineData(@"{
 '{sweet}'
 
-}, right?", new[] { 0, 13 }, @"'{sweet}'")]
+}, right?", new[] { 0, 13 }, @"
+'{sweet}'
+
+")]
         public void ParseLiterals_position_and_inner_text(string source, int[] position, string expectedInnerText)
         {
             var sb = new StringBuilder(source);

--- a/src/Jeffijoe.MessageFormat/Jeffijoe.MessageFormat.csproj
+++ b/src/Jeffijoe.MessageFormat/Jeffijoe.MessageFormat.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="6.0.1" />
-    <PackageReference Include="MinVer" Version="2.5.0">
+    <PackageReference Include="MinVer" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Jeffijoe.MessageFormat/Parsing/LiteralParser.cs
+++ b/src/Jeffijoe.MessageFormat/Parsing/LiteralParser.cs
@@ -52,19 +52,22 @@ namespace Jeffijoe.MessageFormat.Parsing
                 for (var i = 0; i < sb.Length; i++)
                 {
                     var c = sb[i];
-                    if (c == Lf)
-                    {
-                        lineNumber++;
-                        columnNumber = 0;
-                        continue;
-                    }
-
+                    
                     if (c == Cr)
                     {
                         continue;
                     }
-
-                    columnNumber++;
+                    
+                    if (c == Lf)
+                    {
+                        lineNumber++;
+                        columnNumber = 0;
+                        
+                    }
+                    else
+                    {
+                        columnNumber++;    
+                    }
 
                     if (c == EscapingChar)
                     {

--- a/src/Jeffijoe.MessageFormat/Parsing/PatternParser.cs
+++ b/src/Jeffijoe.MessageFormat/Parsing/PatternParser.cs
@@ -3,7 +3,9 @@
 // Author: Jeff Hansen <jeff@jeffijoe.com>
 // Copyright (C) Jeff Hansen 2014. All rights reserved.
 
+#if NET5_0_OR_GREATER
 using System;
+#endif
 using System.Linq;
 using System.Text;
 using Jeffijoe.MessageFormat.Formatting;


### PR DESCRIPTION
This was originally intentional, but apparently MessageFormat.js doesn't do this so I removed it.

Fixes #34