### PR TITLE
[API CHANGE] Add optional graceful handling of missing variables

### DIFF
--- a/src/Jeffijoe.MessageFormat.MetadataGenerator/Jeffijoe.MessageFormat.MetadataGenerator.csproj
+++ b/src/Jeffijoe.MessageFormat.MetadataGenerator/Jeffijoe.MessageFormat.MetadataGenerator.csproj
@@ -5,7 +5,7 @@
     <AssemblyOriginatorKeyFile>../Jeffijoe.MessageFormat/MessageFormat.snk</AssemblyOriginatorKeyFile>
     <LangVersion>default</LangVersion>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>net6.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/DateFormatterTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/DateFormatterTests.cs
@@ -51,10 +51,10 @@ namespace Jeffijoe.MessageFormat.Tests.Formatting.Formatters
         {
             var formatter = new CustomValueFormatters
             {
-                Date = (CultureInfo _, object? value, string? _, out string? formatted) =>
+                Date = (CultureInfo culture, object? value, string? _, out string? formatted) =>
                 {
                     // This is just a test, you probably shouldn't be doing this in real workloads.
-                    formatted = $"{value:MMMM d 'in the year' yyyy}";
+                    formatted = ((FormattableString)$"{value:MMMM d 'in the year' yyyy}").ToString(culture);
                     return true;
                 }
             };

--- a/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/NumberFormatterTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/NumberFormatterTests.cs
@@ -30,9 +30,9 @@ namespace Jeffijoe.MessageFormat.Tests.Formatting.Formatters
         {
             var formatters = new CustomValueFormatters
             {
-                Number = (CultureInfo _, object? value, string? style, out string? formatted) =>
+                Number = (CultureInfo culture, object? value, string? style, out string? formatted) =>
                 {
-                    formatted = string.Format($"{{0:{style}}}", value);
+                    formatted = string.Format(culture, $"{{0:{style}}}", value);
                     return true;
                 }
             };

--- a/src/Jeffijoe.MessageFormat.Tests/MessageFormatterFullIntegrationTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/MessageFormatterFullIntegrationTests.cs
@@ -472,6 +472,9 @@ namespace Jeffijoe.MessageFormat.Tests
             var ex = Assert.Throws<VariableNotFoundException>(() => subject.FormatMessage(Pattern, new { }));
             Assert.Equal("UnreadCount", ex.MissingVariable);
 
+            actual = subject.FormatMessage(Pattern, new { }, true);
+            Assert.Equal("You have no unread messages today.", actual);
+
             actual = subject.FormatMessage(Pattern, new { UnreadCount = 1 });
             Assert.Equal("You have just one unread message today.", actual);
             actual = subject.FormatMessage(Pattern, new { UnreadCount = 2 });

--- a/src/Jeffijoe.MessageFormat.Tests/Parsing/LiteralParserTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Parsing/LiteralParserTests.cs
@@ -4,6 +4,7 @@
 // Author: Jeff Hansen <jeff@jeffijoe.com>
 // Copyright (C) Jeff Hansen 2015. All rights reserved.
 
+using System;
 using System.Linq;
 using System.Text;
 
@@ -135,6 +136,11 @@ sweet
 ")]
         public void ParseLiterals_position_and_inner_text(string source, int[] position, string expectedInnerText)
         {
+            // It seems that depending on platform this is compiled on, the actual representation of new lines in the
+            // string literals can differ, which can make this test fail due to differences.
+            // This will normalize those changes.
+            expectedInnerText = expectedInnerText.Replace("\r\n", "\n");
+
             var sb = new StringBuilder(source);
             var subject = new LiteralParser();
             var actual = subject.ParseLiterals(sb);

--- a/src/Jeffijoe.MessageFormat.Tests/TestHelpers/FakeMessageFormatter.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/TestHelpers/FakeMessageFormatter.cs
@@ -9,7 +9,7 @@ namespace Jeffijoe.MessageFormat.Tests.TestHelpers
     {
         public CustomValueFormatter? CustomValueFormatter { get; set; }
 
-        public string FormatMessage(string pattern, IReadOnlyDictionary<string, object?> argsMap) => pattern;
+        public string FormatMessage(string pattern, IReadOnlyDictionary<string, object?> argsMap, bool ignoreMissingVariables = false) => pattern;
 
         public string FormatMessage(string pattern, object args) => pattern;
     }

--- a/src/Jeffijoe.MessageFormat/Formatting/Formatters/NumberFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/Formatters/NumberFormatter.cs
@@ -55,7 +55,7 @@ public class NumberFormatter : BaseValueFormatter, IFormatter
         value switch
         {
             decimal or float or double => string.Format(cultureInfo, "{0}", Convert.ToInt64(value)),
-            string s => decimal.TryParse(s, out var parsed) ? FormatInteger(cultureInfo, parsed) : s,
+            string s => decimal.TryParse(s, NumberStyles.Any, cultureInfo, out var parsed) ? FormatInteger(cultureInfo, parsed) : s,
             _ => string.Format(cultureInfo, "{0}", value)
         };
 }

--- a/src/Jeffijoe.MessageFormat/IMessageFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/IMessageFormatter.cs
@@ -35,7 +35,7 @@ namespace Jeffijoe.MessageFormat
         /// <returns>
         ///     The <see cref="string" />.
         /// </returns>
-        string FormatMessage(string pattern, IReadOnlyDictionary<string, object?> argsMap);
+        string FormatMessage(string pattern, IReadOnlyDictionary<string, object?> argsMap, bool ignoreMissingVariables = false);
 
         #endregion
     }

--- a/src/Jeffijoe.MessageFormat/MessageFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/MessageFormatter.cs
@@ -222,7 +222,7 @@ public class MessageFormatter : IMessageFormatter
     /// <returns>
     ///     The <see cref="string" />.
     /// </returns>
-    public string FormatMessage(string pattern, IReadOnlyDictionary<string, object?> args)
+    public string FormatMessage(string pattern, IReadOnlyDictionary<string, object?> args, bool ignoreMissingVariables = false)
     {
         /*
          * We are assuming the formatters are ordered correctly
@@ -241,7 +241,7 @@ public class MessageFormatter : IMessageFormatter
 
                 var formatter = this.Formatters.GetFormatter(request);
 
-                if (args.TryGetValue(request.Variable, out var value) == false && formatter.VariableMustExist)
+                if (args.TryGetValue(request.Variable, out var value) == false && !ignoreMissingVariables && formatter.VariableMustExist)
                 {
                     throw new VariableNotFoundException(request.Variable);
                 }

--- a/src/Jeffijoe.MessageFormat/MessageFormatterExtensions.cs
+++ b/src/Jeffijoe.MessageFormat/MessageFormatterExtensions.cs
@@ -46,8 +46,8 @@ public static class MessageFormatterExtensions
     /// <returns>
     ///     The <see cref="string" />.
     /// </returns>
-    public static string FormatMessage(this IMessageFormatter formatter, string pattern, object args)
+    public static string FormatMessage(this IMessageFormatter formatter, string pattern, object args, bool ignoreMissingVariables = false)
     {
-        return formatter.FormatMessage(pattern, args.ToDictionary());
+        return formatter.FormatMessage(pattern, args.ToDictionary(), ignoreMissingVariables);
     }
 }


### PR DESCRIPTION
In application I am working on, we have a lot of user generated content which gets updated and changed over time.

This results in some of the configured variables to get out of date. This makes the formatting functions throw lots of exceptions, which litters the logs and it's not quite desirable.

I have added an optional boolean argument, which allows the formatting to quietly ignore missing variables where desired and just assume they're default values, which is more preferable behavior for my use-case.

NOTE: This includes commits from my other two PR's, since I had to do those to be able to compile and run tests.