### PR TITLE
Fix source generator not working prperly

### DIFF
--- a/src/Jeffijoe.MessageFormat.MetadataGenerator/Jeffijoe.MessageFormat.MetadataGenerator.csproj
+++ b/src/Jeffijoe.MessageFormat.MetadataGenerator/Jeffijoe.MessageFormat.MetadataGenerator.csproj
@@ -5,7 +5,7 @@
     <AssemblyOriginatorKeyFile>../Jeffijoe.MessageFormat/MessageFormat.snk</AssemblyOriginatorKeyFile>
     <LangVersion>default</LangVersion>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>net6.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/DateFormatterTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/DateFormatterTests.cs
@@ -51,10 +51,10 @@ namespace Jeffijoe.MessageFormat.Tests.Formatting.Formatters
         {
             var formatter = new CustomValueFormatters
             {
-                Date = (CultureInfo _, object? value, string? _, out string? formatted) =>
+                Date = (CultureInfo culture, object? value, string? _, out string? formatted) =>
                 {
                     // This is just a test, you probably shouldn't be doing this in real workloads.
-                    formatted = $"{value:MMMM d 'in the year' yyyy}";
+                    formatted = ((FormattableString)$"{value:MMMM d 'in the year' yyyy}").ToString(culture);
                     return true;
                 }
             };

--- a/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/NumberFormatterTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/NumberFormatterTests.cs
@@ -30,9 +30,9 @@ namespace Jeffijoe.MessageFormat.Tests.Formatting.Formatters
         {
             var formatters = new CustomValueFormatters
             {
-                Number = (CultureInfo _, object? value, string? style, out string? formatted) =>
+                Number = (CultureInfo culture, object? value, string? style, out string? formatted) =>
                 {
-                    formatted = string.Format($"{{0:{style}}}", value);
+                    formatted = string.Format(culture, $"{{0:{style}}}", value);
                     return true;
                 }
             };

--- a/src/Jeffijoe.MessageFormat.Tests/Parsing/LiteralParserTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Parsing/LiteralParserTests.cs
@@ -4,6 +4,7 @@
 // Author: Jeff Hansen <jeff@jeffijoe.com>
 // Copyright (C) Jeff Hansen 2015. All rights reserved.
 
+using System;
 using System.Linq;
 using System.Text;
 
@@ -135,6 +136,11 @@ sweet
 ")]
         public void ParseLiterals_position_and_inner_text(string source, int[] position, string expectedInnerText)
         {
+            // It seems that depending on platform this is compiled on, the actual representation of new lines in the
+            // string literals can differ, which can make this test fail due to differences.
+            // This will normalize those changes.
+            expectedInnerText = expectedInnerText.Replace("\r\n", "\n");
+
             var sb = new StringBuilder(source);
             var subject = new LiteralParser();
             var actual = subject.ParseLiterals(sb);

--- a/src/Jeffijoe.MessageFormat/Formatting/Formatters/NumberFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/Formatters/NumberFormatter.cs
@@ -55,7 +55,7 @@ public class NumberFormatter : BaseValueFormatter, IFormatter
         value switch
         {
             decimal or float or double => string.Format(cultureInfo, "{0}", Convert.ToInt64(value)),
-            string s => decimal.TryParse(s, out var parsed) ? FormatInteger(cultureInfo, parsed) : s,
+            string s => decimal.TryParse(s, NumberStyles.Any, cultureInfo, out var parsed) ? FormatInteger(cultureInfo, parsed) : s,
             _ => string.Format(cultureInfo, "{0}", value)
         };
 }


### PR DESCRIPTION
Source generators must use NetStandard 2.0 as per documentation (see https://learn.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/source-generators-overview). Having .NET 6 and .NetStandard 2.1 included has been causing VS2022 to load the wrong version and not run the source generator properly

Simply removing them makes the library compile properly on my end.