### PR TITLE
Fix source generator not working properly

### DIFF
--- a/src/Jeffijoe.MessageFormat.MetadataGenerator/Jeffijoe.MessageFormat.MetadataGenerator.csproj
+++ b/src/Jeffijoe.MessageFormat.MetadataGenerator/Jeffijoe.MessageFormat.MetadataGenerator.csproj
@@ -5,7 +5,7 @@
     <AssemblyOriginatorKeyFile>../Jeffijoe.MessageFormat/MessageFormat.snk</AssemblyOriginatorKeyFile>
     <LangVersion>default</LangVersion>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>net6.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Source generators must use NetStandard 2.0 as per documentation (see https://learn.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/source-generators-overview). Having .NET 6 and .NetStandard 2.1 included has been causing VS2022 to load the wrong version and not run the source generator properly

Simply removing them makes the library compile properly on my end.