### PR TITLE
Fix extension parsing

### DIFF
--- a/src/.idea/.idea.MessageFormat/.idea/projectSettingsUpdater.xml
+++ b/src/.idea/.idea.MessageFormat/.idea/projectSettingsUpdater.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="RiderProjectSettingsUpdater">
+    <option name="singleClickDiffPreview" value="1" />
     <option name="vcsConfiguration" value="3" />
   </component>
 </project>

--- a/src/Jeffijoe.MessageFormat.MetadataGenerator/Plural/Parsing/AST/Condition.cs
+++ b/src/Jeffijoe.MessageFormat.MetadataGenerator/Plural/Parsing/AST/Condition.cs
@@ -1,22 +1,21 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics;
 
-namespace Jeffijoe.MessageFormat.MetadataGenerator.Plural.Parsing.AST
+namespace Jeffijoe.MessageFormat.MetadataGenerator.Plural.Parsing.AST;
+
+[DebuggerDisplay("{{RuleDescription}}")]
+public class Condition
 {
-    [DebuggerDisplay("{{RuleDescription}}")]
-    public class Condition
+    public Condition(string count, string ruleDescription, IReadOnlyList<OrCondition> orConditions)
     {
-        public Condition(string count, string ruleDescription, IReadOnlyList<OrCondition> orConditions)
-        {
-            Count = count;
-            RuleDescription = ruleDescription;
-            OrConditions = orConditions;
-        }
-
-        public string Count { get; }
-
-        public string RuleDescription { get; }
-
-        public IReadOnlyList<OrCondition> OrConditions { get; }
+        Count = count;
+        RuleDescription = ruleDescription;
+        OrConditions = orConditions;
     }
+
+    public string Count { get; }
+
+    public string RuleDescription { get; }
+
+    public IReadOnlyList<OrCondition> OrConditions { get; }
 }

--- a/src/Jeffijoe.MessageFormat.MetadataGenerator/Plural/Parsing/AST/ILeftOperand.cs
+++ b/src/Jeffijoe.MessageFormat.MetadataGenerator/Plural/Parsing/AST/ILeftOperand.cs
@@ -1,6 +1,5 @@
-﻿namespace Jeffijoe.MessageFormat.MetadataGenerator.Plural.Parsing.AST
+﻿namespace Jeffijoe.MessageFormat.MetadataGenerator.Plural.Parsing.AST;
+
+public interface ILeftOperand
 {
-    public interface ILeftOperand
-    {
-    }
 }

--- a/src/Jeffijoe.MessageFormat.MetadataGenerator/Plural/Parsing/AST/IRightOperand.cs
+++ b/src/Jeffijoe.MessageFormat.MetadataGenerator/Plural/Parsing/AST/IRightOperand.cs
@@ -1,6 +1,5 @@
-﻿namespace Jeffijoe.MessageFormat.MetadataGenerator.Plural.Parsing.AST
+﻿namespace Jeffijoe.MessageFormat.MetadataGenerator.Plural.Parsing.AST;
+
+public interface IRightOperand
 {
-    public interface IRightOperand
-    {
-    }
 }

--- a/src/Jeffijoe.MessageFormat.MetadataGenerator/Plural/Parsing/AST/LeftOperand.cs
+++ b/src/Jeffijoe.MessageFormat.MetadataGenerator/Plural/Parsing/AST/LeftOperand.cs
@@ -1,27 +1,26 @@
-﻿namespace Jeffijoe.MessageFormat.MetadataGenerator.Plural.Parsing.AST
+﻿namespace Jeffijoe.MessageFormat.MetadataGenerator.Plural.Parsing.AST;
+
+public class ModuloOperand : ILeftOperand
 {
-    public class ModuloOperand : ILeftOperand
+    public ModuloOperand(OperandSymbol operandSymbol, int modValue)
     {
-        public ModuloOperand(OperandSymbol operandSymbol, int modValue)
-        {
-            Operand = operandSymbol;
-            ModValue = modValue;
-        }
+        Operand = operandSymbol;
+        ModValue = modValue;
+    }
 
-        public OperandSymbol Operand { get; }
-        public int ModValue { get; }
+    public OperandSymbol Operand { get; }
+    public int ModValue { get; }
 
-        public override bool Equals(object? obj)
-        {
-            if (obj is ModuloOperand op)
-                return op.Operand == Operand && op.ModValue == ModValue;
+    public override bool Equals(object? obj)
+    {
+        if (obj is ModuloOperand op)
+            return op.Operand == Operand && op.ModValue == ModValue;
 
-            return this == obj;
-        }
+        return this == obj;
+    }
 
-        public override int GetHashCode()
-        {
-            return Operand.GetHashCode() + ModValue.GetHashCode();
-        }
+    public override int GetHashCode()
+    {
+        return Operand.GetHashCode() + ModValue.GetHashCode();
     }
 }

--- a/src/Jeffijoe.MessageFormat.MetadataGenerator/Plural/Parsing/AST/NumberOperand.cs
+++ b/src/Jeffijoe.MessageFormat.MetadataGenerator/Plural/Parsing/AST/NumberOperand.cs
@@ -1,25 +1,24 @@
-﻿namespace Jeffijoe.MessageFormat.MetadataGenerator.Plural.Parsing.AST
+﻿namespace Jeffijoe.MessageFormat.MetadataGenerator.Plural.Parsing.AST;
+
+public class NumberOperand : IRightOperand
 {
-    public class NumberOperand : IRightOperand
+    public NumberOperand(int number)
     {
-        public NumberOperand(int number)
-        {
-            Number = number;
-        }
+        Number = number;
+    }
 
-        public int Number { get; }
+    public int Number { get; }
 
-        public override bool Equals(object? obj)
-        {
-            if (obj is NumberOperand n)
-                return n.Number == Number;
+    public override bool Equals(object? obj)
+    {
+        if (obj is NumberOperand n)
+            return n.Number == Number;
 
-            return this == obj;
-        }
+        return this == obj;
+    }
 
-        public override int GetHashCode()
-        {
-            return Number.GetHashCode();
-        }
+    public override int GetHashCode()
+    {
+        return Number.GetHashCode();
     }
 }

--- a/src/Jeffijoe.MessageFormat.MetadataGenerator/Plural/Parsing/AST/OperandSymbol.cs
+++ b/src/Jeffijoe.MessageFormat.MetadataGenerator/Plural/Parsing/AST/OperandSymbol.cs
@@ -1,45 +1,44 @@
-﻿namespace Jeffijoe.MessageFormat.MetadataGenerator.Plural.Parsing.AST
+﻿namespace Jeffijoe.MessageFormat.MetadataGenerator.Plural.Parsing.AST;
+
+public enum OperandSymbol
 {
-    public enum OperandSymbol
-    {
-        /// <summary>
-        /// n - absolute value of the source number.
-        /// </summary>
-        AbsoluteValue,
+    /// <summary>
+    /// n - absolute value of the source number.
+    /// </summary>
+    AbsoluteValue,
 
-        /// <summary>
-        /// i - integer digits of n.
-        /// </summary>
-        IntegerDigits,
+    /// <summary>
+    /// i - integer digits of n.
+    /// </summary>
+    IntegerDigits,
 
-        /// <summary>
-        /// v - number of visible fraction digits in n, with trailing zeros.
-        /// </summary>
-        VisibleFractionDigitNumber,
+    /// <summary>
+    /// v - number of visible fraction digits in n, with trailing zeros.
+    /// </summary>
+    VisibleFractionDigitNumber,
 
-        /// <summary>
-        /// w - number of visible fraction digits in n, without trailing zeros.
-        /// </summary>
-        VisibleFractionDigitNumberWithoutTrailingZeroes,
+    /// <summary>
+    /// w - number of visible fraction digits in n, without trailing zeros.
+    /// </summary>
+    VisibleFractionDigitNumberWithoutTrailingZeroes,
 
-        /// <summary>
-        /// f - number of visible fraction digits in n, with trailing zeros.
-        /// </summary>
-        VisibleFractionDigits,
+    /// <summary>
+    /// f - number of visible fraction digits in n, with trailing zeros.
+    /// </summary>
+    VisibleFractionDigits,
 
-        /// <summary>
-        /// t - visible fraction digits in n, without trailing zeros.
-        /// </summary>
-        VisibleFractionDigitsWithoutTrailingZeroes,
+    /// <summary>
+    /// t - visible fraction digits in n, without trailing zeros.
+    /// </summary>
+    VisibleFractionDigitsWithoutTrailingZeroes,
 
-        /// <summary>
-        /// c - compact decimal exponent value: exponent of the power of 10 used in compact decimal formatting.
-        /// </summary>
-        ExponentC,
+    /// <summary>
+    /// c - compact decimal exponent value: exponent of the power of 10 used in compact decimal formatting.
+    /// </summary>
+    ExponentC,
 
-        /// <summary>
-        /// e - currently, synonym for ‘c’. however, may be redefined in the future.
-        /// </summary>
-        ExponentE,
-    }
+    /// <summary>
+    /// e - currently, synonym for ‘c’. however, may be redefined in the future.
+    /// </summary>
+    ExponentE,
 }

--- a/src/Jeffijoe.MessageFormat.MetadataGenerator/Plural/Parsing/AST/Operation.cs
+++ b/src/Jeffijoe.MessageFormat.MetadataGenerator/Plural/Parsing/AST/Operation.cs
@@ -1,20 +1,19 @@
 ﻿using System.Collections.Generic;
 
-namespace Jeffijoe.MessageFormat.MetadataGenerator.Plural.Parsing.AST
+namespace Jeffijoe.MessageFormat.MetadataGenerator.Plural.Parsing.AST;
+
+public class Operation
 {
-    public class Operation
+    public Operation(ILeftOperand operandLeft, Relation relation, IReadOnlyList<IRightOperand> operandRight)
     {
-        public Operation(ILeftOperand operandLeft, Relation relation, IReadOnlyList<IRightOperand> operandRight)
-        {
-            OperandLeft = operandLeft;
-            Relation = relation;
-            OperandRight = operandRight;
-        }
-
-        public ILeftOperand OperandLeft { get; }
-
-        public Relation Relation { get; }
-
-        public IReadOnlyList<IRightOperand> OperandRight { get; }
+        OperandLeft = operandLeft;
+        Relation = relation;
+        OperandRight = operandRight;
     }
+
+    public ILeftOperand OperandLeft { get; }
+
+    public Relation Relation { get; }
+
+    public IReadOnlyList<IRightOperand> OperandRight { get; }
 }

--- a/src/Jeffijoe.MessageFormat.MetadataGenerator/Plural/Parsing/AST/OrCondition.cs
+++ b/src/Jeffijoe.MessageFormat.MetadataGenerator/Plural/Parsing/AST/OrCondition.cs
@@ -1,14 +1,13 @@
 ﻿using System.Collections.Generic;
 
-namespace Jeffijoe.MessageFormat.MetadataGenerator.Plural.Parsing.AST
-{
-    public class OrCondition
-    {
-        public OrCondition(IReadOnlyList<Operation> andConditions)
-        {
-            AndConditions = andConditions;
-        }
+namespace Jeffijoe.MessageFormat.MetadataGenerator.Plural.Parsing.AST;
 
-        public IReadOnlyList<Operation> AndConditions { get; }
+public class OrCondition
+{
+    public OrCondition(IReadOnlyList<Operation> andConditions)
+    {
+        AndConditions = andConditions;
     }
+
+    public IReadOnlyList<Operation> AndConditions { get; }
 }

--- a/src/Jeffijoe.MessageFormat.MetadataGenerator/Plural/Parsing/AST/PluralRule.cs
+++ b/src/Jeffijoe.MessageFormat.MetadataGenerator/Plural/Parsing/AST/PluralRule.cs
@@ -1,17 +1,16 @@
 ﻿using System.Collections.Generic;
 
-namespace Jeffijoe.MessageFormat.MetadataGenerator.Plural.Parsing.AST
+namespace Jeffijoe.MessageFormat.MetadataGenerator.Plural.Parsing.AST;
+
+public class PluralRule
 {
-    public class PluralRule
+    public PluralRule(string[] locales, IReadOnlyList<Condition> conditions)
     {
-        public PluralRule(string[] locales, IReadOnlyList<Condition> conditions)
-        {
-            Locales = locales;
-            Conditions = conditions;
-        }
-
-        public string[] Locales { get; }
-
-        public IReadOnlyList<Condition> Conditions { get; }
+        Locales = locales;
+        Conditions = conditions;
     }
+
+    public string[] Locales { get; }
+
+    public IReadOnlyList<Condition> Conditions { get; }
 }

--- a/src/Jeffijoe.MessageFormat.MetadataGenerator/Plural/Parsing/AST/RangeOperand.cs
+++ b/src/Jeffijoe.MessageFormat.MetadataGenerator/Plural/Parsing/AST/RangeOperand.cs
@@ -1,27 +1,26 @@
-﻿namespace Jeffijoe.MessageFormat.MetadataGenerator.Plural.Parsing.AST
+﻿namespace Jeffijoe.MessageFormat.MetadataGenerator.Plural.Parsing.AST;
+
+public class RangeOperand : IRightOperand
 {
-    public class RangeOperand : IRightOperand
+    public RangeOperand(int start, int end)
     {
-        public RangeOperand(int start, int end)
-        {
-            Start = start;
-            End = end;
-        }
+        Start = start;
+        End = end;
+    }
 
-        public int Start { get; }
-        public int End { get; }
+    public int Start { get; }
+    public int End { get; }
 
-        public override bool Equals(object? obj)
-        {
-            if (obj is RangeOperand n)
-                return n.Start == Start && n.End == End;
+    public override bool Equals(object? obj)
+    {
+        if (obj is RangeOperand n)
+            return n.Start == Start && n.End == End;
 
-            return this == obj;
-        }
+        return this == obj;
+    }
 
-        public override int GetHashCode()
-        {
-            return Start.GetHashCode() + End.GetHashCode();
-        }
+    public override int GetHashCode()
+    {
+        return Start.GetHashCode() + End.GetHashCode();
     }
 }

--- a/src/Jeffijoe.MessageFormat.MetadataGenerator/Plural/Parsing/AST/Relation.cs
+++ b/src/Jeffijoe.MessageFormat.MetadataGenerator/Plural/Parsing/AST/Relation.cs
@@ -1,7 +1,6 @@
-﻿namespace Jeffijoe.MessageFormat.MetadataGenerator.Plural.Parsing.AST
+﻿namespace Jeffijoe.MessageFormat.MetadataGenerator.Plural.Parsing.AST;
+
+public enum Relation
 {
-    public enum Relation
-    {
-        Equals, NotEquals
-    }
+    Equals, NotEquals
 }

--- a/src/Jeffijoe.MessageFormat.MetadataGenerator/Plural/Parsing/AST/VariableOperand.cs
+++ b/src/Jeffijoe.MessageFormat.MetadataGenerator/Plural/Parsing/AST/VariableOperand.cs
@@ -1,25 +1,24 @@
-﻿namespace Jeffijoe.MessageFormat.MetadataGenerator.Plural.Parsing.AST
+﻿namespace Jeffijoe.MessageFormat.MetadataGenerator.Plural.Parsing.AST;
+
+public class VariableOperand : ILeftOperand
 {
-    public class VariableOperand : ILeftOperand
+    public VariableOperand(OperandSymbol operand)
     {
-        public VariableOperand(OperandSymbol operand)
-        {
-            Operand = operand;
-        }
+        Operand = operand;
+    }
 
-        public OperandSymbol Operand { get; }
+    public OperandSymbol Operand { get; }
 
-        public override bool Equals(object? obj)
-        {
-            if (obj is VariableOperand op)
-                return op.Operand == Operand;
+    public override bool Equals(object? obj)
+    {
+        if (obj is VariableOperand op)
+            return op.Operand == Operand;
 
-            return this == obj;
-        }
+        return this == obj;
+    }
 
-        public override int GetHashCode()
-        {
-            return Operand.GetHashCode();
-        }
+    public override int GetHashCode()
+    {
+        return Operand.GetHashCode();
     }
 }

--- a/src/Jeffijoe.MessageFormat.MetadataGenerator/Plural/Parsing/InvalidCharacterException.cs
+++ b/src/Jeffijoe.MessageFormat.MetadataGenerator/Plural/Parsing/InvalidCharacterException.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 
-namespace Jeffijoe.MessageFormat.MetadataGenerator.Plural.Parsing
+namespace Jeffijoe.MessageFormat.MetadataGenerator.Plural.Parsing;
+
+public class InvalidCharacterException : FormatException
 {
-    public class InvalidCharacterException : FormatException
+    public InvalidCharacterException(char character) : base($"Invalid format, do not recognise character '{character}'")
     {
-        public InvalidCharacterException(char character) : base($"Invalid format, do not recognise character '{character}'")
-        {
-        }
     }
 }

--- a/src/Jeffijoe.MessageFormat.MetadataGenerator/Plural/Parsing/PluralParser.cs
+++ b/src/Jeffijoe.MessageFormat.MetadataGenerator/Plural/Parsing/PluralParser.cs
@@ -3,74 +3,73 @@ using System.Xml;
 using System.Linq;
 using Jeffijoe.MessageFormat.MetadataGenerator.Plural.Parsing.AST;
 
-namespace Jeffijoe.MessageFormat.MetadataGenerator.Plural.Parsing
+namespace Jeffijoe.MessageFormat.MetadataGenerator.Plural.Parsing;
+
+public class PluralParser
 {
-    public class PluralParser
+    private readonly XmlDocument _rulesDocument;
+    private readonly HashSet<string> _excludedLocales;
+
+    public PluralParser(XmlDocument rulesDocument, string[] excludedLocales)
     {
-        private readonly XmlDocument _rulesDocument;
-        private readonly HashSet<string> _excludedLocales;
+        _rulesDocument = rulesDocument;
+        _excludedLocales = new HashSet<string>(excludedLocales);
+    }
 
-        public PluralParser(XmlDocument rulesDocument, string[] excludedLocales)
-        {
-            _rulesDocument = rulesDocument;
-            _excludedLocales = new HashSet<string>(excludedLocales);
-        }
-
-        public IEnumerable<PluralRule> Parse()
-        {
-            var root = _rulesDocument.DocumentElement!;
+    public IEnumerable<PluralRule> Parse()
+    {
+        var root = _rulesDocument.DocumentElement!;
             
-            foreach(XmlNode dataElement in root.ChildNodes)
+        foreach(XmlNode dataElement in root.ChildNodes)
+        {
+            if (dataElement.Name != "plurals")
             {
-                if (dataElement.Name != "plurals")
-                {
-                    continue;
-                }
+                continue;
+            }
                 
-                foreach (XmlNode rule in dataElement.ChildNodes)
+            foreach (XmlNode rule in dataElement.ChildNodes)
+            {
+                if(rule.Name == "pluralRules")
                 {
-                    if(rule.Name == "pluralRules")
+                    var parsed = ParseSingleRule(rule);
+                    if (parsed != null)
                     {
-                        var parsed = ParseSingleRule(rule);
-                        if (parsed != null)
-                        {
-                            yield return parsed;
-                        }
+                        yield return parsed;
                     }
                 }
             }
         }
+    }
 
-        private PluralRule? ParseSingleRule(XmlNode rule)
+    private PluralRule? ParseSingleRule(XmlNode rule)
+    {
+        var locales = rule.Attributes!["locales"]!.Value.Split(' ');
+
+        if (locales.All(l => _excludedLocales.Contains(l)))
         {
-            var locales = rule.Attributes!["locales"]!.Value.Split(' ');
-
-            if (locales.All(l => _excludedLocales.Contains(l)))
-            {
-                return null;
-            }
-
-            var conditions = new List<Condition>();
-            foreach (XmlNode condition in rule.ChildNodes)
-            {
-                if (condition.Name == "pluralRule")
-                {
-                    var count = condition.Attributes!["count"]!.Value;
-
-                    // Ignore other, because other is basically everything else except for the conditions present
-                    if (count == "other")
-                        continue;
-
-                    var ruleContent = condition.InnerText;
-
-                    var ruleParser = new RuleParser(ruleContent);
-                    var orConditions = ruleParser.ParseRuleContent();
-
-                    conditions.Add(new Condition(count, ruleContent, orConditions));
-                }
-            }
-
-            return new PluralRule(locales, conditions);
+            return null;
         }
+
+        var conditions = new List<Condition>();
+        foreach (XmlNode condition in rule.ChildNodes)
+        {
+            if (condition.Name == "pluralRule")
+            {
+                var count = condition.Attributes!["count"]!.Value;
+
+                // Ignore other, because other is basically everything else except for the conditions present
+                if (count == "other")
+                    continue;
+
+                var ruleContent = condition.InnerText;
+
+                var ruleParser = new RuleParser(ruleContent);
+                var orConditions = ruleParser.ParseRuleContent();
+
+                conditions.Add(new Condition(count, ruleContent, orConditions));
+            }
+        }
+
+        return new PluralRule(locales, conditions);
     }
 }

--- a/src/Jeffijoe.MessageFormat.MetadataGenerator/Plural/Parsing/RuleParser.cs
+++ b/src/Jeffijoe.MessageFormat.MetadataGenerator/Plural/Parsing/RuleParser.cs
@@ -2,253 +2,252 @@
 using System.Collections.Generic;
 using Jeffijoe.MessageFormat.MetadataGenerator.Plural.Parsing.AST;
 
-namespace Jeffijoe.MessageFormat.MetadataGenerator.Plural.Parsing
+namespace Jeffijoe.MessageFormat.MetadataGenerator.Plural.Parsing;
+
+public class RuleParser
 {
-    public class RuleParser
+    private readonly string _ruleText;
+    private int _position;
+
+    public RuleParser(string ruleText)
     {
-        private readonly string _ruleText;
-        private int _position;
+        _ruleText = ruleText;
+    }
 
-        public RuleParser(string ruleText)
+    public IReadOnlyList<OrCondition> ParseRuleContent()
+    {
+        var conditions = new List<OrCondition>();
+
+        while (!IsEnd)
         {
-            _ruleText = ruleText;
-        }
-
-        public IReadOnlyList<OrCondition> ParseRuleContent()
-        {
-            var conditions = new List<OrCondition>();
-
-            while (!IsEnd)
+            if (PeekCurrentChar == '@')
             {
-                if (PeekCurrentChar == '@')
-                {
-                    return conditions;
-                }
-
-                var condition = ParseOrCondition();
-                conditions.Add(condition);
-
-                AdvanceWhitespace();
-                
-                if (IsEnd)
-                {
-                    return conditions;
-                }
-
-                var character = ConsumeChar();
-
-                // This is where the samples start, we don't care about any of those.
-                if (character == '@')
-                {
-                    return conditions;
-                }
-
-                // We expect the next token to be "or"
-                var characterNext = ConsumeChar();
-                if (character == 'o' && characterNext == 'r')
-                {
-                    continue;
-                }
-
-                throw new InvalidCharacterException(character);
+                return conditions;
             }
 
-            return conditions;
+            var condition = ParseOrCondition();
+            conditions.Add(condition);
+
+            AdvanceWhitespace();
+                
+            if (IsEnd)
+            {
+                return conditions;
+            }
+
+            var character = ConsumeChar();
+
+            // This is where the samples start, we don't care about any of those.
+            if (character == '@')
+            {
+                return conditions;
+            }
+
+            // We expect the next token to be "or"
+            var characterNext = ConsumeChar();
+            if (character == 'o' && characterNext == 'r')
+            {
+                continue;
+            }
+
+            throw new InvalidCharacterException(character);
         }
 
-        private static readonly char NullCharacter = '\0';
+        return conditions;
+    }
 
-        private char PeekCurrentChar =>
-            _position < _ruleText.Length
+    private static readonly char NullCharacter = '\0';
+
+    private char PeekCurrentChar =>
+        _position < _ruleText.Length
             ? _ruleText[_position]
             : NullCharacter;
 
-        private char PeekNextChar =>
-            _position + 1 < _ruleText.Length
+    private char PeekNextChar =>
+        _position + 1 < _ruleText.Length
             ? _ruleText[_position + 1]
             : NullCharacter;
 
-        private char PeekAt(int delta)
-        {
-            if (_position + delta >= _ruleText.Length)
-                return NullCharacter;
+    private char PeekAt(int delta)
+    {
+        if (_position + delta >= _ruleText.Length)
+            return NullCharacter;
 
-            return _ruleText[_position + delta];
+        return _ruleText[_position + delta];
+    }
+
+    private ReadOnlySpan<char> ConsumeCharacters(int count)
+    {
+        if (_position + count > _ruleText.Length)
+        {
+            var characters = _ruleText.AsSpan(_position, _ruleText.Length - _position);
+            _position = _ruleText.Length;
+            return characters;
         }
-
-        private ReadOnlySpan<char> ConsumeCharacters(int count)
+        else
         {
-            if (_position + count > _ruleText.Length)
-            {
-                var characters = _ruleText.AsSpan(_position, _ruleText.Length - _position);
-                _position = _ruleText.Length;
-                return characters;
-            }
-            else
-            {
-                var characters = _ruleText.AsSpan(_position, count);
-                _position += count;
-                return characters;
-            }
+            var characters = _ruleText.AsSpan(_position, count);
+            _position += count;
+            return characters;
         }
+    }
 
-        private char ConsumeChar()
+    private char ConsumeChar()
+    {
+        if (IsEnd)
+            return NullCharacter;
+
+        var character = PeekCurrentChar;
+        _position++;
+        return character;
+    }
+
+    private bool IsEnd => _position >= _ruleText.Length;
+
+    private void AdvanceWhitespace()
+    {
+        while (!IsEnd && char.IsWhiteSpace(PeekCurrentChar))
         {
-            if (IsEnd)
-                return NullCharacter;
-
-            var character = PeekCurrentChar;
-            _position++;
-            return character;
+            ConsumeChar();
         }
+    }
 
-        private bool IsEnd => _position >= _ruleText.Length;
-
-        private void AdvanceWhitespace()
+    private ILeftOperand ParseLeftOperand()
+    {
+        var operandSymbol = ConsumeChar() switch
         {
-            while (!IsEnd && char.IsWhiteSpace(PeekCurrentChar))
-            {
-                ConsumeChar();
-            }
-        }
+            'n' => OperandSymbol.AbsoluteValue,
+            'i' => OperandSymbol.IntegerDigits,
+            'v' => OperandSymbol.VisibleFractionDigitNumber,
+            'w' => OperandSymbol.VisibleFractionDigitNumberWithoutTrailingZeroes,
+            'f' => OperandSymbol.VisibleFractionDigits,
+            't' => OperandSymbol.VisibleFractionDigitsWithoutTrailingZeroes,
+            'c' => OperandSymbol.ExponentC,
+            'e' => OperandSymbol.ExponentE,
+            var otherCharacter => throw new InvalidCharacterException(otherCharacter)
+        };
 
-        private ILeftOperand ParseLeftOperand()
+        AdvanceWhitespace();
+
+        if(PeekCurrentChar == '%')
         {
-            var operandSymbol = ConsumeChar() switch
-            {
-                'n' => OperandSymbol.AbsoluteValue,
-                'i' => OperandSymbol.IntegerDigits,
-                'v' => OperandSymbol.VisibleFractionDigitNumber,
-                'w' => OperandSymbol.VisibleFractionDigitNumberWithoutTrailingZeroes,
-                'f' => OperandSymbol.VisibleFractionDigits,
-                't' => OperandSymbol.VisibleFractionDigitsWithoutTrailingZeroes,
-                'c' => OperandSymbol.ExponentC,
-                'e' => OperandSymbol.ExponentE,
-                var otherCharacter => throw new InvalidCharacterException(otherCharacter)
-            };
-
+            ConsumeChar();
             AdvanceWhitespace();
 
-            if(PeekCurrentChar == '%')
-            {
-                ConsumeChar();
-                AdvanceWhitespace();
+            var number = ParseNumber();
 
-                var number = ParseNumber();
-
-                return new ModuloOperand(operandSymbol, number);
-            }
-
-            return new VariableOperand(operandSymbol);
+            return new ModuloOperand(operandSymbol, number);
         }
 
-        private Operation ParseAndCondition()
-        {
-            AdvanceWhitespace();
-            var leftOperand = ParseLeftOperand();
+        return new VariableOperand(operandSymbol);
+    }
+
+    private Operation ParseAndCondition()
+    {
+        AdvanceWhitespace();
+        var leftOperand = ParseLeftOperand();
             
 
-            AdvanceWhitespace();
-            var firstRelationCharacter = ConsumeChar();
-            var relation = firstRelationCharacter switch
-            {
-                '=' => Relation.Equals,
-                '!' when ConsumeChar() == '='
-                    => Relation.NotEquals,
-                var otherCharacter => throw new InvalidCharacterException(otherCharacter)
-            };
-
-            AdvanceWhitespace();
-            var rightOperand = ParseRightOperand();
-            return new Operation(leftOperand, relation, rightOperand);
-        }
-
-        private IReadOnlyList<IRightOperand> ParseRightOperand()
+        AdvanceWhitespace();
+        var firstRelationCharacter = ConsumeChar();
+        var relation = firstRelationCharacter switch
         {
-            var numbers = new List<IRightOperand>();
+            '=' => Relation.Equals,
+            '!' when ConsumeChar() == '='
+                => Relation.NotEquals,
+            var otherCharacter => throw new InvalidCharacterException(otherCharacter)
+        };
 
-            while (!IsEnd) 
+        AdvanceWhitespace();
+        var rightOperand = ParseRightOperand();
+        return new Operation(leftOperand, relation, rightOperand);
+    }
+
+    private IReadOnlyList<IRightOperand> ParseRightOperand()
+    {
+        var numbers = new List<IRightOperand>();
+
+        while (!IsEnd) 
+        {
+            AdvanceWhitespace();
+
+            var number = ParseNumber();
+            if (PeekCurrentChar == '.')
             {
-                AdvanceWhitespace();
-
-                var number = ParseNumber();
-                if (PeekCurrentChar == '.')
+                if (PeekNextChar == '.')
                 {
-                    if (PeekNextChar == '.')
-                    {
-                        ConsumeCharacters(2);
-                        AdvanceWhitespace();
+                    ConsumeCharacters(2);
+                    AdvanceWhitespace();
 
-                        var nextNumber = ParseNumber();
-                        numbers.Add(new RangeOperand(number, nextNumber));
-                    }
-                    else
-                    {
-                        throw new InvalidCharacterException(PeekCurrentChar);
-                    }
+                    var nextNumber = ParseNumber();
+                    numbers.Add(new RangeOperand(number, nextNumber));
                 }
                 else
                 {
-                    numbers.Add(new NumberOperand(number));
+                    throw new InvalidCharacterException(PeekCurrentChar);
                 }
+            }
+            else
+            {
+                numbers.Add(new NumberOperand(number));
+            }
 
-                if (PeekCurrentChar == ',')
+            if (PeekCurrentChar == ',')
+            {
+                ConsumeChar();
+                AdvanceWhitespace();
+                continue;
+            }
+
+            break;
+        }
+
+        return numbers;
+    }
+
+    private OrCondition ParseOrCondition()
+    {
+        var andWordSpan = "and".AsSpan();
+
+        var andConditions = new List<Operation>();
+        while (!IsEnd)
+        {
+            var operation = ParseAndCondition();
+            andConditions.Add(operation);
+
+            AdvanceWhitespace();
+
+            if (PeekCurrentChar == 'a')
+            {
+                var andWord = ConsumeCharacters(3);
+
+
+                if (andWord.SequenceEqual(andWordSpan))
                 {
-                    ConsumeChar();
-                    AdvanceWhitespace();
                     continue;
                 }
 
-                break;
-            }
-
-            return numbers;
-        }
-
-        private OrCondition ParseOrCondition()
-        {
-            var andWordSpan = "and".AsSpan();
-
-            var andConditions = new List<Operation>();
-            while (!IsEnd)
-            {
-                var operation = ParseAndCondition();
-                andConditions.Add(operation);
-
-                AdvanceWhitespace();
-
-                if (PeekCurrentChar == 'a')
-                {
-                    var andWord = ConsumeCharacters(3);
-
-
-                    if (andWord.SequenceEqual(andWordSpan))
-                    {
-                        continue;
-                    }
-
-                    throw new InvalidCharacterException(andWord[0]);
-                }
-
-                return new OrCondition(andConditions);
+                throw new InvalidCharacterException(andWord[0]);
             }
 
             return new OrCondition(andConditions);
         }
 
-        private int ParseNumber()
+        return new OrCondition(andConditions);
+    }
+
+    private int ParseNumber()
+    {
+        int numbersCount = 0;
+        while (!IsEnd && char.IsNumber(PeekAt(numbersCount)))
         {
-            int numbersCount = 0;
-            while (!IsEnd && char.IsNumber(PeekAt(numbersCount)))
-            {
-                numbersCount++;
-            }
-
-            var numberSpan = ConsumeCharacters(numbersCount);
-            
-            var number = int.Parse(numberSpan.ToString());
-
-            return number;
+            numbersCount++;
         }
+
+        var numberSpan = ConsumeCharacters(numbersCount);
+            
+        var number = int.Parse(numberSpan.ToString());
+
+        return number;
     }
 }

--- a/src/Jeffijoe.MessageFormat.MetadataGenerator/Plural/PluralLanguagesGenerator.cs
+++ b/src/Jeffijoe.MessageFormat.MetadataGenerator/Plural/PluralLanguagesGenerator.cs
@@ -10,51 +10,50 @@ using System.IO;
 using System.Linq;
 using System.Xml;
 
-namespace Jeffijoe.MessageFormat.MetadataGenerator.Plural
+namespace Jeffijoe.MessageFormat.MetadataGenerator.Plural;
+
+[Generator]
+public class PluralLanguagesGenerator : ISourceGenerator
 {
-    [Generator]
-    public class PluralLanguagesGenerator : ISourceGenerator
+    public void Execute(GeneratorExecutionContext context)
     {
-        public void Execute(GeneratorExecutionContext context)
-        {
-            var excludeLocales = ReadExcludeLocales(context);
-            var rules = GetRules(excludeLocales);
-            var generator = new PluralRulesMetadataGenerator(rules);
-            var sourceCode = generator.GenerateClass();
+        var excludeLocales = ReadExcludeLocales(context);
+        var rules = GetRules(excludeLocales);
+        var generator = new PluralRulesMetadataGenerator(rules);
+        var sourceCode = generator.GenerateClass();
 
-            context.AddSource("PluralRulesMetadata.Generated.cs", sourceCode);
+        context.AddSource("PluralRulesMetadata.Generated.cs", sourceCode);
+    }
+
+    private string[] ReadExcludeLocales(GeneratorExecutionContext context)
+    {
+        if(context.AnalyzerConfigOptions.GlobalOptions.TryGetValue($"build_property.PluralLanguagesMetadataExcludeLocales", out var value))
+        {
+            var locales = value.Trim().Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            return locales;
         }
 
-        private string[] ReadExcludeLocales(GeneratorExecutionContext context)
-        {
-            if(context.AnalyzerConfigOptions.GlobalOptions.TryGetValue($"build_property.PluralLanguagesMetadataExcludeLocales", out var value))
-            {
-                var locales = value.Trim().Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-                return locales;
-            }
+        return Array.Empty<string>();
+    }
 
-            return Array.Empty<string>();
-        }
+    private IReadOnlyList<PluralRule> GetRules(string[] excludedLocales)
+    {
+        using var rulesStream = GetRulesContentStream();
+        var xml = new XmlDocument();
+        xml.Load(rulesStream);
 
-        private IReadOnlyList<PluralRule> GetRules(string[] excludedLocales)
-        {
-            using var rulesStream = GetRulesContentStream();
-            var xml = new XmlDocument();
-            xml.Load(rulesStream);
-
-            var parser = new PluralParser(xml, excludedLocales);
-            return parser.Parse().ToArray();
-        }
+        var parser = new PluralParser(xml, excludedLocales);
+        return parser.Parse().ToArray();
+    }
 
 
-        private Stream GetRulesContentStream()
-        {
-            return typeof(PluralLanguagesGenerator).Assembly.GetManifestResourceStream("Jeffijoe.MessageFormat.MetadataGenerator.data.plurals.xml")!;
-        }
+    private Stream GetRulesContentStream()
+    {
+        return typeof(PluralLanguagesGenerator).Assembly.GetManifestResourceStream("Jeffijoe.MessageFormat.MetadataGenerator.data.plurals.xml")!;
+    }
 
-        public void Initialize(GeneratorInitializationContext context)
-        {
+    public void Initialize(GeneratorInitializationContext context)
+    {
             
-        }
     }
 }

--- a/src/Jeffijoe.MessageFormat.MetadataGenerator/Plural/SourceGeneration/PluralRulesMetadataGenerator.cs
+++ b/src/Jeffijoe.MessageFormat.MetadataGenerator/Plural/SourceGeneration/PluralRulesMetadataGenerator.cs
@@ -2,100 +2,99 @@
 using System.Text;
 using Jeffijoe.MessageFormat.MetadataGenerator.Plural.Parsing.AST;
 
-namespace Jeffijoe.MessageFormat.MetadataGenerator.Plural.SourceGeneration
+namespace Jeffijoe.MessageFormat.MetadataGenerator.Plural.SourceGeneration;
+
+public class PluralRulesMetadataGenerator
 {
-    public class PluralRulesMetadataGenerator
+    private readonly IReadOnlyList<PluralRule> _rules;
+    private readonly StringBuilder _sb;
+    private int _indent;
+
+    public PluralRulesMetadataGenerator(IReadOnlyList<PluralRule> rules)
     {
-        private readonly IReadOnlyList<PluralRule> _rules;
-        private readonly StringBuilder _sb;
-        private int _indent;
+        _rules = rules;
+        _sb = new StringBuilder();
+    }
 
-        public PluralRulesMetadataGenerator(IReadOnlyList<PluralRule> rules)
+    public string GenerateClass()
+    {
+        WriteLine("using System;");
+        WriteLine("using System.Collections.Generic;");
+
+        WriteLine("namespace Jeffijoe.MessageFormat.Formatting.Formatters");
+        WriteLine("{");
+        AddIndent();
+
+        WriteLine("internal static partial class PluralRulesMetadata");
+        WriteLine("{");
+        AddIndent();
+
+        for (var ruleIdx = 0; ruleIdx < _rules.Count; ruleIdx++)
         {
-            _rules = rules;
-            _sb = new StringBuilder();
-        }
+            var rule = _rules[ruleIdx];
 
-        public string GenerateClass()
-        {
-            WriteLine("using System;");
-            WriteLine("using System.Collections.Generic;");
+            var ruleGenerator = new RuleGenerator(rule);
 
-            WriteLine("namespace Jeffijoe.MessageFormat.Formatting.Formatters");
-            WriteLine("{");
-            AddIndent();
-
-            WriteLine("internal static partial class PluralRulesMetadata");
-            WriteLine("{");
-            AddIndent();
-
-            for (var ruleIdx = 0; ruleIdx < _rules.Count; ruleIdx++)
+            foreach(var locale in rule.Locales)
             {
-                var rule = _rules[ruleIdx];
-
-                var ruleGenerator = new RuleGenerator(rule);
-
-                foreach(var locale in rule.Locales)
-                {
-                    WriteLine($"public static string Locale_{locale.ToUpper()}(PluralContext context) => Rule{ruleIdx}(context);");
-                    WriteLine(string.Empty);
-                }
-
-                WriteLine($"private static string Rule{ruleIdx}(PluralContext context)");
-                WriteLine("{");
-                AddIndent();
-
-                ruleGenerator.WriteTo(_sb, _indent);
-
-                DecreaseIndent();
-                WriteLine("}");
+                WriteLine($"public static string Locale_{locale.ToUpper()}(PluralContext context) => Rule{ruleIdx}(context);");
                 WriteLine(string.Empty);
             }
 
-            WriteLine("private static readonly Dictionary<string, ContextPluralizer> Pluralizers = new Dictionary<string, ContextPluralizer>()");
+            WriteLine($"private static string Rule{ruleIdx}(PluralContext context)");
             WriteLine("{");
             AddIndent();
 
-            for (int ruleIdx = 0; ruleIdx < _rules.Count; ruleIdx++)
-            {
-                PluralRule rule = _rules[ruleIdx];
-                foreach (var locale in rule.Locales)
-                {
-                    WriteLine($"{{\"{locale}\", Rule{ruleIdx}}},");
-                }
-
-                WriteLine(string.Empty);
-            }
+            ruleGenerator.WriteTo(_sb, _indent);
 
             DecreaseIndent();
-            WriteLine("};");
+            WriteLine("}");
             WriteLine(string.Empty);
-
-            WriteLine("public static partial bool TryGetRuleByLocale(string locale, out ContextPluralizer contextPluralizer)");
-            WriteLine("{");
-            AddIndent();
-
-            WriteLine("return Pluralizers.TryGetValue(locale, out contextPluralizer);");
-
-            DecreaseIndent();
-            WriteLine("}");
-
-            DecreaseIndent();
-            WriteLine("}");
-
-            DecreaseIndent();
-            WriteLine("}");
-
-            return _sb.ToString();
         }
 
-        private void AddIndent() => _indent += 4;
-        private void DecreaseIndent() => _indent -= 4;
+        WriteLine("private static readonly Dictionary<string, ContextPluralizer> Pluralizers = new Dictionary<string, ContextPluralizer>()");
+        WriteLine("{");
+        AddIndent();
 
-        private void WriteLine(string line)
+        for (int ruleIdx = 0; ruleIdx < _rules.Count; ruleIdx++)
         {
-            _sb.Append(' ', _indent);
-            _sb.AppendLine(line);
+            PluralRule rule = _rules[ruleIdx];
+            foreach (var locale in rule.Locales)
+            {
+                WriteLine($"{{\"{locale}\", Rule{ruleIdx}}},");
+            }
+
+            WriteLine(string.Empty);
         }
+
+        DecreaseIndent();
+        WriteLine("};");
+        WriteLine(string.Empty);
+
+        WriteLine("public static partial bool TryGetRuleByLocale(string locale, out ContextPluralizer contextPluralizer)");
+        WriteLine("{");
+        AddIndent();
+
+        WriteLine("return Pluralizers.TryGetValue(locale, out contextPluralizer);");
+
+        DecreaseIndent();
+        WriteLine("}");
+
+        DecreaseIndent();
+        WriteLine("}");
+
+        DecreaseIndent();
+        WriteLine("}");
+
+        return _sb.ToString();
+    }
+
+    private void AddIndent() => _indent += 4;
+    private void DecreaseIndent() => _indent -= 4;
+
+    private void WriteLine(string line)
+    {
+        _sb.Append(' ', _indent);
+        _sb.AppendLine(line);
     }
 }

--- a/src/Jeffijoe.MessageFormat.Tests/Formatting/BaseFormatterTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Formatting/BaseFormatterTests.cs
@@ -13,361 +13,360 @@ using Jeffijoe.MessageFormat.Tests.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Jeffijoe.MessageFormat.Tests.Formatting
+namespace Jeffijoe.MessageFormat.Tests.Formatting;
+
+/// <summary>
+///     The base formatter tests.
+/// </summary>
+public class BaseFormatterTests
 {
+    #region Fields
+
     /// <summary>
-    ///     The base formatter tests.
+    ///     The output helper.
     /// </summary>
-    public class BaseFormatterTests
+    private readonly ITestOutputHelper outputHelper;
+
+    #endregion
+
+    #region Constructors and Destructors
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BaseFormatterTests"/> class.
+    /// </summary>
+    /// <param name="outputHelper">
+    /// The output helper.
+    /// </param>
+    public BaseFormatterTests(ITestOutputHelper outputHelper)
     {
-        #region Fields
+        this.outputHelper = outputHelper;
+    }
 
-        /// <summary>
-        ///     The output helper.
-        /// </summary>
-        private readonly ITestOutputHelper outputHelper;
+    #endregion
 
-        #endregion
+    #region Public Properties
 
-        #region Constructors and Destructors
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="BaseFormatterTests"/> class.
-        /// </summary>
-        /// <param name="outputHelper">
-        /// The output helper.
-        /// </param>
-        public BaseFormatterTests(ITestOutputHelper outputHelper)
+    /// <summary>
+    ///     Gets the parse arguments_tests.
+    /// </summary>
+    public static IEnumerable<object[]> ParseArgumentsTests
+    {
+        get
         {
-            this.outputHelper = outputHelper;
-        }
-
-        #endregion
-
-        #region Public Properties
-
-        /// <summary>
-        ///     Gets the parse arguments_tests.
-        /// </summary>
-        public static IEnumerable<object[]> ParseArgumentsTests
-        {
-            get
-            {
-                yield return
-                    new object[]
-                    {
-                        "offset:1 test:1337 one {programmer}   other{programmers}",
-                        new[] { "offset", "test" },
-                        new[] { "1", "1337" },
-                        new[] { "one", "other" },
-                        new[] { "programmer", "programmers" }
-                    };
-
-                yield return
-                    new object[]
-                    {
-                        "offset:1 test:1337 one\\123 {programmer}   other{programmers}",
-                        new[] { "offset", "test" },
-                        new[] { "1", "1337" },
-                        new[] { "one\\123", "other" },
-                        new[] { "programmer", "programmers" }
-                    };
-            }
-        }
-
-        /// <summary>
-        ///     Gets the parse keyed blocks_tests.
-        /// </summary>
-        public static IEnumerable<object?[]> ParseKeyedBlocksTests
-        {
-            get
-            {
-                yield return
-                    new object?[]
-                    {
-                        null,
-                        Array.Empty<string>(),
-                        Array.Empty<string>()
-                    };
-                yield return
-                    new object[]
-                    {
-                        "male {he} female {she}unknown{they}",
-                        new[] { "male", "female", "unknown" },
-                        new[] { "he", "she", "they" }
-                    };
-                yield return
-                    new object[]
-                    {
-                        "zero {} other {wee}",
-                        new[] { "zero", "other" },
-                        new[] { string.Empty, "wee" }
-                    };
-                yield return
-                    new object[]
-                    {
-                        "male {''he''}",
-                        new[] { "male"},
-                        new[] { "''he''" }
-                    };
-                yield return new object[]
+            yield return
+                new object[]
                 {
-                    @"
+                    "offset:1 test:1337 one {programmer}   other{programmers}",
+                    new[] { "offset", "test" },
+                    new[] { "1", "1337" },
+                    new[] { "one", "other" },
+                    new[] { "programmer", "programmers" }
+                };
+
+            yield return
+                new object[]
+                {
+                    "offset:1 test:1337 one\\123 {programmer}   other{programmers}",
+                    new[] { "offset", "test" },
+                    new[] { "1", "1337" },
+                    new[] { "one\\123", "other" },
+                    new[] { "programmer", "programmers" }
+                };
+        }
+    }
+
+    /// <summary>
+    ///     Gets the parse keyed blocks_tests.
+    /// </summary>
+    public static IEnumerable<object?[]> ParseKeyedBlocksTests
+    {
+        get
+        {
+            yield return
+                new object?[]
+                {
+                    null,
+                    Array.Empty<string>(),
+                    Array.Empty<string>()
+                };
+            yield return
+                new object[]
+                {
+                    "male {he} female {she}unknown{they}",
+                    new[] { "male", "female", "unknown" },
+                    new[] { "he", "she", "they" }
+                };
+            yield return
+                new object[]
+                {
+                    "zero {} other {wee}",
+                    new[] { "zero", "other" },
+                    new[] { string.Empty, "wee" }
+                };
+            yield return
+                new object[]
+                {
+                    "male {''he''}",
+                    new[] { "male"},
+                    new[] { "''he''" }
+                };
+            yield return new object[]
+            {
+                @"
                         male {he} 
                         female {she}
 unknown
     {they}
 ",
-                    new[] { "male", "female", "unknown" }, new[] { "he", "she", "they" }
-                };
-                yield return new object[]
-                {
-                    @"
+                new[] { "male", "female", "unknown" }, new[] { "he", "she", "they" }
+            };
+            yield return new object[]
+            {
+                @"
                         male {he} 
                         female {she{dawg}}
 unknown
     {they'{dawg}'}
 ",
-                    new[] { "male", "female", "unknown" }, new[] { "he", "she{dawg}", @"they'{dawg}'" }
-                };
-            }
+                new[] { "male", "female", "unknown" }, new[] { "he", "she{dawg}", @"they'{dawg}'" }
+            };
         }
+    }
 
-        #endregion
+    #endregion
 
-        #region Public Methods and Operators
+    #region Public Methods and Operators
 
-        /// <summary>
-        /// The parse arguments.
-        /// </summary>
-        /// <param name="args">
-        /// The args.
-        /// </param>
-        /// <param name="extensionKeys">
-        /// The extension keys.
-        /// </param>
-        /// <param name="extensionValues">
-        /// The extension values.
-        /// </param>
-        /// <param name="keys">
-        /// The keys.
-        /// </param>
-        /// <param name="blocks">
-        /// The blocks.
-        /// </param>
-        [Theory]
-        [MemberData(nameof(ParseArgumentsTests))]
-        public void ParseArguments(
-            string args,
-            string[] extensionKeys,
-            string[] extensionValues,
-            string[] keys,
-            string[] blocks)
+    /// <summary>
+    /// The parse arguments.
+    /// </summary>
+    /// <param name="args">
+    /// The args.
+    /// </param>
+    /// <param name="extensionKeys">
+    /// The extension keys.
+    /// </param>
+    /// <param name="extensionValues">
+    /// The extension values.
+    /// </param>
+    /// <param name="keys">
+    /// The keys.
+    /// </param>
+    /// <param name="blocks">
+    /// The blocks.
+    /// </param>
+    [Theory]
+    [MemberData(nameof(ParseArgumentsTests))]
+    public void ParseArguments(
+        string args,
+        string[] extensionKeys,
+        string[] extensionValues,
+        string[] keys,
+        string[] blocks)
+    {
+        var subject = new BaseFormatterImpl();
+        var req = new FormatterRequest(new Literal(1, 1, 1, 1, ""), string.Empty, null, args);
+        var actual = subject.ParseArguments(req);
+
+        Assert.Equal(extensionKeys.Length, actual.Extensions.Count());
+        Assert.Equal(keys.Length, actual.KeyedBlocks.Count());
+
+        for (int i = 0; i < actual.Extensions.ToArray().Length; i++)
         {
-            var subject = new BaseFormatterImpl();
-            var req = new FormatterRequest(new Literal(1, 1, 1, 1, ""), string.Empty, null, args);
-            var actual = subject.ParseArguments(req);
-
-            Assert.Equal(extensionKeys.Length, actual.Extensions.Count());
-            Assert.Equal(keys.Length, actual.KeyedBlocks.Count());
-
-            for (int i = 0; i < actual.Extensions.ToArray().Length; i++)
-            {
-                var extension = actual.Extensions.ToArray()[i];
-                Assert.Equal(extensionKeys[i], extension.Extension);
-                Assert.Equal(extensionValues[i], extension.Value);
-            }
-
-            for (int i = 0; i < actual.KeyedBlocks.ToArray().Length; i++)
-            {
-                var block = actual.KeyedBlocks.ToArray()[i];
-                Assert.Equal(keys[i], block.Key);
-                Assert.Equal(blocks[i], block.BlockText);
-            }
+            var extension = actual.Extensions.ToArray()[i];
+            Assert.Equal(extensionKeys[i], extension.Extension);
+            Assert.Equal(extensionValues[i], extension.Value);
         }
 
-        /// <summary>
-        /// The parse arguments_invalid.
-        /// </summary>
-        /// <param name="args">
-        /// The args.
-        /// </param>
-        [Theory]
-        [InlineData("hello {{dawg}")]
-        [InlineData("hello {dawg}}")]
-        [InlineData("hello '{dawg}")]
-        [InlineData("hello {dawg'}")]
-        [InlineData("hello {dawg} {sweet}")]
-        [InlineData("hello {dawg} test{sweet}}")]
-        [InlineData("hello '{{dawg'}} test{sweet}")]
-        public void ParseArguments_invalid(string args)
+        for (int i = 0; i < actual.KeyedBlocks.ToArray().Length; i++)
         {
-            var subject = new BaseFormatterImpl();
-            var req = new FormatterRequest(new Literal(1, 1, 1, 1, ""), string.Empty, null, args);
-            var ex = Assert.Throws<MalformedLiteralException>(() => subject.ParseArguments(req));
-            Assert.Equal(args, ex.SourceSnippet);
-            this.outputHelper.WriteLine(ex.Message);
+            var block = actual.KeyedBlocks.ToArray()[i];
+            Assert.Equal(keys[i], block.Key);
+            Assert.Equal(blocks[i], block.BlockText);
         }
+    }
 
-        /// <summary>
-        /// The parse extensions.
-        /// </summary>
-        /// <param name="args">
-        /// The args.
-        /// </param>
-        /// <param name="extension">
-        /// The extension.
-        /// </param>
-        /// <param name="value">
-        /// The value.
-        /// </param>
-        /// <param name="expectedIndex">
-        /// The expected index.
-        /// </param>
-        [Theory]
-        [InlineData(" offset:3 boom", "offset", "3", 9)]
-        [InlineData("testie:dawg lel", "testie", "dawg", 11)]
-        public void ParseExtensions(string? args, string extension, string value, int expectedIndex)
+    /// <summary>
+    /// The parse arguments_invalid.
+    /// </summary>
+    /// <param name="args">
+    /// The args.
+    /// </param>
+    [Theory]
+    [InlineData("hello {{dawg}")]
+    [InlineData("hello {dawg}}")]
+    [InlineData("hello '{dawg}")]
+    [InlineData("hello {dawg'}")]
+    [InlineData("hello {dawg} {sweet}")]
+    [InlineData("hello {dawg} test{sweet}}")]
+    [InlineData("hello '{{dawg'}} test{sweet}")]
+    public void ParseArguments_invalid(string args)
+    {
+        var subject = new BaseFormatterImpl();
+        var req = new FormatterRequest(new Literal(1, 1, 1, 1, ""), string.Empty, null, args);
+        var ex = Assert.Throws<MalformedLiteralException>(() => subject.ParseArguments(req));
+        Assert.Equal(args, ex.SourceSnippet);
+        this.outputHelper.WriteLine(ex.Message);
+    }
+
+    /// <summary>
+    /// The parse extensions.
+    /// </summary>
+    /// <param name="args">
+    /// The args.
+    /// </param>
+    /// <param name="extension">
+    /// The extension.
+    /// </param>
+    /// <param name="value">
+    /// The value.
+    /// </param>
+    /// <param name="expectedIndex">
+    /// The expected index.
+    /// </param>
+    [Theory]
+    [InlineData(" offset:3 boom", "offset", "3", 9)]
+    [InlineData("testie:dawg lel", "testie", "dawg", 11)]
+    public void ParseExtensions(string? args, string extension, string value, int expectedIndex)
+    {
+        var subject = new BaseFormatterImpl();
+        var req = new FormatterRequest(new Literal(1, 1, 1, 1, ""), string.Empty, null, args);
+
+        // Warmup
+        subject.ParseExtensions(req, out var index);
+
+        Benchmark.Start("Parsing extensions a few times (warmed up)", this.outputHelper);
+        for (int i = 0; i < 1000; i++)
         {
-            var subject = new BaseFormatterImpl();
-            var req = new FormatterRequest(new Literal(1, 1, 1, 1, ""), string.Empty, null, args);
-
-            // Warmup
-            subject.ParseExtensions(req, out var index);
-
-            Benchmark.Start("Parsing extensions a few times (warmed up)", this.outputHelper);
-            for (int i = 0; i < 1000; i++)
-            {
-                subject.ParseExtensions(req, out index);
-            }
-
-            Benchmark.End(this.outputHelper);
-
-            var actual = subject.ParseExtensions(req, out index).ToList();
-            Assert.NotEmpty(actual);
-            var first = actual.First();
-            Assert.Equal(extension, first.Extension);
-            Assert.Equal(value, first.Value);
-            Assert.Equal(expectedIndex, index);
+            subject.ParseExtensions(req, out index);
         }
+
+        Benchmark.End(this.outputHelper);
+
+        var actual = subject.ParseExtensions(req, out index).ToList();
+        Assert.NotEmpty(actual);
+        var first = actual.First();
+        Assert.Equal(extension, first.Extension);
+        Assert.Equal(value, first.Value);
+        Assert.Equal(expectedIndex, index);
+    }
  
-        /// <summary>
-        /// The parse extensions returns empty collection when formatter arguments is null.
-        /// </summary>
-        [Fact]
-        public void ParseExtensions_returns_empty_collection_when_formatter_arguments_is_null()
-        {
-            string? args = null;
-            var subject = new BaseFormatterImpl();
-            var req = new FormatterRequest(new Literal(1, 1, 1, 1, ""), string.Empty, null, args);
+    /// <summary>
+    /// The parse extensions returns empty collection when formatter arguments is null.
+    /// </summary>
+    [Fact]
+    public void ParseExtensions_returns_empty_collection_when_formatter_arguments_is_null()
+    {
+        string? args = null;
+        var subject = new BaseFormatterImpl();
+        var req = new FormatterRequest(new Literal(1, 1, 1, 1, ""), string.Empty, null, args);
             
-            var actual = subject.ParseExtensions(req, out var index);
+        var actual = subject.ParseExtensions(req, out var index);
 
-            Assert.Empty(actual);
-            Assert.Equal(-1, index);
-        }
+        Assert.Empty(actual);
+        Assert.Equal(-1, index);
+    }
 
-        /// <summary>
-        ///     The parse extensions_multiple.
-        /// </summary>
-        [Fact]
-        public void ParseExtensions_multiple()
+    /// <summary>
+    ///     The parse extensions_multiple.
+    /// </summary>
+    [Fact]
+    public void ParseExtensions_multiple()
+    {
+        var subject = new BaseFormatterImpl();
+        var args = " offset:2 code:js ";
+        var expectedIndex = 17;
+
+        var req = new FormatterRequest(new Literal(1, 1, 1, 1, ""), string.Empty, null, args);
+
+        var actual = subject.ParseExtensions(req, out var index).ToList();
+        Assert.NotEmpty(actual);
+        var result = actual.First();
+        Assert.Equal("offset", result.Extension);
+        Assert.Equal("2", result.Value);
+
+        result = actual.ElementAt(1);
+        Assert.Equal("code", result.Extension);
+        Assert.Equal("js", result.Value);
+
+        Assert.Equal(expectedIndex, index);
+    }
+
+    /// <summary>
+    /// The parse keyed blocks.
+    /// </summary>
+    /// <param name="args">
+    /// The args.
+    /// </param>
+    /// <param name="keys">
+    /// The keys.
+    /// </param>
+    /// <param name="values">
+    /// The values.
+    /// </param>
+    [Theory]
+    [MemberData(nameof(ParseKeyedBlocksTests))]
+    public void ParseKeyedBlocks(string? args, string[] keys, string[] values)
+    {
+        var subject = new BaseFormatterImpl();
+        var req = new FormatterRequest(new Literal(1, 1, 1, 1, ""), string.Empty, null, args);
+
+        // Warm-up
+        subject.ParseKeyedBlocks(req, 0);
+
+        Benchmark.Start("Parsing keyed blocks..", this.outputHelper);
+        for (int i = 0; i < 10000; i++)
         {
-            var subject = new BaseFormatterImpl();
-            var args = " offset:2 code:js ";
-            var expectedIndex = 17;
-
-            var req = new FormatterRequest(new Literal(1, 1, 1, 1, ""), string.Empty, null, args);
-
-            var actual = subject.ParseExtensions(req, out var index).ToList();
-            Assert.NotEmpty(actual);
-            var result = actual.First();
-            Assert.Equal("offset", result.Extension);
-            Assert.Equal("2", result.Value);
-
-            result = actual.ElementAt(1);
-            Assert.Equal("code", result.Extension);
-            Assert.Equal("js", result.Value);
-
-            Assert.Equal(expectedIndex, index);
-        }
-
-        /// <summary>
-        /// The parse keyed blocks.
-        /// </summary>
-        /// <param name="args">
-        /// The args.
-        /// </param>
-        /// <param name="keys">
-        /// The keys.
-        /// </param>
-        /// <param name="values">
-        /// The values.
-        /// </param>
-        [Theory]
-        [MemberData(nameof(ParseKeyedBlocksTests))]
-        public void ParseKeyedBlocks(string? args, string[] keys, string[] values)
-        {
-            var subject = new BaseFormatterImpl();
-            var req = new FormatterRequest(new Literal(1, 1, 1, 1, ""), string.Empty, null, args);
-
-            // Warm-up
             subject.ParseKeyedBlocks(req, 0);
-
-            Benchmark.Start("Parsing keyed blocks..", this.outputHelper);
-            for (int i = 0; i < 10000; i++)
-            {
-                subject.ParseKeyedBlocks(req, 0);
-            }
-
-            Benchmark.End(this.outputHelper);
-
-            var actual = subject.ParseKeyedBlocks(req, 0).ToList();
-            Assert.Equal(keys.Length, actual.Count());
-            this.outputHelper.WriteLine("Input: " + args);
-            this.outputHelper.WriteLine("-----");
-            for (int index = 0; index < actual.ToArray().Length; index++)
-            {
-                var keyedBlock = actual.ToArray()[index];
-                var expectedKey = keys[index];
-                var expectedValue = values[index];
-                Assert.Equal(expectedKey, keyedBlock.Key);
-                Assert.Equal(expectedValue, keyedBlock.BlockText);
-
-                this.outputHelper.WriteLine("Key: " + keyedBlock.Key);
-                this.outputHelper.WriteLine("Block: " + keyedBlock.BlockText);
-            }
         }
 
-        /// <summary>
-        /// The parse keyed blocks unclosed_escape_sequence.
-        /// </summary>
-        /// <param name="args">
-        /// The args.
-        /// </param>
-        [Theory]
-        [InlineData("male {he} other {'{they}")]
-        [InlineData("male {he} other {'# they}")]
-        [InlineData("male {he} other }")]
-        [InlineData("male {he} other {'")]
-        [InlineData("male {he} other {'{'")]
-        [InlineData("male{}} female{}")]
-        [InlineData("male haha")]
-        public void ParseKeyedBlocks_bad_formatting(string? args)
+        Benchmark.End(this.outputHelper);
+
+        var actual = subject.ParseKeyedBlocks(req, 0).ToList();
+        Assert.Equal(keys.Length, actual.Count());
+        this.outputHelper.WriteLine("Input: " + args);
+        this.outputHelper.WriteLine("-----");
+        for (int index = 0; index < actual.ToArray().Length; index++)
         {
-            var subject = new BaseFormatterImpl();
-            var req = new FormatterRequest(new Literal(1, 1, 1, 1, ""), string.Empty, null, args);
+            var keyedBlock = actual.ToArray()[index];
+            var expectedKey = keys[index];
+            var expectedValue = values[index];
+            Assert.Equal(expectedKey, keyedBlock.Key);
+            Assert.Equal(expectedValue, keyedBlock.BlockText);
 
-            Assert.Throws<MalformedLiteralException>(() => subject.ParseKeyedBlocks(req, 0));
+            this.outputHelper.WriteLine("Key: " + keyedBlock.Key);
+            this.outputHelper.WriteLine("Block: " + keyedBlock.BlockText);
         }
+    }
 
-        #endregion
+    /// <summary>
+    /// The parse keyed blocks unclosed_escape_sequence.
+    /// </summary>
+    /// <param name="args">
+    /// The args.
+    /// </param>
+    [Theory]
+    [InlineData("male {he} other {'{they}")]
+    [InlineData("male {he} other {'# they}")]
+    [InlineData("male {he} other }")]
+    [InlineData("male {he} other {'")]
+    [InlineData("male {he} other {'{'")]
+    [InlineData("male{}} female{}")]
+    [InlineData("male haha")]
+    public void ParseKeyedBlocks_bad_formatting(string? args)
+    {
+        var subject = new BaseFormatterImpl();
+        var req = new FormatterRequest(new Literal(1, 1, 1, 1, ""), string.Empty, null, args);
 
-        /// <summary>
-        ///     The base formatter impl.
-        /// </summary>
-        private class BaseFormatterImpl : BaseFormatter
-        {
-        }
+        Assert.Throws<MalformedLiteralException>(() => subject.ParseKeyedBlocks(req, 0));
+    }
+
+    #endregion
+
+    /// <summary>
+    ///     The base formatter impl.
+    /// </summary>
+    private class BaseFormatterImpl : BaseFormatter
+    {
     }
 }

--- a/src/Jeffijoe.MessageFormat.Tests/Formatting/FormatterLibraryTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Formatting/FormatterLibraryTests.cs
@@ -9,46 +9,45 @@ using Jeffijoe.MessageFormat.Parsing;
 using Jeffijoe.MessageFormat.Tests.TestHelpers;
 using Xunit;
 
-namespace Jeffijoe.MessageFormat.Tests.Formatting
+namespace Jeffijoe.MessageFormat.Tests.Formatting;
+
+/// <summary>
+/// The formatter library tests.
+/// </summary>
+public class FormatterLibraryTests
 {
+    #region Public Methods and Operators
+
     /// <summary>
-    /// The formatter library tests.
+    /// The get formatter.
     /// </summary>
-    public class FormatterLibraryTests
+    [Fact]
+    public void GetFormatter()
     {
-        #region Public Methods and Operators
-
-        /// <summary>
-        /// The get formatter.
-        /// </summary>
-        [Fact]
-        public void GetFormatter()
-        {
-            var subject = new FormatterLibrary();
+        var subject = new FormatterLibrary();
             
-            var req = new FormatterRequest(new Literal(1, 1, 1, 1, ""), "test", "dawg", null);
-            var formatter1 = new FakeFormatter();
-            var formatter2 = new FakeFormatter();
+        var req = new FormatterRequest(new Literal(1, 1, 1, 1, ""), "test", "dawg", null);
+        var formatter1 = new FakeFormatter();
+        var formatter2 = new FakeFormatter();
             
-            subject.Add(formatter1);
-            subject.Add(formatter2);
+        subject.Add(formatter1);
+        subject.Add(formatter2);
 
-            Assert.Throws<FormatterNotFoundException>(() => subject.GetFormatter(req));
+        Assert.Throws<FormatterNotFoundException>(() => subject.GetFormatter(req));
 
-            formatter2.SetCanFormat(true);
+        formatter2.SetCanFormat(true);
             
-            var actual = subject.GetFormatter(req);
-            Assert.Same(formatter2, actual);
+        var actual = subject.GetFormatter(req);
+        Assert.Same(formatter2, actual);
 
-            formatter1.SetCanFormat(true);
-            actual = subject.GetFormatter(req);
-            Assert.Same(formatter1, actual);
-        }
-
-        #endregion
-
-        #region Fakes
-
-        #endregion
+        formatter1.SetCanFormat(true);
+        actual = subject.GetFormatter(req);
+        Assert.Same(formatter1, actual);
     }
+
+    #endregion
+
+    #region Fakes
+
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/DateFormatterTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/DateFormatterTests.cs
@@ -3,68 +3,67 @@ using System.Globalization;
 using Jeffijoe.MessageFormat.Formatting;
 using Xunit;
 
-namespace Jeffijoe.MessageFormat.Tests.Formatting.Formatters
+namespace Jeffijoe.MessageFormat.Tests.Formatting.Formatters;
+
+public class DateFormatterTests
 {
-    public class DateFormatterTests
+    [Theory]
+    [InlineData("en-US", "1994-09-06T15:00:00Z", "9/6/1994")]
+    [InlineData("da-DK", "1994-09-06T15:00:00Z", "06.09.1994")]
+    public void DateFormatter_Short(string locale, string dateStr, string expected)
     {
-        [Theory]
-        [InlineData("en-US", "1994-09-06T15:00:00Z", "9/6/1994")]
-        [InlineData("da-DK", "1994-09-06T15:00:00Z", "06.09.1994")]
-        public void DateFormatter_Short(string locale, string dateStr, string expected)
+        var mf = new MessageFormatter(locale: locale);
+        var actual = mf.FormatMessage("{value, date}", new
         {
-            var mf = new MessageFormatter(locale: locale);
-            var actual = mf.FormatMessage("{value, date}", new
+            value = DateTimeOffset.Parse(dateStr)
+        });
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData("en-US", "1994-09-06T15:00:00Z", "Tuesday, September 6, 1994")]
+    [InlineData("da-DK", "1994-09-06T15:00:00Z", "tirsdag den 6. september 1994")]
+    public void DateFormatter_Full(string locale, string dateStr, string expected)
+    {
+        var mf = new MessageFormatter(locale: locale);
+        var actual = mf.FormatMessage("{value, date, full}", new
+        {
+            value = DateTimeOffset.Parse(dateStr)
+        });
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void DateFormatter_UnsupportedStyle()
+    {
+        var mf = new MessageFormatter();
+        Assert.Throws<UnsupportedFormatStyleException>(
+            () => mf.FormatMessage("{value, date, long}", new
             {
-                value = DateTimeOffset.Parse(dateStr)
-            });
-
-            Assert.Equal(expected, actual);
-        }
-
-        [Theory]
-        [InlineData("en-US", "1994-09-06T15:00:00Z", "Tuesday, September 6, 1994")]
-        [InlineData("da-DK", "1994-09-06T15:00:00Z", "tirsdag den 6. september 1994")]
-        public void DateFormatter_Full(string locale, string dateStr, string expected)
-        {
-            var mf = new MessageFormatter(locale: locale);
-            var actual = mf.FormatMessage("{value, date, full}", new
-            {
-                value = DateTimeOffset.Parse(dateStr)
-            });
-
-            Assert.Equal(expected, actual);
-        }
-
-        [Fact]
-        public void DateFormatter_UnsupportedStyle()
-        {
-            var mf = new MessageFormatter();
-            Assert.Throws<UnsupportedFormatStyleException>(
-                () => mf.FormatMessage("{value, date, long}", new
-                {
-                    value = DateTimeOffset.UtcNow
-                }));
-        }
+                value = DateTimeOffset.UtcNow
+            }));
+    }
         
-        [Fact]
-        public void DateFormatter_Custom()
+    [Fact]
+    public void DateFormatter_Custom()
+    {
+        var formatter = new CustomValueFormatters
         {
-            var formatter = new CustomValueFormatters
+            Date = (CultureInfo culture, object? value, string? _, out string? formatted) =>
             {
-                Date = (CultureInfo culture, object? value, string? _, out string? formatted) =>
-                {
-                    // This is just a test, you probably shouldn't be doing this in real workloads.
-                    formatted = ((FormattableString)$"{value:MMMM d 'in the year' yyyy}").ToString(culture);
-                    return true;
-                }
-            };
-            var mf = new MessageFormatter(locale: "en-US", customValueFormatter: formatter);
-            var actual = mf.FormatMessage("{value, date, long}", new
-            {
-                value = DateTimeOffset.Parse("1994-09-06T15:00:00Z")
-            });
+                // This is just a test, you probably shouldn't be doing this in real workloads.
+                formatted = ((FormattableString)$"{value:MMMM d 'in the year' yyyy}").ToString(culture);
+                return true;
+            }
+        };
+        var mf = new MessageFormatter(locale: "en-US", customValueFormatter: formatter);
+        var actual = mf.FormatMessage("{value, date, long}", new
+        {
+            value = DateTimeOffset.Parse("1994-09-06T15:00:00Z")
+        });
 
-            Assert.Equal("September 6 in the year 1994", actual);
-        }
+        Assert.Equal("September 6 in the year 1994", actual);
     }
 }

--- a/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/NumberFormatterTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/NumberFormatterTests.cs
@@ -2,149 +2,148 @@ using System.Globalization;
 using Jeffijoe.MessageFormat.Formatting;
 using Xunit;
 
-namespace Jeffijoe.MessageFormat.Tests.Formatting.Formatters
+namespace Jeffijoe.MessageFormat.Tests.Formatting.Formatters;
+
+public class NumberFormatterTests
 {
-    public class NumberFormatterTests
+    [Theory]
+    [InlineData(69, "69")]
+    [InlineData(69.420, "69.42")]
+    [InlineData(123_456.789, "123,456.789")]
+    [InlineData(1234567.1234567, "1,234,567.123")]
+    public void NumberFormatter_Default(decimal number, string expected)
     {
-        [Theory]
-        [InlineData(69, "69")]
-        [InlineData(69.420, "69.42")]
-        [InlineData(123_456.789, "123,456.789")]
-        [InlineData(1234567.1234567, "1,234,567.123")]
-        public void NumberFormatter_Default(decimal number, string expected)
+        var mf = new MessageFormatter(locale: "en-US");
+        // NOTE: The whitespace at the end is on purpose to cover whitespace tolerance in parsing.
+        var actual = mf.FormatMessage("{value, number }", new
         {
-            var mf = new MessageFormatter(locale: "en-US");
-            // NOTE: The whitespace at the end is on purpose to cover whitespace tolerance in parsing.
-            var actual = mf.FormatMessage("{value, number }", new
-            {
-                value = number
-            });
+            value = number
+        });
 
-            Assert.Equal(expected, actual);
-        }
+        Assert.Equal(expected, actual);
+    }
 
-        [Theory]
-        [InlineData(69, "69.0000")]
-        [InlineData(69.420, "69.4200")]
-        public void NumberFormatter_Decimal_CustomFormat(decimal number, string expected)
+    [Theory]
+    [InlineData(69, "69.0000")]
+    [InlineData(69.420, "69.4200")]
+    public void NumberFormatter_Decimal_CustomFormat(decimal number, string expected)
+    {
+        var formatters = new CustomValueFormatters
         {
-            var formatters = new CustomValueFormatters
+            Number = (CultureInfo culture, object? value, string? style, out string? formatted) =>
             {
-                Number = (CultureInfo culture, object? value, string? style, out string? formatted) =>
-                {
-                    formatted = string.Format(culture, $"{{0:{style}}}", value);
-                    return true;
-                }
-            };
-            var mf = new MessageFormatter(locale: "en-US", customValueFormatter: formatters);
+                formatted = string.Format(culture, $"{{0:{style}}}", value);
+                return true;
+            }
+        };
+        var mf = new MessageFormatter(locale: "en-US", customValueFormatter: formatters);
 
-            var actual = mf.FormatMessage("{value, number, 0.0000}", new
-            {
-                value = number
-            });
-
-            Assert.Equal(expected, actual);
-        }
-
-        [Theory]
-        [InlineData(0.2, "20%")]
-        [InlineData(1.2, "120%")]
-        [InlineData(1234567.1234567, "123,456,712%")]
-        public void NumberFormatter_Percent(decimal number, string expected)
+        var actual = mf.FormatMessage("{value, number, 0.0000}", new
         {
-            var mf = new MessageFormatter(locale: "en-US");
+            value = number
+        });
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData(0.2, "20%")]
+    [InlineData(1.2, "120%")]
+    [InlineData(1234567.1234567, "123,456,712%")]
+    public void NumberFormatter_Percent(decimal number, string expected)
+    {
+        var mf = new MessageFormatter(locale: "en-US");
             
-            // NOTE: The inconsistent whitespace in the pattern is to cover whitespace tolerance in parsing.
-            var actual = mf.FormatMessage("{value, number,percent}", new
+        // NOTE: The inconsistent whitespace in the pattern is to cover whitespace tolerance in parsing.
+        var actual = mf.FormatMessage("{value, number,percent}", new
+        {
+            value = number
+        });
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData(0.2, "0")]
+    [InlineData(1.2, "1")]
+    [InlineData(2.7, "3")]
+    [InlineData("2.7", "3")]
+    [InlineData("a string", "a string")]
+    [InlineData(true, "True")]
+    public void NumberFormatter_Integer(object? value, string expected)
+    {
+        var mf = new MessageFormatter(locale: "en-US");
+        var actual = mf.FormatMessage("{value, number, integer}", new
+        {
+            value
+        });
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData("en-US", 20, "$20.00")]
+    [InlineData("en-US", 99.99, "$99.99")]
+    [InlineData("da-DK", 99.99, "99,99 kr.")]
+    public void NumberFormatter_Currency(string locale, decimal number, string expected)
+    {
+        var mf = new MessageFormatter(locale: locale);
+
+        // NOTE: The inconsistent whitespace in the pattern is to cover whitespace tolerance in parsing.
+        var actual = mf.FormatMessage("{value, number, currency }", new
+        {
+            value = number
+        });
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void NumberFormatter_ThrowsIfStyleIsNotSupported()
+    {
+        const decimal Number = 12.34m;
+        var mf = new MessageFormatter(locale: "en-US");
+        var ex = Assert.Throws<UnsupportedFormatStyleException>(() =>
+            mf.FormatMessage($"{{value, number, wow}}",
+                new
+                {
+                    value = Number
+                }));
+        Assert.Equal("value", ex.Variable);
+        Assert.Equal("number", ex.Format);
+        Assert.Equal("wow", ex.Style);
+    }
+
+    [Fact]
+    public void NumberFormatter_BadInput_FallsBackToRegularFormat()
+    {
+        var mf = new MessageFormatter(locale: "en-US");
+
+        {
+            var actual = mf.FormatMessage($"{{value, number, currency}}", new
             {
-                value = number
+                value = "a lot of money"
             });
 
-            Assert.Equal(expected, actual);
+            Assert.Equal("a lot of money", actual);
         }
 
-        [Theory]
-        [InlineData(0.2, "0")]
-        [InlineData(1.2, "1")]
-        [InlineData(2.7, "3")]
-        [InlineData("2.7", "3")]
-        [InlineData("a string", "a string")]
-        [InlineData(true, "True")]
-        public void NumberFormatter_Integer(object? value, string expected)
         {
-            var mf = new MessageFormatter(locale: "en-US");
-            var actual = mf.FormatMessage("{value, number, integer}", new
+            var actual = mf.FormatMessage($"{{value, number, integer}}", new
             {
-                value
+                value = "a lot of money"
             });
 
-            Assert.Equal(expected, actual);
+            Assert.Equal("a lot of money", actual);
         }
 
-        [Theory]
-        [InlineData("en-US", 20, "$20.00")]
-        [InlineData("en-US", 99.99, "$99.99")]
-        [InlineData("da-DK", 99.99, "99,99 kr.")]
-        public void NumberFormatter_Currency(string locale, decimal number, string expected)
         {
-            var mf = new MessageFormatter(locale: locale);
-
-            // NOTE: The inconsistent whitespace in the pattern is to cover whitespace tolerance in parsing.
-            var actual = mf.FormatMessage("{value, number, currency }", new
+            var actual = mf.FormatMessage($"{{value, number, integer}}", new
             {
-                value = number
+                value = true
             });
 
-            Assert.Equal(expected, actual);
-        }
-
-        [Fact]
-        public void NumberFormatter_ThrowsIfStyleIsNotSupported()
-        {
-            const decimal Number = 12.34m;
-            var mf = new MessageFormatter(locale: "en-US");
-            var ex = Assert.Throws<UnsupportedFormatStyleException>(() =>
-                mf.FormatMessage($"{{value, number, wow}}",
-                    new
-                    {
-                        value = Number
-                    }));
-            Assert.Equal("value", ex.Variable);
-            Assert.Equal("number", ex.Format);
-            Assert.Equal("wow", ex.Style);
-        }
-
-        [Fact]
-        public void NumberFormatter_BadInput_FallsBackToRegularFormat()
-        {
-            var mf = new MessageFormatter(locale: "en-US");
-
-            {
-                var actual = mf.FormatMessage($"{{value, number, currency}}", new
-                {
-                    value = "a lot of money"
-                });
-
-                Assert.Equal("a lot of money", actual);
-            }
-
-            {
-                var actual = mf.FormatMessage($"{{value, number, integer}}", new
-                {
-                    value = "a lot of money"
-                });
-
-                Assert.Equal("a lot of money", actual);
-            }
-
-            {
-                var actual = mf.FormatMessage($"{{value, number, integer}}", new
-                {
-                    value = true
-                });
-
-                Assert.Equal("True", actual);
-            }
+            Assert.Equal("True", actual);
         }
     }
 }

--- a/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/PluralFormatterTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/PluralFormatterTests.cs
@@ -12,110 +12,109 @@ using Jeffijoe.MessageFormat.Parsing;
 
 using Xunit;
 
-namespace Jeffijoe.MessageFormat.Tests.Formatting.Formatters
+namespace Jeffijoe.MessageFormat.Tests.Formatting.Formatters;
+
+/// <summary>
+/// The plural formatter tests.
+/// </summary>
+public class PluralFormatterTests
 {
+    #region Public Methods and Operators
+
     /// <summary>
-    /// The plural formatter tests.
+    /// The pluralize.
     /// </summary>
-    public class PluralFormatterTests
+    /// <param name="n">
+    /// The n.
+    /// </param>
+    /// <param name="expected">
+    /// The expected.
+    /// </param>
+    [Theory]
+    [InlineData(0, "nothing")]
+    [InlineData(1, "just one")]
+    [InlineData(1337, "wow")]
+    public void Pluralize(double n, string expected)
     {
-        #region Public Methods and Operators
-
-        /// <summary>
-        /// The pluralize.
-        /// </summary>
-        /// <param name="n">
-        /// The n.
-        /// </param>
-        /// <param name="expected">
-        /// The expected.
-        /// </param>
-        [Theory]
-        [InlineData(0, "nothing")]
-        [InlineData(1, "just one")]
-        [InlineData(1337, "wow")]
-        public void Pluralize(double n, string expected)
-        {
-            var subject = new PluralFormatter();
-            var args = new Dictionary<string, object> { { "test", n } };
-            var arguments =
-                new ParsedArguments(
-                    new[]
-                    {
-                        new KeyedBlock("zero", "nothing"),
-                        new KeyedBlock("one", "just one"),
-                        new KeyedBlock("other", "wow")
-                    },
-                    Array.Empty<FormatterExtension>());
-            var request = new FormatterRequest(new Literal(1, 1, 1, 1, ""), "test", "plural", null);
-            var actual = subject.Pluralize("en", arguments, new PluralContext(Convert.ToDecimal(Convert.ToDouble(args[request.Variable]))), 0);
-            Assert.Equal(expected, actual);
-        }
-
-        /// <summary>
-        /// The pluralize_defaults_to_en_locale_when_specified_locale_is_not_found
-        /// </summary>
-        [Fact]
-        public void Pluralize_defaults_to_en_locale_when_specified_locale_is_not_found()
-        {
-            var subject = new PluralFormatter();
-            var args = new Dictionary<string, object> { { "test", 1 } };
-            var arguments =
-                new ParsedArguments(
-                    new[]
-                    {
-                        new KeyedBlock("zero", "nothing"),
-                        new KeyedBlock("one", "just one"),
-                        new KeyedBlock("other", "wow")
-                    },
-                    Array.Empty<FormatterExtension>());
-            var request = new FormatterRequest(new Literal(1, 1, 1, 1, ""), "test", "plural", null);
-            var actual = subject.Pluralize("unknown", arguments, new PluralContext(Convert.ToDecimal(Convert.ToDouble(args[request.Variable]))), 0);
-            Assert.Equal("just one", actual);
-        }
-        
-                /// <summary>
-        /// The pluralize_defaults_to_en_locale_when_specified_locale_is_not_found
-        /// </summary>
-        [Fact]
-        public void Pluralize_throws_when_missing_other_block()
-        {
-            var subject = new PluralFormatter();
-            var args = new Dictionary<string, object> { { "test", 5 } };
-            var arguments =
-                new ParsedArguments(
-                    new[]
-                    {
-                        new KeyedBlock("zero", "nothing"),
-                        new KeyedBlock("one", "just one")
-                    },
-                    Array.Empty<FormatterExtension>());
-            var request = new FormatterRequest(new Literal(1, 1, 1, 1, ""), "test", "plural", null);
-            Assert.Throws<MessageFormatterException>(() => subject.Pluralize("unknown", arguments, new PluralContext(Convert.ToDecimal(Convert.ToDouble(args[request.Variable]))), 0));
-        }
-
-        /// <summary>
-        /// The replace number literals.
-        /// </summary>
-        /// <param name="input">
-        /// The input.
-        /// </param>
-        /// <param name="expected">
-        /// The expected.
-        /// </param>
-        [Theory]
-        [InlineData(@"Number '#1' has # results", "Number '#1' has 1337 results")]
-        [InlineData(@"Number '#'1 has # results", "Number '#'1 has 1337 results")]
-        [InlineData(@"Number '#'# has # results", "Number '#'1337 has 1337 results")]
-        [InlineData(@"Number '''#'''# has # results", "Number '''#'''1337 has 1337 results")]
-        [InlineData(@"# results", "1337 results")]
-        public void ReplaceNumberLiterals(string input, string expected)
-        {
-            var subject = new PluralFormatter();
-            var actual = subject.ReplaceNumberLiterals(input, 1337);
-            Assert.Equal(expected, actual);
-        }
-
-        #endregion
+        var subject = new PluralFormatter();
+        var args = new Dictionary<string, object> { { "test", n } };
+        var arguments =
+            new ParsedArguments(
+                new[]
+                {
+                    new KeyedBlock("zero", "nothing"),
+                    new KeyedBlock("one", "just one"),
+                    new KeyedBlock("other", "wow")
+                },
+                Array.Empty<FormatterExtension>());
+        var request = new FormatterRequest(new Literal(1, 1, 1, 1, ""), "test", "plural", null);
+        var actual = subject.Pluralize("en", arguments, new PluralContext(Convert.ToDecimal(Convert.ToDouble(args[request.Variable]))), 0);
+        Assert.Equal(expected, actual);
     }
+
+    /// <summary>
+    /// The pluralize_defaults_to_en_locale_when_specified_locale_is_not_found
+    /// </summary>
+    [Fact]
+    public void Pluralize_defaults_to_en_locale_when_specified_locale_is_not_found()
+    {
+        var subject = new PluralFormatter();
+        var args = new Dictionary<string, object> { { "test", 1 } };
+        var arguments =
+            new ParsedArguments(
+                new[]
+                {
+                    new KeyedBlock("zero", "nothing"),
+                    new KeyedBlock("one", "just one"),
+                    new KeyedBlock("other", "wow")
+                },
+                Array.Empty<FormatterExtension>());
+        var request = new FormatterRequest(new Literal(1, 1, 1, 1, ""), "test", "plural", null);
+        var actual = subject.Pluralize("unknown", arguments, new PluralContext(Convert.ToDecimal(Convert.ToDouble(args[request.Variable]))), 0);
+        Assert.Equal("just one", actual);
+    }
+        
+    /// <summary>
+    /// The pluralize_defaults_to_en_locale_when_specified_locale_is_not_found
+    /// </summary>
+    [Fact]
+    public void Pluralize_throws_when_missing_other_block()
+    {
+        var subject = new PluralFormatter();
+        var args = new Dictionary<string, object> { { "test", 5 } };
+        var arguments =
+            new ParsedArguments(
+                new[]
+                {
+                    new KeyedBlock("zero", "nothing"),
+                    new KeyedBlock("one", "just one")
+                },
+                Array.Empty<FormatterExtension>());
+        var request = new FormatterRequest(new Literal(1, 1, 1, 1, ""), "test", "plural", null);
+        Assert.Throws<MessageFormatterException>(() => subject.Pluralize("unknown", arguments, new PluralContext(Convert.ToDecimal(Convert.ToDouble(args[request.Variable]))), 0));
+    }
+
+    /// <summary>
+    /// The replace number literals.
+    /// </summary>
+    /// <param name="input">
+    /// The input.
+    /// </param>
+    /// <param name="expected">
+    /// The expected.
+    /// </param>
+    [Theory]
+    [InlineData(@"Number '#1' has # results", "Number '#1' has 1337 results")]
+    [InlineData(@"Number '#'1 has # results", "Number '#'1 has 1337 results")]
+    [InlineData(@"Number '#'# has # results", "Number '#'1337 has 1337 results")]
+    [InlineData(@"Number '''#'''# has # results", "Number '''#'''1337 has 1337 results")]
+    [InlineData(@"# results", "1337 results")]
+    public void ReplaceNumberLiterals(string input, string expected)
+    {
+        var subject = new PluralFormatter();
+        var actual = subject.ReplaceNumberLiterals(input, 1337);
+        Assert.Equal(expected, actual);
+    }
+
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/SelectFormatterTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/SelectFormatterTests.cs
@@ -11,82 +11,81 @@ using Jeffijoe.MessageFormat.Parsing;
 using Jeffijoe.MessageFormat.Tests.TestHelpers;
 using Xunit;
 
-namespace Jeffijoe.MessageFormat.Tests.Formatting.Formatters
+namespace Jeffijoe.MessageFormat.Tests.Formatting.Formatters;
+
+/// <summary>
+/// The select formatter tests.
+/// </summary>
+public class SelectFormatterTests
 {
+    #region Public Properties
+
     /// <summary>
-    /// The select formatter tests.
+    /// Gets the format_tests.
     /// </summary>
-    public class SelectFormatterTests
+    public static IEnumerable<object[]> FormatTests
     {
-        #region Public Properties
-
-        /// <summary>
-        /// Gets the format_tests.
-        /// </summary>
-        public static IEnumerable<object[]> FormatTests
+        get
         {
-            get
-            {
-                yield return new object[] { "male {he said} female {she said} other {they said}", "male", "he said" };
-                yield return new object[]
-                    { "male {he said} female {she said} other {they said}", "female", "she said" };
-                yield return new object[] { "male {he said} female {she said} other {they said}", "dawg", "they said" };
-            }
+            yield return new object[] { "male {he said} female {she said} other {they said}", "male", "he said" };
+            yield return new object[]
+                { "male {he said} female {she said} other {they said}", "female", "she said" };
+            yield return new object[] { "male {he said} female {she said} other {they said}", "dawg", "they said" };
         }
-
-        #endregion
-
-        #region Public Methods and Operators
-
-        /// <summary>
-        /// The format.
-        /// </summary>
-        /// <param name="formatterArgs">
-        /// The formatter args.
-        /// </param>
-        /// <param name="gender">
-        /// The gender.
-        /// </param>
-        /// <param name="expectedBlock">
-        /// The expected block.
-        /// </param>
-        [Theory]
-        [MemberData(nameof(FormatTests))]
-        public void Format(string formatterArgs, string gender, string expectedBlock)
-        {
-            var subject = new SelectFormatter();
-            var messageFormatter = new FakeMessageFormatter();
-            var req = new FormatterRequest(
-                new Literal(1, 1, 1, 1, ""),
-                "gender",
-                "select",
-                formatterArgs);
-            var args = new Dictionary<string, object?> { { "gender", gender } };
-            var result = subject.Format("en", req, args, gender, messageFormatter);
-            Assert.Equal(expectedBlock, result);
-        }
-
-        /// <summary>
-        /// Verifies that format throws when no other option is given.
-        /// </summary>
-        [Fact]
-        public void VerifyFormatThrowsWhenNoOtherOptionIsGiven()
-        {
-            var subject = new SelectFormatter();
-            var messageFormatter = new FakeMessageFormatter();
-            var req = new FormatterRequest(
-                new Literal(1, 1, 1, 1, ""),
-                "gender",
-                "select",
-                "male {he} female{she}");
-            var args = new Dictionary<string, object?> { { "gender", "non-binary" } };
-
-            Assert.Throws<MessageFormatterException>(() =>
-            {
-                subject.Format("en", req, args, "non-binary", messageFormatter);
-            });
-        }
-
-        #endregion
     }
+
+    #endregion
+
+    #region Public Methods and Operators
+
+    /// <summary>
+    /// The format.
+    /// </summary>
+    /// <param name="formatterArgs">
+    /// The formatter args.
+    /// </param>
+    /// <param name="gender">
+    /// The gender.
+    /// </param>
+    /// <param name="expectedBlock">
+    /// The expected block.
+    /// </param>
+    [Theory]
+    [MemberData(nameof(FormatTests))]
+    public void Format(string formatterArgs, string gender, string expectedBlock)
+    {
+        var subject = new SelectFormatter();
+        var messageFormatter = new FakeMessageFormatter();
+        var req = new FormatterRequest(
+            new Literal(1, 1, 1, 1, ""),
+            "gender",
+            "select",
+            formatterArgs);
+        var args = new Dictionary<string, object?> { { "gender", gender } };
+        var result = subject.Format("en", req, args, gender, messageFormatter);
+        Assert.Equal(expectedBlock, result);
+    }
+
+    /// <summary>
+    /// Verifies that format throws when no other option is given.
+    /// </summary>
+    [Fact]
+    public void VerifyFormatThrowsWhenNoOtherOptionIsGiven()
+    {
+        var subject = new SelectFormatter();
+        var messageFormatter = new FakeMessageFormatter();
+        var req = new FormatterRequest(
+            new Literal(1, 1, 1, 1, ""),
+            "gender",
+            "select",
+            "male {he} female{she}");
+        var args = new Dictionary<string, object?> { { "gender", "non-binary" } };
+
+        Assert.Throws<MessageFormatterException>(() =>
+        {
+            subject.Format("en", req, args, "non-binary", messageFormatter);
+        });
+    }
+
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/TimeFormatterTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/TimeFormatterTests.cs
@@ -4,82 +4,81 @@ using System.Text.RegularExpressions;
 using Jeffijoe.MessageFormat.Formatting;
 using Xunit;
 
-namespace Jeffijoe.MessageFormat.Tests.Formatting.Formatters
+namespace Jeffijoe.MessageFormat.Tests.Formatting.Formatters;
+
+public partial class TimeFormatterTests
 {
-    public partial class TimeFormatterTests
+
+    [Theory]
+    [InlineData("en-US", "1994-09-06T15:01:23Z", "3:01 PM")]
+    [InlineData("da-DK", "1994-09-06T15:01:23Z", "15.01")]
+    public void TimeFormatter_Short(string locale, string dateStr, string expected)
     {
-
-        [Theory]
-        [InlineData("en-US", "1994-09-06T15:01:23Z", "3:01 PM")]
-        [InlineData("da-DK", "1994-09-06T15:01:23Z", "15.01")]
-        public void TimeFormatter_Short(string locale, string dateStr, string expected)
+        var mf = new MessageFormatter(locale: locale);
+        var actual = mf.FormatMessage("{value, time, short}", new
         {
-            var mf = new MessageFormatter(locale: locale);
-            var actual = mf.FormatMessage("{value, time, short}", new
+            value = DateTimeOffset.Parse(dateStr)
+        });
+
+        // Replacing all whitespace due to a difference in formatting on macOS vs Linux.
+        expected = Normalize(expected);
+        actual = Normalize(actual);
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData("en-US", "1994-09-06T15:01:23Z", "3:01:23 PM")]
+    [InlineData("da-DK", "1994-09-06T15:01:23Z", "15.01.23")]
+    public void TimeFormatter_Default(string locale, string dateStr, string expected)
+    {
+        var mf = new MessageFormatter(locale: locale);
+        var actual = mf.FormatMessage("{value, time}", new
+        {
+            value = DateTimeOffset.Parse(dateStr)
+        });
+
+        // Replacing all whitespace due to a difference in formatting on macOS vs Linux.
+        expected = Normalize(expected);
+        actual = Normalize(actual);
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void TimeFormatter_UnsupportedStyle()
+    {
+        var mf = new MessageFormatter();
+        Assert.Throws<UnsupportedFormatStyleException>(
+            () => mf.FormatMessage("{value, time, lol}", new
             {
-                value = DateTimeOffset.Parse(dateStr)
-            });
-
-            // Replacing all whitespace due to a difference in formatting on macOS vs Linux.
-            expected = Normalize(expected);
-            actual = Normalize(actual);
-            Assert.Equal(expected, actual);
-        }
-
-        [Theory]
-        [InlineData("en-US", "1994-09-06T15:01:23Z", "3:01:23 PM")]
-        [InlineData("da-DK", "1994-09-06T15:01:23Z", "15.01.23")]
-        public void TimeFormatter_Default(string locale, string dateStr, string expected)
-        {
-            var mf = new MessageFormatter(locale: locale);
-            var actual = mf.FormatMessage("{value, time}", new
-            {
-                value = DateTimeOffset.Parse(dateStr)
-            });
-
-            // Replacing all whitespace due to a difference in formatting on macOS vs Linux.
-            expected = Normalize(expected);
-            actual = Normalize(actual);
-            Assert.Equal(expected, actual);
-        }
-
-        [Fact]
-        public void TimeFormatter_UnsupportedStyle()
-        {
-            var mf = new MessageFormatter();
-            Assert.Throws<UnsupportedFormatStyleException>(
-                () => mf.FormatMessage("{value, time, lol}", new
-                {
-                    value = DateTimeOffset.UtcNow
-                }));
-        }
+                value = DateTimeOffset.UtcNow
+            }));
+    }
         
-        [Fact]
-        public void TimeFormatter_Custom()
+    [Fact]
+    public void TimeFormatter_Custom()
+    {
+        var formatter = new CustomValueFormatters
         {
-            var formatter = new CustomValueFormatters
+            Time = (CultureInfo _, object? value, string? _, out string? formatted) =>
             {
-                Time = (CultureInfo _, object? value, string? _, out string? formatted) =>
-                {
-                    formatted = $"{value:hmm} nice";
-                    return true;
-                }
-            };
-            var mf = new MessageFormatter(locale: "en-US", customValueFormatter: formatter);
-            var actual = mf.FormatMessage("{value, time, long}", new
-            {
-                value = DateTimeOffset.Parse("1994-09-06T16:20:09Z")
-            });
-
-            Assert.Equal("420 nice", actual);
-        }
-
-        [GeneratedRegex("\\s")]
-        private static partial Regex WhitespaceRegex();
-
-        private static string Normalize(string input)
+                formatted = $"{value:hmm} nice";
+                return true;
+            }
+        };
+        var mf = new MessageFormatter(locale: "en-US", customValueFormatter: formatter);
+        var actual = mf.FormatMessage("{value, time, long}", new
         {
-            return WhitespaceRegex().Replace(input, string.Empty);
-        }
+            value = DateTimeOffset.Parse("1994-09-06T16:20:09Z")
+        });
+
+        Assert.Equal("420 nice", actual);
+    }
+
+    [GeneratedRegex("\\s")]
+    private static partial Regex WhitespaceRegex();
+
+    private static string Normalize(string input)
+    {
+        return WhitespaceRegex().Replace(input, string.Empty);
     }
 }

--- a/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/TimeFormatterTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/TimeFormatterTests.cs
@@ -1,12 +1,14 @@
 using System;
 using System.Globalization;
+using System.Text.RegularExpressions;
 using Jeffijoe.MessageFormat.Formatting;
 using Xunit;
 
 namespace Jeffijoe.MessageFormat.Tests.Formatting.Formatters
 {
-    public class TimeFormatterTests
+    public partial class TimeFormatterTests
     {
+
         [Theory]
         [InlineData("en-US", "1994-09-06T15:01:23Z", "3:01 PM")]
         [InlineData("da-DK", "1994-09-06T15:01:23Z", "15.01")]
@@ -19,8 +21,8 @@ namespace Jeffijoe.MessageFormat.Tests.Formatting.Formatters
             });
 
             // Replacing all whitespace due to a difference in formatting on macOS vs Linux.
-            expected = expected.Replace(" ", "");
-            actual = actual.Replace(" ", "");
+            expected = Normalize(expected);
+            actual = Normalize(actual);
             Assert.Equal(expected, actual);
         }
 
@@ -36,8 +38,8 @@ namespace Jeffijoe.MessageFormat.Tests.Formatting.Formatters
             });
 
             // Replacing all whitespace due to a difference in formatting on macOS vs Linux.
-            expected = expected.Replace(" ", "");
-            actual = actual.Replace(" ", "");
+            expected = Normalize(expected);
+            actual = Normalize(actual);
             Assert.Equal(expected, actual);
         }
 
@@ -70,6 +72,14 @@ namespace Jeffijoe.MessageFormat.Tests.Formatting.Formatters
             });
 
             Assert.Equal("420 nice", actual);
+        }
+
+        [GeneratedRegex("\\s")]
+        private static partial Regex WhitespaceRegex();
+
+        private static string Normalize(string input)
+        {
+            return WhitespaceRegex().Replace(input, string.Empty);
         }
     }
 }

--- a/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/VariableFormatterTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/VariableFormatterTests.cs
@@ -12,82 +12,81 @@ using Jeffijoe.MessageFormat.Tests.TestHelpers;
 
 using Xunit;
 
-namespace Jeffijoe.MessageFormat.Tests.Formatting.Formatters
+namespace Jeffijoe.MessageFormat.Tests.Formatting.Formatters;
+
+/// <summary>
+///     The variable formatter tests.
+/// </summary>
+public class VariableFormatterTests
 {
+    #region Fields
+
     /// <summary>
-    ///     The variable formatter tests.
+    ///     The subject.
     /// </summary>
-    public class VariableFormatterTests
+    private readonly VariableFormatter subject;
+
+    /// <summary>
+    ///     The fake message formatter.
+    /// </summary>
+    private readonly IMessageFormatter formatter;
+
+    #endregion
+
+    #region Constructors and Destructors
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="VariableFormatterTests" /> class.
+    /// </summary>
+    public VariableFormatterTests()
     {
-        #region Fields
-
-        /// <summary>
-        ///     The subject.
-        /// </summary>
-        private readonly VariableFormatter subject;
-
-        /// <summary>
-        ///     The fake message formatter.
-        /// </summary>
-        private readonly IMessageFormatter formatter;
-
-        #endregion
-
-        #region Constructors and Destructors
-
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="VariableFormatterTests" /> class.
-        /// </summary>
-        public VariableFormatterTests()
-        {
-            this.formatter = new FakeMessageFormatter();
-            this.subject = new VariableFormatter();
-        }
-
-        #endregion
-
-        #region Public Methods and Operators
-
-        /// <summary>
-        ///     Verifies that an empty string is returned when the argument is null.
-        /// </summary>
-        [Fact]
-        public void VerifyAnEmptyStringIsReturnedWhenTheArgumentIsNull()
-        {
-            var req = CreateRequest();
-            var args = new Dictionary<string, object?>();
-
-            Assert.Equal(string.Empty, this.subject.Format("en", req, args, null, this.formatter));
-        }
-
-        /// <summary>
-        ///     Verifies that the value from the given arguments is returned as a string.
-        /// </summary>
-        [Fact]
-        public void VerifyTheValueFromTheGivenArgumentsIsReturnedAsAString()
-        {
-            var req = CreateRequest();
-            var args = new Dictionary<string, object?>();
-
-            Assert.Equal("is good", this.subject.Format("en", req, args, "is good", this.formatter));
-        }
-
-        #endregion
-
-        #region Methods
-
-        /// <summary>
-        ///     Creates the request.
-        /// </summary>
-        /// <returns>
-        ///     The <see cref="FormatterRequest" />.
-        /// </returns>
-        private static FormatterRequest CreateRequest()
-        {
-            var req = new FormatterRequest(new Literal(1, 10, 1, 1, ""), "test", null, null);
-            return req;
-        }
-
-        #endregion
+        this.formatter = new FakeMessageFormatter();
+        this.subject = new VariableFormatter();
     }
+
+    #endregion
+
+    #region Public Methods and Operators
+
+    /// <summary>
+    ///     Verifies that an empty string is returned when the argument is null.
+    /// </summary>
+    [Fact]
+    public void VerifyAnEmptyStringIsReturnedWhenTheArgumentIsNull()
+    {
+        var req = CreateRequest();
+        var args = new Dictionary<string, object?>();
+
+        Assert.Equal(string.Empty, this.subject.Format("en", req, args, null, this.formatter));
+    }
+
+    /// <summary>
+    ///     Verifies that the value from the given arguments is returned as a string.
+    /// </summary>
+    [Fact]
+    public void VerifyTheValueFromTheGivenArgumentsIsReturnedAsAString()
+    {
+        var req = CreateRequest();
+        var args = new Dictionary<string, object?>();
+
+        Assert.Equal("is good", this.subject.Format("en", req, args, "is good", this.formatter));
+    }
+
+    #endregion
+
+    #region Methods
+
+    /// <summary>
+    ///     Creates the request.
+    /// </summary>
+    /// <returns>
+    ///     The <see cref="FormatterRequest" />.
+    /// </returns>
+    private static FormatterRequest CreateRequest()
+    {
+        var req = new FormatterRequest(new Literal(1, 10, 1, 1, ""), "test", null, null);
+        return req;
+    }
+
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat.Tests/Helpers/CharHelperTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Helpers/CharHelperTests.cs
@@ -8,31 +8,30 @@ using Jeffijoe.MessageFormat.Helpers;
 
 using Xunit;
 
-namespace Jeffijoe.MessageFormat.Tests.Helpers
+namespace Jeffijoe.MessageFormat.Tests.Helpers;
+
+/// <summary>
+/// The char helper tests.
+/// </summary>
+public class CharHelperTests
 {
+    #region Public Methods and Operators
+
     /// <summary>
-    /// The char helper tests.
+    /// The is alpha numeric.
     /// </summary>
-    public class CharHelperTests
+    [Fact]
+    public void IsAlphaNumeric()
     {
-        #region Public Methods and Operators
-
-        /// <summary>
-        /// The is alpha numeric.
-        /// </summary>
-        [Fact]
-        public void IsAlphaNumeric()
-        {
-            Assert.True('a'.IsAlphaNumeric());
-            Assert.True('A'.IsAlphaNumeric());
-            Assert.True('0'.IsAlphaNumeric());
-            Assert.True('1'.IsAlphaNumeric());
-            Assert.False('ä'.IsAlphaNumeric());
-            Assert.False('ø'.IsAlphaNumeric());
-            Assert.False('æ'.IsAlphaNumeric());
-            Assert.False('å'.IsAlphaNumeric());
-        }
-
-        #endregion
+        Assert.True('a'.IsAlphaNumeric());
+        Assert.True('A'.IsAlphaNumeric());
+        Assert.True('0'.IsAlphaNumeric());
+        Assert.True('1'.IsAlphaNumeric());
+        Assert.False('ä'.IsAlphaNumeric());
+        Assert.False('ø'.IsAlphaNumeric());
+        Assert.False('æ'.IsAlphaNumeric());
+        Assert.False('å'.IsAlphaNumeric());
     }
+
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat.Tests/Helpers/ObjectHelperTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Helpers/ObjectHelperTests.cs
@@ -14,118 +14,117 @@ using Xunit.Abstractions;
 
 // ReSharper disable UnusedMember.Local
 
-namespace Jeffijoe.MessageFormat.Tests.Helpers
+namespace Jeffijoe.MessageFormat.Tests.Helpers;
+
+/// <summary>
+/// The object helper tests.
+/// </summary>
+public class ObjectHelperTests
 {
+    #region Fields
+
     /// <summary>
-    /// The object helper tests.
+    /// The output helper.
     /// </summary>
-    public class ObjectHelperTests
+    private readonly ITestOutputHelper outputHelper;
+
+    #endregion
+
+    #region Constructors and Destructors
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ObjectHelperTests"/> class.
+    /// </summary>
+    /// <param name="outputHelper">
+    /// The output helper.
+    /// </param>
+    public ObjectHelperTests(ITestOutputHelper outputHelper)
     {
-        #region Fields
+        this.outputHelper = outputHelper;
+    }
+
+    #endregion
+
+    #region Public Methods and Operators
+
+    /// <summary>
+    /// The get properties_anonymous_and_dynamic.
+    /// </summary>
+    [Fact]
+    public void GetProperties_anonymous_and_dynamic()
+    {
+        var obj = new { Test = "wee", Toast = "woo" };
+        var actual = ObjectHelper.GetProperties(obj);
+        Assert.Equal(2, actual.Count());
+
+        dynamic d = new { Cool = "sweet" };
+        actual = ObjectHelper.GetProperties(d);
+        Assert.Single(actual);
+    }
+
+    /// <summary>
+    /// The get properties_base_and_derived.
+    /// </summary>
+    [Fact]
+    public void GetProperties_base_and_derived()
+    {
+        var actual = ObjectHelper.GetProperties(new Base());
+        Assert.Single(actual);
+
+        actual = ObjectHelper.GetProperties(new Derived());
+        Assert.Equal(2, actual.Count());
+    }
+
+    /// <summary>
+    /// The to dictionary.
+    /// </summary>
+    [Fact]
+    public void ToDictionary()
+    {
+        var obj = new { name = "test", num = 1337 };
+        var actual = obj.ToDictionary();
+        Assert.Equal(2, actual.Count);
+        Assert.Equal("test", actual["name"]);
+        Assert.Equal(1337, actual["num"]);
+
+        Benchmark.Start("Converting object to dictionary..", this.outputHelper);
+        for (int i = 0; i < 10000; i++)
+        {
+            obj.ToDictionary();
+        }
+
+        Benchmark.End(this.outputHelper);
+    }
+
+    #endregion
+
+    /// <summary>
+    /// The base.
+    /// </summary>
+    private class Base
+    {
+        #region Public Properties
 
         /// <summary>
-        /// The output helper.
+        /// Gets or sets the prop 1.
         /// </summary>
-        private readonly ITestOutputHelper outputHelper;
+        public string? Prop1 { get; set; }
 
         #endregion
+    }
 
-        #region Constructors and Destructors
+    /// <summary>
+    /// The derived.
+    /// </summary>
+    private class Derived : Base
+    {
+        #region Public Properties
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ObjectHelperTests"/> class.
+        /// Gets or sets the prop 2.
         /// </summary>
-        /// <param name="outputHelper">
-        /// The output helper.
-        /// </param>
-        public ObjectHelperTests(ITestOutputHelper outputHelper)
-        {
-            this.outputHelper = outputHelper;
-        }
+        public int Prop2 { get; set; }
 
         #endregion
-
-        #region Public Methods and Operators
-
-        /// <summary>
-        /// The get properties_anonymous_and_dynamic.
-        /// </summary>
-        [Fact]
-        public void GetProperties_anonymous_and_dynamic()
-        {
-            var obj = new { Test = "wee", Toast = "woo" };
-            var actual = ObjectHelper.GetProperties(obj);
-            Assert.Equal(2, actual.Count());
-
-            dynamic d = new { Cool = "sweet" };
-            actual = ObjectHelper.GetProperties(d);
-            Assert.Single(actual);
-        }
-
-        /// <summary>
-        /// The get properties_base_and_derived.
-        /// </summary>
-        [Fact]
-        public void GetProperties_base_and_derived()
-        {
-            var actual = ObjectHelper.GetProperties(new Base());
-            Assert.Single(actual);
-
-            actual = ObjectHelper.GetProperties(new Derived());
-            Assert.Equal(2, actual.Count());
-        }
-
-        /// <summary>
-        /// The to dictionary.
-        /// </summary>
-        [Fact]
-        public void ToDictionary()
-        {
-            var obj = new { name = "test", num = 1337 };
-            var actual = obj.ToDictionary();
-            Assert.Equal(2, actual.Count);
-            Assert.Equal("test", actual["name"]);
-            Assert.Equal(1337, actual["num"]);
-
-            Benchmark.Start("Converting object to dictionary..", this.outputHelper);
-            for (int i = 0; i < 10000; i++)
-            {
-                obj.ToDictionary();
-            }
-
-            Benchmark.End(this.outputHelper);
-        }
-
-        #endregion
-
-        /// <summary>
-        /// The base.
-        /// </summary>
-        private class Base
-        {
-            #region Public Properties
-
-            /// <summary>
-            /// Gets or sets the prop 1.
-            /// </summary>
-            public string? Prop1 { get; set; }
-
-            #endregion
-        }
-
-        /// <summary>
-        /// The derived.
-        /// </summary>
-        private class Derived : Base
-        {
-            #region Public Properties
-
-            /// <summary>
-            /// Gets or sets the prop 2.
-            /// </summary>
-            public int Prop2 { get; set; }
-
-            #endregion
-        }
     }
 }

--- a/src/Jeffijoe.MessageFormat.Tests/Helpers/StringBuilderHelperTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Helpers/StringBuilderHelperTests.cs
@@ -10,78 +10,77 @@ using Jeffijoe.MessageFormat.Helpers;
 
 using Xunit;
 
-namespace Jeffijoe.MessageFormat.Tests.Helpers
+namespace Jeffijoe.MessageFormat.Tests.Helpers;
+
+/// <summary>
+/// The string builder helper tests.
+/// </summary>
+public class StringBuilderHelperTests
 {
+    #region Public Methods and Operators
+
     /// <summary>
-    /// The string builder helper tests.
+    /// The contains.
     /// </summary>
-    public class StringBuilderHelperTests
+    /// <param name="src">
+    /// The src.
+    /// </param>
+    /// <param name="c">
+    /// The c.
+    /// </param>
+    /// <param name="expected">
+    /// The expected.
+    /// </param>
+    [Theory]
+    [InlineData("hello ", ' ', true)]
+    [InlineData("hello ", 'l', true)]
+    [InlineData("hello ", 'p', false)]
+    public void Contains(string src, char c, bool expected)
     {
-        #region Public Methods and Operators
-
-        /// <summary>
-        /// The contains.
-        /// </summary>
-        /// <param name="src">
-        /// The src.
-        /// </param>
-        /// <param name="c">
-        /// The c.
-        /// </param>
-        /// <param name="expected">
-        /// The expected.
-        /// </param>
-        [Theory]
-        [InlineData("hello ", ' ', true)]
-        [InlineData("hello ", 'l', true)]
-        [InlineData("hello ", 'p', false)]
-        public void Contains(string src, char c, bool expected)
-        {
-            Assert.Equal(expected, new StringBuilder(src).Contains(c));
-        }
-
-        /// <summary>
-        /// The contains whitespace.
-        /// </summary>
-        /// <param name="src">
-        /// The src.
-        /// </param>
-        /// <param name="expected">
-        /// The expected.
-        /// </param>
-        [Theory]
-        [InlineData(" hello", true)]
-        [InlineData(" hello ", true)]
-        [InlineData("hello ", true)]
-        [InlineData("Hi", false)]
-        public void ContainsWhitespace(string src, bool expected)
-        {
-            Assert.Equal(expected, new StringBuilder(src).ContainsWhitespace());
-        }
-
-        /// <summary>
-        /// The trim whitespace.
-        /// </summary>
-        /// <param name="input">
-        /// The input.
-        /// </param>
-        /// <param name="expected">
-        /// The expected.
-        /// </param>
-        [Theory]
-        [InlineData("  dawg  ", "dawg")]
-        [InlineData("  dawg  dawg  ", "dawg  dawg")]
-        [InlineData("  dawg  dawg", "dawg  dawg")]
-        [InlineData("dawg  dawg  ", "dawg  dawg")]
-        [InlineData(" dawg  dawg  ", "dawg  dawg")]
-        [InlineData(" dawg  dawg", "dawg  dawg")]
-        [InlineData("dawg  dawg", "dawg  dawg")]
-        public void TrimWhitespace(string input, string expected)
-        {
-            string actual = new StringBuilder(input).TrimWhitespace().ToString();
-            Assert.Equal(expected, actual);
-        }
-
-        #endregion
+        Assert.Equal(expected, new StringBuilder(src).Contains(c));
     }
+
+    /// <summary>
+    /// The contains whitespace.
+    /// </summary>
+    /// <param name="src">
+    /// The src.
+    /// </param>
+    /// <param name="expected">
+    /// The expected.
+    /// </param>
+    [Theory]
+    [InlineData(" hello", true)]
+    [InlineData(" hello ", true)]
+    [InlineData("hello ", true)]
+    [InlineData("Hi", false)]
+    public void ContainsWhitespace(string src, bool expected)
+    {
+        Assert.Equal(expected, new StringBuilder(src).ContainsWhitespace());
+    }
+
+    /// <summary>
+    /// The trim whitespace.
+    /// </summary>
+    /// <param name="input">
+    /// The input.
+    /// </param>
+    /// <param name="expected">
+    /// The expected.
+    /// </param>
+    [Theory]
+    [InlineData("  dawg  ", "dawg")]
+    [InlineData("  dawg  dawg  ", "dawg  dawg")]
+    [InlineData("  dawg  dawg", "dawg  dawg")]
+    [InlineData("dawg  dawg  ", "dawg  dawg")]
+    [InlineData(" dawg  dawg  ", "dawg  dawg")]
+    [InlineData(" dawg  dawg", "dawg  dawg")]
+    [InlineData("dawg  dawg", "dawg  dawg")]
+    public void TrimWhitespace(string input, string expected)
+    {
+        string actual = new StringBuilder(input).TrimWhitespace().ToString();
+        Assert.Equal(expected, actual);
+    }
+
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat.Tests/Jeffijoe.MessageFormat.Tests.csproj
+++ b/src/Jeffijoe.MessageFormat.Tests/Jeffijoe.MessageFormat.Tests.csproj
@@ -4,7 +4,7 @@
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>MessageFormat.snk</AssemblyOriginatorKeyFile>
 	<GenerateAssemblyInfo>False</GenerateAssemblyInfo>
-	<LangVersion>9</LangVersion>
+	<LangVersion>12</LangVersion>
 	<Nullable>enable</Nullable>
 	<TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>

--- a/src/Jeffijoe.MessageFormat.Tests/MessageFormatterCachingTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/MessageFormatterCachingTests.cs
@@ -8,43 +8,42 @@ using Jeffijoe.MessageFormat.Formatting;
 using Jeffijoe.MessageFormat.Tests.TestHelpers;
 using Xunit;
 
-namespace Jeffijoe.MessageFormat.Tests
+namespace Jeffijoe.MessageFormat.Tests;
+
+/// <summary>
+/// The message formatter_caching_tests.
+/// </summary>
+public class MessageFormatterCachingTests
 {
+    #region Public Methods and Operators
+
     /// <summary>
-    /// The message formatter_caching_tests.
+    /// The format message_caches_reused_pattern.
     /// </summary>
-    public class MessageFormatterCachingTests()
+    [Fact]
+    public void FormatMessage_caches_reused_pattern()
     {
-        #region Public Methods and Operators
+        var parser = new TrackingPatternParser();
+        var library = new FormatterLibrary();
 
-        /// <summary>
-        /// The format message_caches_reused_pattern.
-        /// </summary>
-        [Fact]
-        public void FormatMessage_caches_reused_pattern()
-        {
-            var parser = new TrackingPatternParser();
-            var library = new FormatterLibrary();
+        var subject = new MessageFormatter(patternParser: parser, library: library, useCache: true);
 
-            var subject = new MessageFormatter(patternParser: parser, library: library, useCache: true);
+        var pattern = "Hi {gender, select, male {Sir} female {Ma'am}}!";
+        var actual = subject.FormatMessage(pattern, new { gender = "male" });
+        Assert.Equal("Hi Sir!", actual);
 
-            var pattern = "Hi {gender, select, male {Sir} female {Ma'am}}!";
-            var actual = subject.FormatMessage(pattern, new { gender = "male" });
-            Assert.Equal("Hi Sir!", actual);
+        // '2' because it did not format "Ma'am" yet.
+        Assert.Equal(2, parser.ParseCount);
 
-            // '2' because it did not format "Ma'am" yet.
-            Assert.Equal(2, parser.ParseCount);
+        actual = subject.FormatMessage(pattern, new { gender = "female" });
+        Assert.Equal("Hi Ma'am!", actual);
+        Assert.Equal(3, parser.ParseCount);
 
-            actual = subject.FormatMessage(pattern, new { gender = "female" });
-            Assert.Equal("Hi Ma'am!", actual);
-            Assert.Equal(3, parser.ParseCount);
-
-            // '3' because it has cached all options
-            actual = subject.FormatMessage(pattern, new { gender = "female" });
-            Assert.Equal("Hi Ma'am!", actual);
-            Assert.Equal(3, parser.ParseCount);
-        }
-        
-        #endregion
+        // '3' because it has cached all options
+        actual = subject.FormatMessage(pattern, new { gender = "female" });
+        Assert.Equal("Hi Ma'am!", actual);
+        Assert.Equal(3, parser.ParseCount);
     }
+        
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat.Tests/MessageFormatterCachingTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/MessageFormatterCachingTests.cs
@@ -4,48 +4,17 @@
 // Author: Jeff Hansen <jeff@jeffijoe.com>
 // Copyright (C) Jeff Hansen 2015. All rights reserved.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-
 using Jeffijoe.MessageFormat.Formatting;
-using Jeffijoe.MessageFormat.Helpers;
 using Jeffijoe.MessageFormat.Tests.TestHelpers;
-
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Jeffijoe.MessageFormat.Tests
 {
     /// <summary>
     /// The message formatter_caching_tests.
     /// </summary>
-    public class MessageFormatterCachingTests
+    public class MessageFormatterCachingTests()
     {
-        #region Fields
-
-        /// <summary>
-        /// The output helper.
-        /// </summary>
-        private readonly ITestOutputHelper outputHelper;
-
-        #endregion
-
-        #region Constructors and Destructors
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MessageFormatterCachingTests"/> class.
-        /// </summary>
-        /// <param name="outputHelper">
-        /// The output helper.
-        /// </param>
-        public MessageFormatterCachingTests(ITestOutputHelper outputHelper)
-        {
-            this.outputHelper = outputHelper;
-        }
-
-        #endregion
-
         #region Public Methods and Operators
 
         /// <summary>
@@ -75,71 +44,7 @@ namespace Jeffijoe.MessageFormat.Tests
             Assert.Equal("Hi Ma'am!", actual);
             Assert.Equal(3, parser.ParseCount);
         }
-
-        /// <summary>
-        /// The format message_with_cache_benchmark.
-        /// </summary>
-        [Fact]
-        public void FormatMessage_with_cache_benchmark()
-        {
-            var subject = new MessageFormatter(useCache: true);
-            this.Benchmark(subject);
-        }
-
-        /// <summary>
-        /// The format message_without_cache_benchmark.
-        /// </summary>
-        [Fact]
-        public void FormatMessage_without_cache_benchmark()
-        {
-            var subject = new MessageFormatter(false);
-            this.Benchmark(subject);
-        }
-
-        #endregion
-
-        #region Methods
-
-        /// <summary>
-        /// The benchmark.
-        /// </summary>
-        /// <param name="subject">
-        /// The subject.
-        /// </param>
-        private void Benchmark(MessageFormatter subject)
-        {
-            var pattern = "\r\n----\r\nOh {name}? And if we were " + "to surround {gender, select, " + "male {his} "
-                          + "female {her}" + "} name with '{' and '}', it would look "
-                          + "like '{'{name}'}'? Yeah, I know {gender, select, " + "male {him} " + "female {her}"
-                          + "}. {gender, select, " + "male {He's}" + "female {She's}" + "} got {messageCount, plural, "
-                          + "zero {no messages}" + "one {just one message}" + "=42 {a universal amount of messages}"
-                          + "other {uuhm... let's see.. Oh yeah, # messages - and here's a pound: '#'}" + "}!";
-            int iterations = 100000;
-            var args = new Dictionary<string, object?>[iterations];
-            var rnd = new Random();
-            for (int i = 0; i < iterations; i++)
-            {
-                var val = rnd.Next(50);
-                args[i] =
-                    new
-                    {
-                        gender = val % 2 == 0 ? "male" : "female",
-                        name = val % 2 == 0 ? "Jeff" : "Marcela",
-                        messageCount = val
-                    }.ToDictionary();
-            }
-
-            TestHelpers.Benchmark.Start("Formatting message " + iterations + " times, no warm-up.", this.outputHelper);
-            var output = new StringBuilder();
-            for (int i = 0; i < iterations; i++)
-            {
-                output.AppendLine(subject.FormatMessage(pattern, args[i]));
-            }
-
-            TestHelpers.Benchmark.End(this.outputHelper);
-            this.outputHelper.WriteLine(output.ToString());
-        }
-
+        
         #endregion
     }
 }

--- a/src/Jeffijoe.MessageFormat.Tests/MessageFormatterFullIntegrationTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/MessageFormatterFullIntegrationTests.cs
@@ -10,143 +10,143 @@ using Jeffijoe.MessageFormat.Tests.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Jeffijoe.MessageFormat.Tests
+namespace Jeffijoe.MessageFormat.Tests;
+
+/// <summary>
+/// The message formatter_full_integration_tests.
+/// </summary>
+public class MessageFormatterFullIntegrationTests
 {
+    #region Fields
+
     /// <summary>
-    /// The message formatter_full_integration_tests.
+    /// The output helper.
     /// </summary>
-    public class MessageFormatterFullIntegrationTests
+    private readonly ITestOutputHelper outputHelper;
+
+    #endregion
+
+    #region Constructors and Destructors
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MessageFormatterFullIntegrationTests"/> class.
+    /// </summary>
+    /// <param name="outputHelper">
+    /// The output helper.
+    /// </param>
+    public MessageFormatterFullIntegrationTests(ITestOutputHelper outputHelper)
     {
-        #region Fields
+        this.outputHelper = outputHelper;
+    }
 
-        /// <summary>
-        /// The output helper.
-        /// </summary>
-        private readonly ITestOutputHelper outputHelper;
+    #endregion
 
-        #endregion
+    #region Public Properties
 
-        #region Constructors and Destructors
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MessageFormatterFullIntegrationTests"/> class.
-        /// </summary>
-        /// <param name="outputHelper">
-        /// The output helper.
-        /// </param>
-        public MessageFormatterFullIntegrationTests(ITestOutputHelper outputHelper)
+    public static IEnumerable<object[]> EscapingTests
+    {
+        get
         {
-            this.outputHelper = outputHelper;
+            yield return
+                new object[]
+                {
+                    "This '{isn''t}' obvious",
+                    new Dictionary<string, object?>(),
+                    "This {isn't} obvious"
+                };
+            yield return
+                new object[]
+                {
+                    "Anna's house has '{0} and # in the roof' and {NUM_COWS} cows.",
+                    new Dictionary<string, object?> { { "NUM_COWS", 5 } },
+                    "Anna's house has {0} and # in the roof and 5 cows."
+                };
+            yield return
+                new object[]
+                {
+                    "Anna's house has '{'0'} and # in the roof' and {NUM_COWS} cows.",
+                    new Dictionary<string, object?> { { "NUM_COWS", 5 } },
+                    "Anna's house has {0} and # in the roof and 5 cows."
+                };
+            yield return
+                new object[]
+                {
+                    "Anna's house has '{0}' and '# in the roof' and {NUM_COWS} cows.",
+                    new Dictionary<string, object?> { { "NUM_COWS", 5 } },
+                    "Anna's house has {0} and # in the roof and 5 cows."
+                };
+            yield return
+                new object[]
+                {
+                    "Anna's house 'has {NUM_COWS} cows'.",
+                    new Dictionary<string, object?> { { "NUM_COWS", 5 } },
+                    "Anna's house 'has 5 cows'."
+                };
+            yield return
+                new object[]
+                {
+                    "Anna''s house a'{''''b'",
+                    new Dictionary<string, object?>(),
+                    "Anna's house a{''b"
+                };
+            yield return
+                new object[]
+                {
+                    "a''{NUM_COWS}'b",
+                    new Dictionary<string, object?> { { "NUM_COWS", 5 } },
+                    "a'5'b"
+                };
+            yield return
+                new object[]
+                {
+                    "a'{NUM_COWS}'b'",
+                    new Dictionary<string, object?> { { "NUM_COWS", 5 } },
+                    "a{NUM_COWS}b'"
+                };
+            yield return
+                new object[]
+                {
+                    "These '{'braces'}' and thoses '{braces}' ain''t not escaped, which makes a total of {braces, plural, one {a single pair} other {'#'# (=#) pairs}} of escaped braces.",
+                    new Dictionary<string, object?> { { "braces", 2 } },
+                    "These {braces} and thoses {braces} ain't not escaped, which makes a total of #2 (=2) pairs of escaped braces."
+                };
+            yield return
+                new object[]
+                {
+                    "{num, plural, =1 {1} other {'#'{num, plural, =1 {1} other {'{'#'#'#'}'}}}}",
+                    new Dictionary<string, object?> { { "num", 2 } },
+                    "#{2#2}"
+                };
+            yield return
+                new object[]
+                {
+                    "'''{'''",
+                    new Dictionary<string, object?>(),
+                    "'{'"
+                };
+            // yield return
+            //     new object[]
+            //     {
+            //         "{num, plural, =1 {1} other {'''{'''#'''}'''}}",
+            //         new Dictionary<string, object?> { { "num", 2 } },
+            //         "'{'2'}'"
+            //     };
         }
+    }
 
-        #endregion
-
-        #region Public Properties
-
-        public static IEnumerable<object[]> EscapingTests
+    /// <summary>
+    /// Gets the tests.
+    /// </summary>
+    public static IEnumerable<object[]> Tests
+    {
+        get
         {
-            get
-            {
-                yield return
-                    new object[]
-                    {
-                        "This '{isn''t}' obvious",
-                        new Dictionary<string, object?>(),
-                        "This {isn't} obvious"
-                    };
-                yield return
-                    new object[]
-                    {
-                        "Anna's house has '{0} and # in the roof' and {NUM_COWS} cows.",
-                        new Dictionary<string, object?> { { "NUM_COWS", 5 } },
-                        "Anna's house has {0} and # in the roof and 5 cows."
-                    };
-                yield return
-                    new object[]
-                    {
-                        "Anna's house has '{'0'} and # in the roof' and {NUM_COWS} cows.",
-                        new Dictionary<string, object?> { { "NUM_COWS", 5 } },
-                        "Anna's house has {0} and # in the roof and 5 cows."
-                    };
-                yield return
-                    new object[]
-                    {
-                        "Anna's house has '{0}' and '# in the roof' and {NUM_COWS} cows.",
-                        new Dictionary<string, object?> { { "NUM_COWS", 5 } },
-                        "Anna's house has {0} and # in the roof and 5 cows."
-                    };
-                yield return
-                    new object[]
-                    {
-                        "Anna's house 'has {NUM_COWS} cows'.",
-                        new Dictionary<string, object?> { { "NUM_COWS", 5 } },
-                        "Anna's house 'has 5 cows'."
-                    };
-                yield return
-                    new object[]
-                    {
-                        "Anna''s house a'{''''b'",
-                        new Dictionary<string, object?>(),
-                        "Anna's house a{''b"
-                    };
-                yield return
-                    new object[]
-                    {
-                        "a''{NUM_COWS}'b",
-                        new Dictionary<string, object?> { { "NUM_COWS", 5 } },
-                        "a'5'b"
-                    };
-                yield return
-                    new object[]
-                    {
-                        "a'{NUM_COWS}'b'",
-                        new Dictionary<string, object?> { { "NUM_COWS", 5 } },
-                        "a{NUM_COWS}b'"
-                    };
-                yield return
-                    new object[]
-                    {
-                        "These '{'braces'}' and thoses '{braces}' ain''t not escaped, which makes a total of {braces, plural, one {a single pair} other {'#'# (=#) pairs}} of escaped braces.",
-                        new Dictionary<string, object?> { { "braces", 2 } },
-                        "These {braces} and thoses {braces} ain't not escaped, which makes a total of #2 (=2) pairs of escaped braces."
-                    };
-                yield return
-                    new object[]
-                    {
-                        "{num, plural, =1 {1} other {'#'{num, plural, =1 {1} other {'{'#'#'#'}'}}}}",
-                        new Dictionary<string, object?> { { "num", 2 } },
-                        "#{2#2}"
-                    };
-                yield return
-                    new object[]
-                    {
-                        "'''{'''",
-                        new Dictionary<string, object?>(),
-                        "'{'"
-                    };
-                // yield return
-                //     new object[]
-                //     {
-                //         "{num, plural, =1 {1} other {'''{'''#'''}'''}}",
-                //         new Dictionary<string, object?> { { "num", 2 } },
-                //         "'{'2'}'"
-                //     };
-            }
-        }
-
-        /// <summary>
-        /// Gets the tests.
-        /// </summary>
-        public static IEnumerable<object[]> Tests
-        {
-            get
-            {
-                const string Case1 = @"{gender, select, 
+            const string Case1 = @"{gender, select, 
                            male {He - '{'{name}'}' -}
                            female {She - '{'{name}'}' -}
                            other {They}
                       } said: You're pretty cool!";
-                const string Case2 = @"{gender, select, 
+            const string Case2 = @"{gender, select, 
                            male {He - '{'{name}'}' -}
                            female {She - '{'{name}'}' -}
                            other {They}
@@ -156,13 +156,13 @@ namespace Jeffijoe.MessageFormat.Tests
                             =42 {a universal amount of notifications}
                             other {# notifications}
                       }. Have a nice day!";
-                const string Case3 = @"You have {count, plural, 
+            const string Case3 = @"You have {count, plural, 
                             zero {no notifications}
                             one {just one notification}
                             =42 {a universal amount of notifications}
                             other {# notifications}
                       }. Have a nice day!";
-                const string Case4 = @"{gender, select, 
+            const string Case4 = @"{gender, select, 
                            male {He}
                            female {She}
                            other {They}
@@ -173,8 +173,8 @@ namespace Jeffijoe.MessageFormat.Tests
                             other {# notifications}
                       }. Have a nice day!";
 
-                // Please take the following sample in the spirit it was intended. :)
-                const string Case5 = @"{gender, select, 
+            // Please take the following sample in the spirit it was intended. :)
+            const string Case5 = @"{gender, select, 
                            male {He (who has {genitals, plural, 
                                     zero {no testicles}
                                     one {just one testicle}
@@ -195,220 +195,220 @@ namespace Jeffijoe.MessageFormat.Tests
                             other {# notifications}
                       }. Have a nice day!";
 
-                const string Case6 = @"You {count, plural, offset:1,
+            const string Case6 = @"You {count, plural, offset:1,
                                         =0{didn't add this to your profile}
                                         =1{added this to your profile}
                                         one {and one other person added this to their profile}
                                         other {and # others added this to their profiles}
                                         }.";
 
-                yield return
-                    new object[]
-                    {
-                        Case1,
-                        new Dictionary<string, object?> { { "gender", "male" }, { "name", "Jeff" } },
-                        "He - {Jeff} - said: You're pretty cool!"
-                    };
-                yield return
-                    new object[]
-                    {
-                        Case2,
-                        new Dictionary<string, object?> { { "gender", "male" }, { "name", "Jeff" }, { "count", 0 } },
-                        "He - {Jeff} - said: You have no notifications. Have a nice day!"
-                    };
-                yield return
-                    new object[]
-                    {
-                        Case2,
-                        new Dictionary<string, object?>
-                            { { "gender", "female" }, { "name", "Amanda" }, { "count", 1 } },
-                        "She - {Amanda} - said: You have just one notification. Have a nice day!"
-                    };
-                yield return
-                    new object[]
-                    {
-                        Case2,
-                        new Dictionary<string, object?> { { "gender", "uni" }, { "count", 42 } },
-                        "They said: You have a universal amount of notifications. Have a nice day!"
-                    };
-                yield return
-                    new object[]
-                    {
-                        Case3,
-                        new Dictionary<string, object?> { { "count", 5 } },
-                        "You have 5 notifications. Have a nice day!"
-                    };
-                yield return
-                    new object[]
-                    {
-                        Case4,
-                        new Dictionary<string, object?> { { "count", 5 }, { "gender", "male" } },
-                        "He said: You have 5 notifications. Have a nice day!"
-                    };
-                yield return
-                    new object[]
-                    {
-                        Case5,
-                        new Dictionary<string, object?> { { "count", 5 }, { "gender", "male" }, { "genitals", 0 } },
-                        "He (who has no testicles) said: You have 5 notifications. Have a nice day!"
-                    };
-                yield return
-                    new object[]
-                    {
-                        Case5,
-                        new Dictionary<string, object?> { { "count", 5 }, { "gender", "female" }, { "genitals", 0 } },
-                        "She (who has no boobies) said: You have 5 notifications. Have a nice day!"
-                    };
-                yield return
-                    new object[]
-                    {
-                        Case5,
-                        new Dictionary<string, object?> { { "count", 0 }, { "gender", "female" }, { "genitals", 1 } },
-                        "She (who has just one boob) said: You have no notifications. Have a nice day!"
-                    };
-                yield return
-                    new object[]
-                    {
-                        Case5,
-                        new Dictionary<string, object?> { { "count", 0 }, { "gender", "female" }, { "genitals", 2 } },
-                        "She (who has a pair of lovelies) said: You have no notifications. Have a nice day!"
-                    };
-                yield return
-                    new object[]
-                    {
-                        Case5,
-                        new Dictionary<string, object?> { { "count", 0 }, { "gender", "female" }, { "genitals", 102 } },
-                        "She (who has the freakish amount of 102 boobies) said: You have no notifications. Have a nice day!"
-                    };
-                yield return
-                    new object[]
-                    {
-                        Case5,
-                        new Dictionary<string, object?>
-                            { { "count", 42 }, { "gender", "female" }, { "genitals", 102 } },
-                        "She (who has the freakish amount of 102 boobies) said: You have a universal amount of notifications. Have a nice day!"
-                    };
-                yield return
-                    new object[]
-                    {
-                        Case5,
-                        new Dictionary<string, object?> { { "count", 1 }, { "gender", "male" }, { "genitals", 102 } },
-                        "He (who has the insane amount of 102 testicles) said: You have just one notification. Have a nice day!"
-                    };
+            yield return
+                new object[]
+                {
+                    Case1,
+                    new Dictionary<string, object?> { { "gender", "male" }, { "name", "Jeff" } },
+                    "He - {Jeff} - said: You're pretty cool!"
+                };
+            yield return
+                new object[]
+                {
+                    Case2,
+                    new Dictionary<string, object?> { { "gender", "male" }, { "name", "Jeff" }, { "count", 0 } },
+                    "He - {Jeff} - said: You have no notifications. Have a nice day!"
+                };
+            yield return
+                new object[]
+                {
+                    Case2,
+                    new Dictionary<string, object?>
+                        { { "gender", "female" }, { "name", "Amanda" }, { "count", 1 } },
+                    "She - {Amanda} - said: You have just one notification. Have a nice day!"
+                };
+            yield return
+                new object[]
+                {
+                    Case2,
+                    new Dictionary<string, object?> { { "gender", "uni" }, { "count", 42 } },
+                    "They said: You have a universal amount of notifications. Have a nice day!"
+                };
+            yield return
+                new object[]
+                {
+                    Case3,
+                    new Dictionary<string, object?> { { "count", 5 } },
+                    "You have 5 notifications. Have a nice day!"
+                };
+            yield return
+                new object[]
+                {
+                    Case4,
+                    new Dictionary<string, object?> { { "count", 5 }, { "gender", "male" } },
+                    "He said: You have 5 notifications. Have a nice day!"
+                };
+            yield return
+                new object[]
+                {
+                    Case5,
+                    new Dictionary<string, object?> { { "count", 5 }, { "gender", "male" }, { "genitals", 0 } },
+                    "He (who has no testicles) said: You have 5 notifications. Have a nice day!"
+                };
+            yield return
+                new object[]
+                {
+                    Case5,
+                    new Dictionary<string, object?> { { "count", 5 }, { "gender", "female" }, { "genitals", 0 } },
+                    "She (who has no boobies) said: You have 5 notifications. Have a nice day!"
+                };
+            yield return
+                new object[]
+                {
+                    Case5,
+                    new Dictionary<string, object?> { { "count", 0 }, { "gender", "female" }, { "genitals", 1 } },
+                    "She (who has just one boob) said: You have no notifications. Have a nice day!"
+                };
+            yield return
+                new object[]
+                {
+                    Case5,
+                    new Dictionary<string, object?> { { "count", 0 }, { "gender", "female" }, { "genitals", 2 } },
+                    "She (who has a pair of lovelies) said: You have no notifications. Have a nice day!"
+                };
+            yield return
+                new object[]
+                {
+                    Case5,
+                    new Dictionary<string, object?> { { "count", 0 }, { "gender", "female" }, { "genitals", 102 } },
+                    "She (who has the freakish amount of 102 boobies) said: You have no notifications. Have a nice day!"
+                };
+            yield return
+                new object[]
+                {
+                    Case5,
+                    new Dictionary<string, object?>
+                        { { "count", 42 }, { "gender", "female" }, { "genitals", 102 } },
+                    "She (who has the freakish amount of 102 boobies) said: You have a universal amount of notifications. Have a nice day!"
+                };
+            yield return
+                new object[]
+                {
+                    Case5,
+                    new Dictionary<string, object?> { { "count", 1 }, { "gender", "male" }, { "genitals", 102 } },
+                    "He (who has the insane amount of 102 testicles) said: You have just one notification. Have a nice day!"
+                };
 
-                // Case from https://github.com/jeffijoe/messageformat.net/issues/2
-                yield return
-                    new object[]
-                    {
-                        "{nbrAttachments, plural, zero {} one {{nbrAttachmentsFmt} attachment} other {{nbrAttachmentsFmt} attachments}}",
-                        new Dictionary<string, object?> { { "nbrAttachments", 0 }, { "nbrAttachmentsFmt", "wut" } },
-                        string.Empty
-                    };
+            // Case from https://github.com/jeffijoe/messageformat.net/issues/2
+            yield return
+                new object[]
+                {
+                    "{nbrAttachments, plural, zero {} one {{nbrAttachmentsFmt} attachment} other {{nbrAttachmentsFmt} attachments}}",
+                    new Dictionary<string, object?> { { "nbrAttachments", 0 }, { "nbrAttachmentsFmt", "wut" } },
+                    string.Empty
+                };
 
-                // Following 2 cases from https://github.com/jeffijoe/messageformat.net/issues/4
-                yield return
-                    new object[]
-                    {
-                        "{maybeCount}",
-                        new Dictionary<string, object?> { { "maybeCount", null } },
-                        string.Empty
-                    };
-                yield return
-                    new object[]
-                    {
-                        "{maybeCount}",
-                        new Dictionary<string, object?> { { "maybeCount", (int?)2 } },
-                        "2"
-                    };
-                yield return
-                    new object[]
-                    {
-                        Case6,
-                        new Dictionary<string, object?> { { "count", 0 } },
-                        "You didn't add this to your profile."
-                    };
-                yield return
-                    new object[]
-                    {
-                        Case6,
-                        new Dictionary<string, object?> { { "count", 1 } },
-                        "You added this to your profile."
-                    };
-                yield return
-                    new object[]
-                    {
-                        Case6,
-                        new Dictionary<string, object?> { { "count", 2 } },
-                        "You and one other person added this to their profile."
-                    };
-                yield return
-                    new object[]
-                    {
-                        Case6,
-                        new Dictionary<string, object?> { { "count", 3 } },
-                        "You and 2 others added this to their profiles."
-                    };
-                yield return
-                    new object[]
-                    {
-                        "{ count, plural, one {1 thing} other {# things} }",
-                        new Dictionary<string, object?> { { "count", 2 } },
-                        "2 things"
-                    };
-            }
+            // Following 2 cases from https://github.com/jeffijoe/messageformat.net/issues/4
+            yield return
+                new object[]
+                {
+                    "{maybeCount}",
+                    new Dictionary<string, object?> { { "maybeCount", null } },
+                    string.Empty
+                };
+            yield return
+                new object[]
+                {
+                    "{maybeCount}",
+                    new Dictionary<string, object?> { { "maybeCount", (int?)2 } },
+                    "2"
+                };
+            yield return
+                new object[]
+                {
+                    Case6,
+                    new Dictionary<string, object?> { { "count", 0 } },
+                    "You didn't add this to your profile."
+                };
+            yield return
+                new object[]
+                {
+                    Case6,
+                    new Dictionary<string, object?> { { "count", 1 } },
+                    "You added this to your profile."
+                };
+            yield return
+                new object[]
+                {
+                    Case6,
+                    new Dictionary<string, object?> { { "count", 2 } },
+                    "You and one other person added this to their profile."
+                };
+            yield return
+                new object[]
+                {
+                    Case6,
+                    new Dictionary<string, object?> { { "count", 3 } },
+                    "You and 2 others added this to their profiles."
+                };
+            yield return
+                new object[]
+                {
+                    "{ count, plural, one {1 thing} other {# things} }",
+                    new Dictionary<string, object?> { { "count", 2 } },
+                    "2 things"
+                };
         }
+    }
 
-        #endregion
+    #endregion
 
-        #region Public Methods and Operators
+    #region Public Methods and Operators
 
-        /// <summary>
-        /// The format message.
-        /// </summary>
-        /// <param name="source">
-        /// The source.
-        /// </param>
-        /// <param name="args">
-        /// The args.
-        /// </param>
-        /// <param name="expected">
-        /// The expected.
-        /// </param>
-        [Theory]
-        [MemberData(nameof(Tests))]
-        public void FormatMessage(string source, Dictionary<string, object?> args, string expected)
-        {
-            var subject = new MessageFormatter(false);
+    /// <summary>
+    /// The format message.
+    /// </summary>
+    /// <param name="source">
+    /// The source.
+    /// </param>
+    /// <param name="args">
+    /// The args.
+    /// </param>
+    /// <param name="expected">
+    /// The expected.
+    /// </param>
+    [Theory]
+    [MemberData(nameof(Tests))]
+    public void FormatMessage(string source, Dictionary<string, object?> args, string expected)
+    {
+        var subject = new MessageFormatter(false);
 
-            // Warmup
-            subject.FormatMessage(source, args);
-            Benchmark.Start("Formatting", this.outputHelper);
-            string result = subject.FormatMessage(source, args);
-            Benchmark.End(this.outputHelper);
-            Assert.Equal(expected, result);
-            this.outputHelper.WriteLine(result);
-        }
+        // Warmup
+        subject.FormatMessage(source, args);
+        Benchmark.Start("Formatting", this.outputHelper);
+        string result = subject.FormatMessage(source, args);
+        Benchmark.End(this.outputHelper);
+        Assert.Equal(expected, result);
+        this.outputHelper.WriteLine(result);
+    }
 
-        /// <summary>
-        /// The format message_debug.
-        /// </summary>
-        [Theory]
-        [MemberData(nameof(EscapingTests))]
-        public void FormatMessage_escaping(string source, Dictionary<string, object?> args, string expected)
-        {
-            var subject = new MessageFormatter(false);
+    /// <summary>
+    /// The format message_debug.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(EscapingTests))]
+    public void FormatMessage_escaping(string source, Dictionary<string, object?> args, string expected)
+    {
+        var subject = new MessageFormatter(false);
 
-            string result = subject.FormatMessage(source, args);
-            Assert.Equal(expected, result);
-        }
+        string result = subject.FormatMessage(source, args);
+        Assert.Equal(expected, result);
+    }
 
-        /// <summary>
-        /// The format message_debug.
-        /// </summary>
-        [Fact]
-        public void FormatMessage_debug()
-        {
-            const string Source = @"{gender, select, 
+    /// <summary>
+    /// The format message_debug.
+    /// </summary>
+    [Fact]
+    public void FormatMessage_debug()
+    {
+        const string Source = @"{gender, select, 
                            male {He}
                            female {She}
                            other {They}
@@ -418,113 +418,113 @@ namespace Jeffijoe.MessageFormat.Tests
                             =42 {a universal amount of notifications}
                             other {# notifications}
                       }. Have a nice day!";
-            const string Expected = "He said: You have 5 notifications. Have a nice day!";
-            var args = new Dictionary<string, object?> { { "gender", "male" }, { "count", 5 } };
-            var subject = new MessageFormatter(false);
+        const string Expected = "He said: You have 5 notifications. Have a nice day!";
+        var args = new Dictionary<string, object?> { { "gender", "male" }, { "count", 5 } };
+        var subject = new MessageFormatter(false);
 
-            string result = subject.FormatMessage(Source, args);
-            Assert.Equal(Expected, result);
-        }
+        string result = subject.FormatMessage(Source, args);
+        Assert.Equal(Expected, result);
+    }
 
-        /// <summary>
-        /// The format message_lets_non_ascii_characters_right_through.
-        /// </summary>
-        [Fact]
-        public void FormatMessage_lets_non_ascii_characters_right_through()
-        {
-            const string Input = "中test中国话不用彁字。";
-            var subject = new MessageFormatter(false);
-            var actual = subject.FormatMessage(Input, new Dictionary<string, object?>());
-            Assert.Equal(Input, actual);
-        }
+    /// <summary>
+    /// The format message_lets_non_ascii_characters_right_through.
+    /// </summary>
+    [Fact]
+    public void FormatMessage_lets_non_ascii_characters_right_through()
+    {
+        const string Input = "中test中国话不用彁字。";
+        var subject = new MessageFormatter(false);
+        var actual = subject.FormatMessage(Input, new Dictionary<string, object?>());
+        Assert.Equal(Input, actual);
+    }
 
-        /// <summary>
-        /// The format message_nesting_with_brace_escaping.
-        /// </summary>
-        [Fact]
-        public void FormatMessage_nesting_with_brace_escaping()
-        {
-            var subject = new MessageFormatter(false);
-            const string Pattern = @"{s1, select, 
+    /// <summary>
+    /// The format message_nesting_with_brace_escaping.
+    /// </summary>
+    [Fact]
+    public void FormatMessage_nesting_with_brace_escaping()
+    {
+        var subject = new MessageFormatter(false);
+        const string Pattern = @"{s1, select, 
                                 1 {{s2, select, 
                                    2 {'{'}
                                 }}
                             }";
-            var actual = subject.FormatMessage(Pattern, new { s1 = 1, s2 = 2 });
-            this.outputHelper.WriteLine(actual);
-            Assert.Equal("{", actual);
-        }
+        var actual = subject.FormatMessage(Pattern, new { s1 = 1, s2 = 2 });
+        this.outputHelper.WriteLine(actual);
+        Assert.Equal("{", actual);
+    }
 
-        /// <summary>
-        /// The format message_with_reflection_overload.
-        /// </summary>
-        [Fact]
-        public void FormatMessage_with_reflection_overload()
+    /// <summary>
+    /// The format message_with_reflection_overload.
+    /// </summary>
+    [Fact]
+    public void FormatMessage_with_reflection_overload()
+    {
+        var subject = new MessageFormatter(false);
+        const string Pattern = "You have {UnreadCount, plural, "
+                               + "zero {no unread messages}"
+                               + "one {just one unread message}" + "other {# unread messages}" + "} today.";
+        var actual = subject.FormatMessage(Pattern, new { UnreadCount = 0 });
+        Assert.Equal("You have no unread messages today.", actual);
+
+        // The absence of UnreadCount should make it throw.
+        var ex = Assert.Throws<VariableNotFoundException>(() => subject.FormatMessage(Pattern, new { }));
+        Assert.Equal("UnreadCount", ex.MissingVariable);
+
+        actual = subject.FormatMessage(Pattern, new { UnreadCount = 1 });
+        Assert.Equal("You have just one unread message today.", actual);
+        actual = subject.FormatMessage(Pattern, new { UnreadCount = 2 });
+        Assert.Equal("You have 2 unread messages today.", actual);
+
+        actual = subject.FormatMessage(Pattern, new { UnreadCount = 3 });
+        Assert.Equal("You have 3 unread messages today.", actual);
+    }
+
+    /// <summary>
+    /// The read me_test_to_make_sure_ i_dont_look_like_a_fool.
+    /// </summary>
+    [Fact]
+    public void ReadMe_test_to_make_sure_I_dont_look_like_a_fool()
+    {
         {
-            var subject = new MessageFormatter(false);
-            const string Pattern = "You have {UnreadCount, plural, "
-                                   + "zero {no unread messages}"
-                                   + "one {just one unread message}" + "other {# unread messages}" + "} today.";
-            var actual = subject.FormatMessage(Pattern, new { UnreadCount = 0 });
-            Assert.Equal("You have no unread messages today.", actual);
-
-            // The absence of UnreadCount should make it throw.
-            var ex = Assert.Throws<VariableNotFoundException>(() => subject.FormatMessage(Pattern, new { }));
-            Assert.Equal("UnreadCount", ex.MissingVariable);
-
-            actual = subject.FormatMessage(Pattern, new { UnreadCount = 1 });
-            Assert.Equal("You have just one unread message today.", actual);
-            actual = subject.FormatMessage(Pattern, new { UnreadCount = 2 });
-            Assert.Equal("You have 2 unread messages today.", actual);
-
-            actual = subject.FormatMessage(Pattern, new { UnreadCount = 3 });
-            Assert.Equal("You have 3 unread messages today.", actual);
-        }
-
-        /// <summary>
-        /// The read me_test_to_make_sure_ i_dont_look_like_a_fool.
-        /// </summary>
-        [Fact]
-        public void ReadMe_test_to_make_sure_I_dont_look_like_a_fool()
-        {
-            {
-                var mf = new MessageFormatter(false);
-                const string Str = @"You have {notifications, plural,
+            var mf = new MessageFormatter(false);
+            const string Str = @"You have {notifications, plural,
                               zero {no notifications}
                               one {one notification}
                               =42 {a universal amount of notifications}
                               other {# notifications}
                             }. Have a nice day, {name}!";
-                var formatted = mf.FormatMessage(
-                    Str,
-                    new Dictionary<string, object?> { { "notifications", 4 }, { "name", "Jeff" } });
-                Assert.Equal("You have 4 notifications. Have a nice day, Jeff!", formatted);
-            }
+            var formatted = mf.FormatMessage(
+                Str,
+                new Dictionary<string, object?> { { "notifications", 4 }, { "name", "Jeff" } });
+            Assert.Equal("You have 4 notifications. Have a nice day, Jeff!", formatted);
+        }
 
-            {
-                var mf = new MessageFormatter(false);
-                const string Str = @"You {NUM_ADDS, plural, offset:1
+        {
+            var mf = new MessageFormatter(false);
+            const string Str = @"You {NUM_ADDS, plural, offset:1
                               =0{didnt add this to your profile} 
                               zero{added this to your profile}
                               one{and one other person added this to their profile}
                               other{and # others added this to their profiles}
                           }.";
-                var formatted = mf.FormatMessage(Str, new Dictionary<string, object?> { { "NUM_ADDS", 0 } });
-                Assert.Equal("You didnt add this to your profile.", formatted);
+            var formatted = mf.FormatMessage(Str, new Dictionary<string, object?> { { "NUM_ADDS", 0 } });
+            Assert.Equal("You didnt add this to your profile.", formatted);
 
-                formatted = mf.FormatMessage(Str, new Dictionary<string, object?> { { "NUM_ADDS", 1 } });
-                Assert.Equal("You added this to your profile.", formatted);
+            formatted = mf.FormatMessage(Str, new Dictionary<string, object?> { { "NUM_ADDS", 1 } });
+            Assert.Equal("You added this to your profile.", formatted);
 
-                formatted = mf.FormatMessage(Str, new Dictionary<string, object?> { { "NUM_ADDS", 2 } });
-                Assert.Equal("You and one other person added this to their profile.", formatted);
+            formatted = mf.FormatMessage(Str, new Dictionary<string, object?> { { "NUM_ADDS", 2 } });
+            Assert.Equal("You and one other person added this to their profile.", formatted);
 
-                formatted = mf.FormatMessage(Str, new Dictionary<string, object?> { { "NUM_ADDS", 3 } });
-                Assert.Equal("You and 2 others added this to their profiles.", formatted);
-            }
+            formatted = mf.FormatMessage(Str, new Dictionary<string, object?> { { "NUM_ADDS", 3 } });
+            Assert.Equal("You and 2 others added this to their profiles.", formatted);
+        }
 
-            {
-                var mf = new MessageFormatter(false);
-                const string Str = @"{GENDER, select,
+        {
+            var mf = new MessageFormatter(false);
+            const string Str = @"{GENDER, select,
                                 male {He}
                               female {She}
                                other {They}
@@ -535,105 +535,104 @@ namespace Jeffijoe.MessageFormat.Tests
                                               one {1 category}
                                             other {# categories}
                                          }.";
-                var formatted = mf.FormatMessage(
-                    Str,
-                    new Dictionary<string, object?>
-                    {
-                        { "GENDER", "male" },
-                        { "NUM_RESULTS", 1 },
-                        { "NUM_CATEGORIES", 2 }
-                    });
-                Assert.Equal("He found 1 result in 2 categories.", formatted);
-
-                formatted = mf.FormatMessage(
-                    Str,
-                    new Dictionary<string, object?>
-                    {
-                        { "GENDER", "male" },
-                        { "NUM_RESULTS", 1 },
-                        { "NUM_CATEGORIES", 1 }
-                    });
-                Assert.Equal("He found 1 result in 1 category.", formatted);
-
-                formatted = mf.FormatMessage(
-                    Str,
-                    new Dictionary<string, object?>
-                    {
-                        { "GENDER", "female" },
-                        { "NUM_RESULTS", 2 },
-                        { "NUM_CATEGORIES", 1 }
-                    });
-                Assert.Equal("She found 2 results in 1 category.", formatted);
-            }
-
-            {
-                var mf = new MessageFormatter(false);
-                const string Str = @"Your {NUM, plural, one{message} other{messages}} go here.";
-                var formatted = mf.FormatMessage(Str, new Dictionary<string, object?> { { "NUM", 1 } });
-                Assert.Equal("Your message go here.", formatted);
-
-                formatted = mf.FormatMessage(Str, new Dictionary<string, object?> { { "NUM", 3 } });
-                Assert.Equal("Your messages go here.", formatted);
-            }
-
-            {
-                var mf = new MessageFormatter(false);
-                const string Str = @"His name is {LAST_NAME}... {FIRST_NAME} {LAST_NAME}";
-                var formatted = mf.FormatMessage(
-                    Str,
-                    new Dictionary<string, object?> { { "FIRST_NAME", "James" }, { "LAST_NAME", "Bond" } });
-                Assert.Equal("His name is Bond... James Bond", formatted);
-            }
-
-            {
-                var mf = new MessageFormatter(false);
-                const string Str = @"{GENDER, select, male{He} female{She} other{They}} liked this.";
-                var formatted = mf.FormatMessage(Str, new Dictionary<string, object?> { { "GENDER", "male" } });
-                Assert.Equal("He liked this.", formatted);
-
-                formatted = mf.FormatMessage(Str, new Dictionary<string, object?> { { "GENDER", "female" } });
-                Assert.Equal("She liked this.", formatted);
-
-                formatted = mf.FormatMessage(Str, new Dictionary<string, object?> { { "GENDER", "somethingelse" } });
-                Assert.Equal("They liked this.", formatted);
-
-                formatted = mf.FormatMessage(Str, new Dictionary<string, object?> { { "GENDER", null } });
-                Assert.Equal("They liked this.", formatted);
-            }
-
-            {
-                var mf = new MessageFormatter(useCache: true, locale: "en");
-                mf.Pluralizers!["en"] = n =>
+            var formatted = mf.FormatMessage(
+                Str,
+                new Dictionary<string, object?>
                 {
-                    // ´n´ is the number being pluralized.
-                    // ReSharper disable once CompareOfFloatsByEqualityOperator
-                    if (n == 0)
-                    {
-                        return "zero";
-                    }
+                    { "GENDER", "male" },
+                    { "NUM_RESULTS", 1 },
+                    { "NUM_CATEGORIES", 2 }
+                });
+            Assert.Equal("He found 1 result in 2 categories.", formatted);
 
-                    // ReSharper disable once CompareOfFloatsByEqualityOperator
-                    if (n == 1)
-                    {
-                        return "one";
-                    }
+            formatted = mf.FormatMessage(
+                Str,
+                new Dictionary<string, object?>
+                {
+                    { "GENDER", "male" },
+                    { "NUM_RESULTS", 1 },
+                    { "NUM_CATEGORIES", 1 }
+                });
+            Assert.Equal("He found 1 result in 1 category.", formatted);
 
-                    if (n > 1000)
-                    {
-                        return "thatsalot";
-                    }
-
-                    return "other";
-                };
-
-                var actual =
-                    mf.FormatMessage(
-                        "You have {number, plural, thatsalot {a shitload of notifications} other {# notifications}}",
-                        new Dictionary<string, object?> { { "number", 1001 } });
-                Assert.Equal("You have a shitload of notifications", actual);
-            }
+            formatted = mf.FormatMessage(
+                Str,
+                new Dictionary<string, object?>
+                {
+                    { "GENDER", "female" },
+                    { "NUM_RESULTS", 2 },
+                    { "NUM_CATEGORIES", 1 }
+                });
+            Assert.Equal("She found 2 results in 1 category.", formatted);
         }
 
-        #endregion
+        {
+            var mf = new MessageFormatter(false);
+            const string Str = @"Your {NUM, plural, one{message} other{messages}} go here.";
+            var formatted = mf.FormatMessage(Str, new Dictionary<string, object?> { { "NUM", 1 } });
+            Assert.Equal("Your message go here.", formatted);
+
+            formatted = mf.FormatMessage(Str, new Dictionary<string, object?> { { "NUM", 3 } });
+            Assert.Equal("Your messages go here.", formatted);
+        }
+
+        {
+            var mf = new MessageFormatter(false);
+            const string Str = @"His name is {LAST_NAME}... {FIRST_NAME} {LAST_NAME}";
+            var formatted = mf.FormatMessage(
+                Str,
+                new Dictionary<string, object?> { { "FIRST_NAME", "James" }, { "LAST_NAME", "Bond" } });
+            Assert.Equal("His name is Bond... James Bond", formatted);
+        }
+
+        {
+            var mf = new MessageFormatter(false);
+            const string Str = @"{GENDER, select, male{He} female{She} other{They}} liked this.";
+            var formatted = mf.FormatMessage(Str, new Dictionary<string, object?> { { "GENDER", "male" } });
+            Assert.Equal("He liked this.", formatted);
+
+            formatted = mf.FormatMessage(Str, new Dictionary<string, object?> { { "GENDER", "female" } });
+            Assert.Equal("She liked this.", formatted);
+
+            formatted = mf.FormatMessage(Str, new Dictionary<string, object?> { { "GENDER", "somethingelse" } });
+            Assert.Equal("They liked this.", formatted);
+
+            formatted = mf.FormatMessage(Str, new Dictionary<string, object?> { { "GENDER", null } });
+            Assert.Equal("They liked this.", formatted);
+        }
+
+        {
+            var mf = new MessageFormatter(useCache: true, locale: "en");
+            mf.Pluralizers!["en"] = n =>
+            {
+                // ´n´ is the number being pluralized.
+                // ReSharper disable once CompareOfFloatsByEqualityOperator
+                if (n == 0)
+                {
+                    return "zero";
+                }
+
+                // ReSharper disable once CompareOfFloatsByEqualityOperator
+                if (n == 1)
+                {
+                    return "one";
+                }
+
+                if (n > 1000)
+                {
+                    return "thatsalot";
+                }
+
+                return "other";
+            };
+
+            var actual =
+                mf.FormatMessage(
+                    "You have {number, plural, thatsalot {a shitload of notifications} other {# notifications}}",
+                    new Dictionary<string, object?> { { "number", 1001 } });
+            Assert.Equal("You have a shitload of notifications", actual);
+        }
     }
+
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat.Tests/MessageFormatterIssues.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/MessageFormatterIssues.cs
@@ -7,70 +7,85 @@
 using System.Collections.Generic;
 using Xunit;
 
-namespace Jeffijoe.MessageFormat.Tests
+namespace Jeffijoe.MessageFormat.Tests;
+
+/// <summary>
+/// Issue cases.
+/// </summary>
+public class MessageFormatterIssues
 {
-    /// <summary>
-    /// Issue cases.
-    /// </summary>
-    public class MessageFormatterIssues
+    [Fact]
+    public void Issue13_Bad_escaping_on_pound_symbol()
     {
-        [Fact]
-        public void Issue13_Bad_escaping_on_pound_symbol()
-        {
-            string plural = @"{num_guests, plural, offset:1, other {# {host} invites # people to their party.}}";
-            string broken = @"{num_guests, plural, offset:1, other {{host} invites # people to their party.}}";
+        string plural = @"{num_guests, plural, offset:1, other {# {host} invites # people to their party.}}";
+        string broken = @"{num_guests, plural, offset:1, other {{host} invites # people to their party.}}";
 
-            var mf = new MessageFormatter();
-            var vars = new { num_guests = "5", host = "Mary" };
-            Assert.Equal("Mary invites 4 people to their party.", mf.FormatMessage(broken, vars));
-            Assert.Equal("4 Mary invites 4 people to their party.", mf.FormatMessage(plural, vars));
-        }
-        
-        [Fact]
-        public void Issue27_WhiteSpace_in_identifiers_is_ignored()
+        var mf = new MessageFormatter();
+        var vars = new { num_guests = "5", host = "Mary" };
+        Assert.Equal("Mary invites 4 people to their party.", mf.FormatMessage(broken, vars));
+        Assert.Equal("4 Mary invites 4 people to their party.", mf.FormatMessage(plural, vars));
+    }
+
+    [Fact]
+    public void Issue27_WhiteSpace_in_identifiers_is_ignored()
+    {
+        var subject = new MessageFormatter(false);
+        var result = subject.FormatMessage("{ count, plural , one {1 thing} other {# things} }", new
         {
-            var subject = new MessageFormatter(false);
-            var result = subject.FormatMessage("{ count, plural , one {1 thing} other {# things} }", new
+            count = 2
+        });
+
+        Assert.Equal("2 things", result);
+    }
+
+    [Fact]
+    public void Issue31_IDictionary_interface_support()
+    {
+        var subject = new MessageFormatter(locale: "en-US");
+
+        IDictionary<string, object> idict = new Dictionary<string, object>
+        {
+            ["string"] = "value"
+        };
+
+        IDictionary<string, object?> idictNullable = new Dictionary<string, object?>
+        {
+            ["string"] = "value"
+        };
+
+        Assert.Equal("value", subject.FormatMessage("{string}", idict));
+        Assert.Equal("value", subject.FormatMessage("{string}", idictNullable!));
+    }
+
+    [Fact]
+    public void Issue34_Newlines_are_stripped()
+    {
+        var subject = new MessageFormatter(locale: "en-US");
+
+        const string Expected = "Single text which will not change.\nSummary:\nAccepted\nData:\n-X\n-Y\n-Z";
+
+        var result = subject.FormatMessage(
+            "Single text which will not change.\nSummary:{acceptedData, select, NONE {} other {\nAccepted\nData:{acceptedData}}}",
+            new
             {
-                count = 2
+                acceptedData = "\n-X\n-Y\n-Z"
             });
+        Assert.Equal(Expected, result);
+    }
 
-            Assert.Equal("2 things", result);
-        }
+    [Fact]
+    public void Issue45_Url_should_not_be_parsed_as_extension()
+    {
+        var subject = new MessageFormatter(locale: "en-US");
 
-        [Fact]
-        public void Issue31_IDictionary_interface_support()
+        IDictionary<string, object> dict = new Dictionary<string, object>
         {
-            var subject = new MessageFormatter(locale: "en-US");
+            ["cond"] = "foo"
+        };
 
-            IDictionary<string, object> idict = new Dictionary<string, object>
-            {
-                ["string"] = "value"
-            };
-            
-            IDictionary<string, object?> idictNullable = new Dictionary<string, object?>
-            {
-                ["string"] = "value"
-            };
-
-            Assert.Equal("value", subject.FormatMessage("{string}", idict));
-            Assert.Equal("value", subject.FormatMessage("{string}", idictNullable!));
-        }
-        
-        [Fact]
-        public void Issue34_Newlines_are_stripped()
-        {
-            var subject = new MessageFormatter(locale: "en-US");
-
-            const string Expected = "Single text which will not change.\nSummary:\nAccepted\nData:\n-X\n-Y\n-Z";
-            
-            var result = subject.FormatMessage(
-                "Single text which will not change.\nSummary:{acceptedData, select, NONE {} other {\nAccepted\nData:{acceptedData}}}",
-                new
-                {
-                    acceptedData = "\n-X\n-Y\n-Z"
-                });
-            Assert.Equal(Expected, result);
-        }
+        var result = subject.FormatMessage(
+            "{cond, select, foo{https://www.google.com/} other{https://www.bing.com/}}",
+            dict);
+        Assert.Equal("https://www.google.com/", result);
     }
 }

--- a/src/Jeffijoe.MessageFormat.Tests/MessageFormatterStringExtensionTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/MessageFormatterStringExtensionTests.cs
@@ -8,37 +8,36 @@ using System.Threading.Tasks;
 
 using Xunit;
 
-namespace Jeffijoe.MessageFormat.Tests
+namespace Jeffijoe.MessageFormat.Tests;
+
+/// <summary>
+/// The message formatter string extension tests.
+/// </summary>
+public class MessageFormatterStringExtensionTests
 {
+    #region Public Methods and Operators
+
     /// <summary>
-    /// The message formatter string extension tests.
+    /// The format message_with_multiple_tasks.
     /// </summary>
-    public class MessageFormatterStringExtensionTests
+    /// <returns>
+    /// The <see cref="Task"/>.
+    /// </returns>
+    [Fact]
+    public async Task FormatMessage_with_multiple_tasks()
     {
-        #region Public Methods and Operators
+        var pattern = "Copying {fileCount, plural, one {one file} other{# files}}.";
 
-        /// <summary>
-        /// The format message_with_multiple_tasks.
-        /// </summary>
-        /// <returns>
-        /// The <see cref="Task"/>.
-        /// </returns>
-        [Fact]
-        public async Task FormatMessage_with_multiple_tasks()
-        {
-            var pattern = "Copying {fileCount, plural, one {one file} other{# files}}.";
+        // 2 with the same message to test there are no issues with caching with multiple threads.
+        var t1 = Task.Run(() => MessageFormatter.Format(pattern, new { fileCount = 1 }));
+        var t2 = Task.Run(() => MessageFormatter.Format(pattern, new { fileCount = 1 }));
+        var t3 = Task.Run(() => MessageFormatter.Format(pattern, new { fileCount = 5 }));
+        await Task.WhenAll(t1, t2, t3);
 
-            // 2 with the same message to test there are no issues with caching with multiple threads.
-            var t1 = Task.Run(() => MessageFormatter.Format(pattern, new { fileCount = 1 }));
-            var t2 = Task.Run(() => MessageFormatter.Format(pattern, new { fileCount = 1 }));
-            var t3 = Task.Run(() => MessageFormatter.Format(pattern, new { fileCount = 5 }));
-            await Task.WhenAll(t1, t2, t3);
-
-            Assert.Equal("Copying one file.", t1.Result);
-            Assert.Equal("Copying one file.", t2.Result);
-            Assert.Equal("Copying 5 files.", t3.Result);
-        }
-
-        #endregion
+        Assert.Equal("Copying one file.", t1.Result);
+        Assert.Equal("Copying one file.", t2.Result);
+        Assert.Equal("Copying 5 files.", t3.Result);
     }
+
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat.Tests/MessageFormatterTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/MessageFormatterTests.cs
@@ -12,111 +12,110 @@ using Jeffijoe.MessageFormat.Parsing;
 
 using Xunit;
 
-namespace Jeffijoe.MessageFormat.Tests
+namespace Jeffijoe.MessageFormat.Tests;
+
+/// <summary>
+///     The message formatter tests.
+/// </summary>
+public class MessageFormatterTests
 {
+    #region Public Methods and Operators
+
     /// <summary>
-    ///     The message formatter tests.
+    /// The format message.
     /// </summary>
-    public class MessageFormatterTests
+    [Fact]
+    public void FormatMessage()
     {
-        #region Public Methods and Operators
-
-        /// <summary>
-        /// The format message.
-        /// </summary>
-        [Fact]
-        public void FormatMessage()
-        {
-            const string Pattern = "{name} has {messages, plural, other {# messages}}.";
-            const string Expected = "Jeff has 123 messages.";
-            IReadOnlyDictionary<string, object?> args = new Dictionary<string, object?> { { "name", "Jeff" }, { "messages", 123} };
+        const string Pattern = "{name} has {messages, plural, other {# messages}}.";
+        const string Expected = "Jeff has 123 messages.";
+        IReadOnlyDictionary<string, object?> args = new Dictionary<string, object?> { { "name", "Jeff" }, { "messages", 123} };
             
-            var actual = MessageFormatter.Format(Pattern, args);
+        var actual = MessageFormatter.Format(Pattern, args);
             
-            Assert.Equal(Expected, actual);
-        }
-
-        /// <summary>
-        /// The unescape literals.
-        /// </summary>
-        /// <param name="source">
-        /// The source.
-        /// </param>
-        /// <param name="expected">
-        /// The expected.
-        /// </param>
-        [Theory]
-        [InlineData(@"Hello '{buddy}', how are you '{doing}'?", "Hello {buddy}, how are you {doing}?")]
-        [InlineData(@"Hello ''{buddy}'', how are you '{doing}'?", @"Hello '{buddy}', how are you {doing}?")]
-        [InlineData(@"{''}", @"{'}")]
-        public void UnescapeLiterals(string source, string expected)
-        {
-            var actual = MessageFormatter.UnescapeLiterals(new StringBuilder(source));
-            Assert.Equal(expected, actual);
-        }
-
-        /// <summary>
-        ///     Verifies that format message throws when variables are missing and the formatter requires it to exist.
-        /// </summary>
-        [Fact]
-        public void VerifyFormatMessageThrowsWhenVariablesAreMissingAndTheFormatterRequiresItToExist()
-        {
-            const string Pattern = "{name}";
-
-            // Note the missing "name" variable.
-            var args = new Dictionary<string, object?> { { "messages", 1 } };
-
-            var subject = new MessageFormatter();
-            
-            var ex = Assert.Throws<VariableNotFoundException>(() => subject.FormatMessage(Pattern, args));
-            Assert.Equal("name", ex.MissingVariable);
-        }
-        
-        /// <summary>
-        ///     Verifies that format message allows non-existent variables when formatter allows it.
-        /// </summary>
-        [Fact]
-        public void VerifyFormatMessageAllowsNonExistentVariablesWhenFormatterAllowsIt()
-        {
-            const string Pattern = "{name, fake}";
-
-            // Note the missing "name" variable.
-            var args = new Dictionary<string, object?> ();
-
-            var library = new FormatterLibrary();
-            library.Add(new TestFormatter(variableMustExist: false, formatterName: "fake"));
-            var subject = new MessageFormatter(new PatternParser(), library, useCache: false);
-
-            var actual = subject.FormatMessage(Pattern, args);
-            
-            Assert.Equal("formatted", actual);
-        }
-
-        #endregion
-
-        #region Fakes
-
-        private class TestFormatter : IFormatter
-        {
-            private readonly string formatterName;
-
-            public TestFormatter(bool variableMustExist, string formatterName)
-            {
-                this.VariableMustExist = variableMustExist;
-                this.formatterName = formatterName;
-            }
-            
-            public bool VariableMustExist { get; }
-
-            public bool CanFormat(FormatterRequest request) => request.FormatterName == this.formatterName;
-
-            public string Format(string locale, FormatterRequest request, IReadOnlyDictionary<string, object?> args, object? value,
-                IMessageFormatter messageFormatter)
-            {
-                return "formatted";
-            }
-        }
-
-        #endregion
+        Assert.Equal(Expected, actual);
     }
+
+    /// <summary>
+    /// The unescape literals.
+    /// </summary>
+    /// <param name="source">
+    /// The source.
+    /// </param>
+    /// <param name="expected">
+    /// The expected.
+    /// </param>
+    [Theory]
+    [InlineData(@"Hello '{buddy}', how are you '{doing}'?", "Hello {buddy}, how are you {doing}?")]
+    [InlineData(@"Hello ''{buddy}'', how are you '{doing}'?", @"Hello '{buddy}', how are you {doing}?")]
+    [InlineData(@"{''}", @"{'}")]
+    public void UnescapeLiterals(string source, string expected)
+    {
+        var actual = MessageFormatter.UnescapeLiterals(new StringBuilder(source));
+        Assert.Equal(expected, actual);
+    }
+
+    /// <summary>
+    ///     Verifies that format message throws when variables are missing and the formatter requires it to exist.
+    /// </summary>
+    [Fact]
+    public void VerifyFormatMessageThrowsWhenVariablesAreMissingAndTheFormatterRequiresItToExist()
+    {
+        const string Pattern = "{name}";
+
+        // Note the missing "name" variable.
+        var args = new Dictionary<string, object?> { { "messages", 1 } };
+
+        var subject = new MessageFormatter();
+            
+        var ex = Assert.Throws<VariableNotFoundException>(() => subject.FormatMessage(Pattern, args));
+        Assert.Equal("name", ex.MissingVariable);
+    }
+        
+    /// <summary>
+    ///     Verifies that format message allows non-existent variables when formatter allows it.
+    /// </summary>
+    [Fact]
+    public void VerifyFormatMessageAllowsNonExistentVariablesWhenFormatterAllowsIt()
+    {
+        const string Pattern = "{name, fake}";
+
+        // Note the missing "name" variable.
+        var args = new Dictionary<string, object?> ();
+
+        var library = new FormatterLibrary();
+        library.Add(new TestFormatter(variableMustExist: false, formatterName: "fake"));
+        var subject = new MessageFormatter(new PatternParser(), library, useCache: false);
+
+        var actual = subject.FormatMessage(Pattern, args);
+            
+        Assert.Equal("formatted", actual);
+    }
+
+    #endregion
+
+    #region Fakes
+
+    private class TestFormatter : IFormatter
+    {
+        private readonly string formatterName;
+
+        public TestFormatter(bool variableMustExist, string formatterName)
+        {
+            this.VariableMustExist = variableMustExist;
+            this.formatterName = formatterName;
+        }
+            
+        public bool VariableMustExist { get; }
+
+        public bool CanFormat(FormatterRequest request) => request.FormatterName == this.formatterName;
+
+        public string Format(string locale, FormatterRequest request, IReadOnlyDictionary<string, object?> args, object? value,
+            IMessageFormatter messageFormatter)
+        {
+            return "formatted";
+        }
+    }
+
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat.Tests/MessageFormatterUsingRealParserTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/MessageFormatterUsingRealParserTests.cs
@@ -13,50 +13,50 @@ using Jeffijoe.MessageFormat.Tests.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Jeffijoe.MessageFormat.Tests
+namespace Jeffijoe.MessageFormat.Tests;
+
+/// <summary>
+/// The message formatter_using_real_parser_ tests.
+/// </summary>
+public class MessageFormatterUsingRealParserTests
 {
+    #region Fields
+
     /// <summary>
-    /// The message formatter_using_real_parser_ tests.
+    /// The output helper.
     /// </summary>
-    public class MessageFormatterUsingRealParserTests
+    private ITestOutputHelper outputHelper;
+
+    #endregion
+
+    #region Constructors and Destructors
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MessageFormatterUsingRealParserTests"/> class.
+    /// </summary>
+    /// <param name="outputHelper">
+    /// The output helper.
+    /// </param>
+    public MessageFormatterUsingRealParserTests(ITestOutputHelper outputHelper)
     {
-        #region Fields
+        this.outputHelper = outputHelper;
+    }
 
-        /// <summary>
-        /// The output helper.
-        /// </summary>
-        private ITestOutputHelper outputHelper;
+    #endregion
 
-        #endregion
+    #region Public Methods and Operators
 
-        #region Constructors and Destructors
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MessageFormatterUsingRealParserTests"/> class.
-        /// </summary>
-        /// <param name="outputHelper">
-        /// The output helper.
-        /// </param>
-        public MessageFormatterUsingRealParserTests(ITestOutputHelper outputHelper)
-        {
-            this.outputHelper = outputHelper;
-        }
-
-        #endregion
-
-        #region Public Methods and Operators
-
-        /// <summary>
-        /// The format message_using_real_parser_and_library_mock.
-        /// </summary>
-        /// <param name="source">
-        /// The source.
-        /// </param>
-        /// <param name="expected">
-        /// The expected.
-        /// </param>
-        [Theory]
-        [InlineData(@"Hi, I'm {name}, and it's still {name, fake, whatever
+    /// <summary>
+    /// The format message_using_real_parser_and_library_mock.
+    /// </summary>
+    /// <param name="source">
+    /// The source.
+    /// </param>
+    /// <param name="expected">
+    /// The expected.
+    /// </param>
+    [Theory]
+    [InlineData(@"Hi, I'm {name}, and it's still {name, fake, whatever
 
 i do what i want
 
@@ -69,35 +69,34 @@ whatchu gonna do?
 whatchu gonna do when dey come for youu?
 
 }, ok?", "Hi, I'm Jeff, and it's still Jeff, ok?")]
-        public void FormatMessage_using_real_parser_and_library_mock(string source, string expected)
+    public void FormatMessage_using_real_parser_and_library_mock(string source, string expected)
+    {
+        var library = new FormatterLibrary();
+        var dummyFormatter = new FakeFormatter(canFormat:true, formatResult: "Jeff");
+        library.Add(dummyFormatter);
+        var subject = new MessageFormatter(
+            new PatternParser(new LiteralParser()), 
+            library,
+            false);
+
+        var args = new Dictionary<string, object?>();
+        args.Add("name", "Jeff");
+
+        // Warm up
+        Benchmark.Start("Warm-up", this.outputHelper);
+        subject.FormatMessage(source, args);
+        Benchmark.End(this.outputHelper);
+
+        Benchmark.Start("Aaaand a few after warm-up", this.outputHelper);
+        for (int i = 0; i < 1000; i++)
         {
-            var library = new FormatterLibrary();
-            var dummyFormatter = new FakeFormatter(canFormat:true, formatResult: "Jeff");
-            library.Add(dummyFormatter);
-            var subject = new MessageFormatter(
-                new PatternParser(new LiteralParser()), 
-                library,
-                false);
-
-            var args = new Dictionary<string, object?>();
-            args.Add("name", "Jeff");
-
-            // Warm up
-            Benchmark.Start("Warm-up", this.outputHelper);
             subject.FormatMessage(source, args);
-            Benchmark.End(this.outputHelper);
-
-            Benchmark.Start("Aaaand a few after warm-up", this.outputHelper);
-            for (int i = 0; i < 1000; i++)
-            {
-                subject.FormatMessage(source, args);
-            }
-
-            Benchmark.End(this.outputHelper);
-
-            Assert.Equal(expected, subject.FormatMessage(source, args));
         }
 
-        #endregion
+        Benchmark.End(this.outputHelper);
+
+        Assert.Equal(expected, subject.FormatMessage(source, args));
     }
+
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat.Tests/MetadataGenerator/GeneratedPluralRulesTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/MetadataGenerator/GeneratedPluralRulesTests.cs
@@ -5,81 +5,80 @@ using Jeffijoe.MessageFormat.Formatting.Formatters;
 using Jeffijoe.MessageFormat.Parsing;
 using Xunit;
 
-namespace Jeffijoe.MessageFormat.Tests.MetadataGenerator
-{
-    public class GeneratedPluralRulesTests
-    {
-        [Theory]
-        [InlineData(0, "днів")]
-        [InlineData(1, "день")]
-        [InlineData(101, "день")]
-        [InlineData(102, "дні")]
-        [InlineData(105, "днів")]
-        public void Uk_PluralizerTests(double n, string expected)
-        {
-            var subject = new PluralFormatter();
-            var args = new Dictionary<string, object> { { "test", n } };
-            var arguments =
-                new ParsedArguments(
-                    new[]
-                    {
-                        new KeyedBlock("one", "день"),
-                        new KeyedBlock("few", "дні"),
-                        new KeyedBlock("many", "днів"),
-                        new KeyedBlock("other", "дня")
-                    },
-                    new FormatterExtension[0]);
-            var request = new FormatterRequest(new Literal(1, 1, 1, 1, ""), "test", "plural", null);
-            var actual = subject.Pluralize("uk", arguments, new PluralContext(Convert.ToDecimal(Convert.ToDouble(args[request.Variable]))), 0);
-            Assert.Equal(expected, actual);
-        }
+namespace Jeffijoe.MessageFormat.Tests.MetadataGenerator;
 
-        [Theory]
-        [InlineData(0, "дней")]
-        [InlineData(1, "день")]
-        [InlineData(101, "день")]
-        [InlineData(102, "дня")]
-        [InlineData(105, "дней")]
-        public void Ru_PluralizerTests(double n, string expected)
-        {
-            var subject = new PluralFormatter();
-            var args = new Dictionary<string, object> { { "test", n } };
-            var arguments =
-                new ParsedArguments(
-                    new[]
-                    {
-                        new KeyedBlock("one", "день"),
-                        new KeyedBlock("few", "дня"),
-                        new KeyedBlock("many", "дней"),
-                        new KeyedBlock("other", "дня")
-                    },
-                    new FormatterExtension[0]);
-            var request = new FormatterRequest(new Literal(1, 1, 1, 1, ""), "test", "plural", null);
-            var actual = subject.Pluralize("ru", arguments, new PluralContext(Convert.ToDecimal(args[request.Variable])), 0);
-            Assert.Equal(expected, actual);
-        }
+public class GeneratedPluralRulesTests
+{
+    [Theory]
+    [InlineData(0, "днів")]
+    [InlineData(1, "день")]
+    [InlineData(101, "день")]
+    [InlineData(102, "дні")]
+    [InlineData(105, "днів")]
+    public void Uk_PluralizerTests(double n, string expected)
+    {
+        var subject = new PluralFormatter();
+        var args = new Dictionary<string, object> { { "test", n } };
+        var arguments =
+            new ParsedArguments(
+                new[]
+                {
+                    new KeyedBlock("one", "день"),
+                    new KeyedBlock("few", "дні"),
+                    new KeyedBlock("many", "днів"),
+                    new KeyedBlock("other", "дня")
+                },
+                new FormatterExtension[0]);
+        var request = new FormatterRequest(new Literal(1, 1, 1, 1, ""), "test", "plural", null);
+        var actual = subject.Pluralize("uk", arguments, new PluralContext(Convert.ToDecimal(Convert.ToDouble(args[request.Variable]))), 0);
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData(0, "дней")]
+    [InlineData(1, "день")]
+    [InlineData(101, "день")]
+    [InlineData(102, "дня")]
+    [InlineData(105, "дней")]
+    public void Ru_PluralizerTests(double n, string expected)
+    {
+        var subject = new PluralFormatter();
+        var args = new Dictionary<string, object> { { "test", n } };
+        var arguments =
+            new ParsedArguments(
+                new[]
+                {
+                    new KeyedBlock("one", "день"),
+                    new KeyedBlock("few", "дня"),
+                    new KeyedBlock("many", "дней"),
+                    new KeyedBlock("other", "дня")
+                },
+                new FormatterExtension[0]);
+        var request = new FormatterRequest(new Literal(1, 1, 1, 1, ""), "test", "plural", null);
+        var actual = subject.Pluralize("ru", arguments, new PluralContext(Convert.ToDecimal(args[request.Variable])), 0);
+        Assert.Equal(expected, actual);
+    }
         
-        [Theory]
-        [InlineData(0, "days")]
-        [InlineData(1, "day")]
-        [InlineData(101, "days")]
-        [InlineData(102, "days")]
-        [InlineData(105, "days")]
-        public void En_PluralizerTests(double n, string expected)
-        {
-            var subject = new PluralFormatter();
-            var args = new Dictionary<string, object> { { "test", n } };
-            var arguments =
-                new ParsedArguments(
-                    new[]
-                    {
-                        new KeyedBlock("one", "day"),
-                        new KeyedBlock("other", "days")
-                    },
-                    new FormatterExtension[0]);
-            var request = new FormatterRequest(new Literal(1, 1, 1, 1, ""), "test", "plural", null);
-            var actual = subject.Pluralize("en", arguments, new PluralContext(Convert.ToDecimal(args[request.Variable])), 0);
-            Assert.Equal(expected, actual);
-        }
+    [Theory]
+    [InlineData(0, "days")]
+    [InlineData(1, "day")]
+    [InlineData(101, "days")]
+    [InlineData(102, "days")]
+    [InlineData(105, "days")]
+    public void En_PluralizerTests(double n, string expected)
+    {
+        var subject = new PluralFormatter();
+        var args = new Dictionary<string, object> { { "test", n } };
+        var arguments =
+            new ParsedArguments(
+                new[]
+                {
+                    new KeyedBlock("one", "day"),
+                    new KeyedBlock("other", "days")
+                },
+                new FormatterExtension[0]);
+        var request = new FormatterRequest(new Literal(1, 1, 1, 1, ""), "test", "plural", null);
+        var actual = subject.Pluralize("en", arguments, new PluralContext(Convert.ToDecimal(args[request.Variable])), 0);
+        Assert.Equal(expected, actual);
     }
 }

--- a/src/Jeffijoe.MessageFormat.Tests/MetadataGenerator/ParserTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/MetadataGenerator/ParserTests.cs
@@ -7,14 +7,14 @@ using System.Xml;
 
 using Xunit;
 
-namespace Jeffijoe.MessageFormat.Tests.MetadataGenerator
+namespace Jeffijoe.MessageFormat.Tests.MetadataGenerator;
+
+public class ParserTests
 {
-    public class ParserTests
+    [Fact]
+    public void CanParseLocales()
     {
-        [Fact]
-        public void CanParseLocales()
-        {
-            var rules = ParseRules(@"
+        var rules = ParseRules(@"
 <supplementalData>
     <plurals type=""cardinal"">
         <pluralRules locales=""am as bn doi fa gu hi kn pcm zu"">
@@ -23,19 +23,19 @@ namespace Jeffijoe.MessageFormat.Tests.MetadataGenerator
 </supplementalData>
 ");
 
-            var rule = Assert.Single(rules);
-            var expected = new[]
-            {
-                "am", "as", "bn", "doi", "fa", "gu", "hi", "kn", "pcm", "zu"
-            };
-            var actual = rule.Locales;
-            Assert.Equal(actual, expected);
-        }
-
-        [Fact]
-        public void OtherCountIsIgnored()
+        var rule = Assert.Single(rules);
+        var expected = new[]
         {
-            var rules = ParseRules(@"
+            "am", "as", "bn", "doi", "fa", "gu", "hi", "kn", "pcm", "zu"
+        };
+        var actual = rule.Locales;
+        Assert.Equal(actual, expected);
+    }
+
+    [Fact]
+    public void OtherCountIsIgnored()
+    {
+        var rules = ParseRules(@"
 <supplementalData>
     <plurals type=""cardinal"">
         <pluralRules locales=""am"">
@@ -44,209 +44,209 @@ namespace Jeffijoe.MessageFormat.Tests.MetadataGenerator
     </plurals>
 </supplementalData>
 ");
-            var rule = Assert.Single(rules);
-            Assert.Empty(rule.Conditions);
-        }
+        var rule = Assert.Single(rules);
+        Assert.Empty(rule.Conditions);
+    }
 
-        [Fact]
-        public void CanParseSingleCount_RuleDescription_WithoutRelations()
-        {
-            var rules = ParseRules(GenerateXmlWithRuleContent("@integer 1, 21, 31, 41, 51, 61, 71, 81, 101, 1001, …"));
+    [Fact]
+    public void CanParseSingleCount_RuleDescription_WithoutRelations()
+    {
+        var rules = ParseRules(GenerateXmlWithRuleContent("@integer 1, 21, 31, 41, 51, 61, 71, 81, 101, 1001, …"));
 
-            var rule = Assert.Single(rules);
-            var condition = Assert.Single(rule.Conditions);
-            var expected = "@integer 1, 21, 31, 41, 51, 61, 71, 81, 101, 1001, …";
-            Assert.Equal(expected, condition.RuleDescription);
-        }
+        var rule = Assert.Single(rules);
+        var condition = Assert.Single(rule.Conditions);
+        var expected = "@integer 1, 21, 31, 41, 51, 61, 71, 81, 101, 1001, …";
+        Assert.Equal(expected, condition.RuleDescription);
+    }
 
-        [Fact]
-        public void CanParseSingleCount_VisibleDigitsNumber()
-        {
-            var rules = ParseRules(
-                GenerateXmlWithRuleContent(@"v = 0 @integer 1, 21, 31, 41, 51, 61, 71, 81, 101, 1001, …"));
-            var rule = Assert.Single(rules);
-            var condition = Assert.Single(rule.Conditions);
-            var orCondition = Assert.Single(condition.OrConditions);
-            var actual = Assert.Single(orCondition.AndConditions);
-            var expected = new Operation(new VariableOperand(OperandSymbol.VisibleFractionDigitNumber), Relation.Equals, new[] { new NumberOperand(0) });
+    [Fact]
+    public void CanParseSingleCount_VisibleDigitsNumber()
+    {
+        var rules = ParseRules(
+            GenerateXmlWithRuleContent(@"v = 0 @integer 1, 21, 31, 41, 51, 61, 71, 81, 101, 1001, …"));
+        var rule = Assert.Single(rules);
+        var condition = Assert.Single(rule.Conditions);
+        var orCondition = Assert.Single(condition.OrConditions);
+        var actual = Assert.Single(orCondition.AndConditions);
+        var expected = new Operation(new VariableOperand(OperandSymbol.VisibleFractionDigitNumber), Relation.Equals, new[] { new NumberOperand(0) });
 
-            AssertOperationEqual(expected, actual);
-        }
+        AssertOperationEqual(expected, actual);
+    }
 
-        [Fact]
-        public void CanParseSingleCount_IntegerDigits()
-        {
-            var rules = ParseRules(
-                GenerateXmlWithRuleContent(@"i = 0 @integer 1, 21, 31, 41, 51, 61, 71, 81, 101, 1001, …"));
-            var rule = Assert.Single(rules);
-            var condition = Assert.Single(rule.Conditions);
-            var orCondition = Assert.Single(condition.OrConditions);
-            var actual = Assert.Single(orCondition.AndConditions);
-            var expected = new Operation(new VariableOperand(OperandSymbol.IntegerDigits), Relation.Equals, new[] { new NumberOperand(0) });
+    [Fact]
+    public void CanParseSingleCount_IntegerDigits()
+    {
+        var rules = ParseRules(
+            GenerateXmlWithRuleContent(@"i = 0 @integer 1, 21, 31, 41, 51, 61, 71, 81, 101, 1001, …"));
+        var rule = Assert.Single(rules);
+        var condition = Assert.Single(rule.Conditions);
+        var orCondition = Assert.Single(condition.OrConditions);
+        var actual = Assert.Single(orCondition.AndConditions);
+        var expected = new Operation(new VariableOperand(OperandSymbol.IntegerDigits), Relation.Equals, new[] { new NumberOperand(0) });
 
-            AssertOperationEqual(expected, actual);
-        }
+        AssertOperationEqual(expected, actual);
+    }
 
-        [Fact]
-        public void CanParseSingleCount_AbsoluteNumber()
-        {
-            var rules = ParseRules(
-                GenerateXmlWithRuleContent("n = 1 @integer 1, 21, 31, 41, 51, 61, 71, 81, 101, 1001, …"));
-            var rule = Assert.Single(rules);
-            var condition = Assert.Single(rule.Conditions);
-            var orCondition = Assert.Single(condition.OrConditions);
-            var actual = Assert.Single(orCondition.AndConditions);
-            var expected = new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), Relation.Equals, new[] {new NumberOperand(1) });
+    [Fact]
+    public void CanParseSingleCount_AbsoluteNumber()
+    {
+        var rules = ParseRules(
+            GenerateXmlWithRuleContent("n = 1 @integer 1, 21, 31, 41, 51, 61, 71, 81, 101, 1001, …"));
+        var rule = Assert.Single(rules);
+        var condition = Assert.Single(rule.Conditions);
+        var orCondition = Assert.Single(condition.OrConditions);
+        var actual = Assert.Single(orCondition.AndConditions);
+        var expected = new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), Relation.Equals, new[] {new NumberOperand(1) });
 
-            AssertOperationEqual(expected, actual);
-        }
+        AssertOperationEqual(expected, actual);
+    }
 
-        [Theory]
-        [InlineData("n = 2 @integer 1, 21, 31, 41, 51, 61, 71, 81, 101, 1001, …", Relation.Equals)]
-        [InlineData("n != 2 @integer 1, 21, 31, 41, 51, 61, 71, 81, 101, 1001, …", Relation.NotEquals)]
-        public void CanParseVariousRelations(string ruleText, Relation expectedRelation)
-        {
-            var rules = ParseRules(GenerateXmlWithRuleContent(ruleText));
-            var rule = Assert.Single(rules);
-            var condition = Assert.Single(rule.Conditions);
-            var orCondition = Assert.Single(condition.OrConditions);
-            var actual = Assert.Single(orCondition.AndConditions);
-            var expected = new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), expectedRelation, new[] { new NumberOperand(2) });
+    [Theory]
+    [InlineData("n = 2 @integer 1, 21, 31, 41, 51, 61, 71, 81, 101, 1001, …", Relation.Equals)]
+    [InlineData("n != 2 @integer 1, 21, 31, 41, 51, 61, 71, 81, 101, 1001, …", Relation.NotEquals)]
+    public void CanParseVariousRelations(string ruleText, Relation expectedRelation)
+    {
+        var rules = ParseRules(GenerateXmlWithRuleContent(ruleText));
+        var rule = Assert.Single(rules);
+        var condition = Assert.Single(rule.Conditions);
+        var orCondition = Assert.Single(condition.OrConditions);
+        var actual = Assert.Single(orCondition.AndConditions);
+        var expected = new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), expectedRelation, new[] { new NumberOperand(2) });
 
-            AssertOperationEqual(expected, actual);
-        }
+        AssertOperationEqual(expected, actual);
+    }
 
-        [Fact]
-        public void CanParseOrRules()
-        {
-            var rules = ParseRules(GenerateXmlWithRuleContent("n = 2 or n = 1 or n = 0 @integer 1, 21, 31, 41, 51, 61, 71, 81, 101, 1001, …"));
-            var rule = Assert.Single(rules);
-            var condition = Assert.Single(rule.Conditions);
+    [Fact]
+    public void CanParseOrRules()
+    {
+        var rules = ParseRules(GenerateXmlWithRuleContent("n = 2 or n = 1 or n = 0 @integer 1, 21, 31, 41, 51, 61, 71, 81, 101, 1001, …"));
+        var rule = Assert.Single(rules);
+        var condition = Assert.Single(rule.Conditions);
             
-            Assert.Equal(3, condition.OrConditions.Count);
+        Assert.Equal(3, condition.OrConditions.Count);
 
-            var actualFirst = Assert.Single(condition.OrConditions[0].AndConditions);
-            var expectedFirst = new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), Relation.Equals, new[] { new NumberOperand(2) });
-            AssertOperationEqual(expectedFirst, actualFirst);
+        var actualFirst = Assert.Single(condition.OrConditions[0].AndConditions);
+        var expectedFirst = new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), Relation.Equals, new[] { new NumberOperand(2) });
+        AssertOperationEqual(expectedFirst, actualFirst);
 
-            var actualSecond = Assert.Single(condition.OrConditions[1].AndConditions);
-            var expectedSecond = new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), Relation.Equals, new[] { new NumberOperand(1) });
-            AssertOperationEqual(expectedSecond, actualSecond);
+        var actualSecond = Assert.Single(condition.OrConditions[1].AndConditions);
+        var expectedSecond = new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), Relation.Equals, new[] { new NumberOperand(1) });
+        AssertOperationEqual(expectedSecond, actualSecond);
 
-            var actualThird = Assert.Single(condition.OrConditions[2].AndConditions);
-            var expectedThird = new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), Relation.Equals, new[] { new NumberOperand(0) });
-            AssertOperationEqual(expectedThird, actualThird);
-        }
+        var actualThird = Assert.Single(condition.OrConditions[2].AndConditions);
+        var expectedThird = new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), Relation.Equals, new[] { new NumberOperand(0) });
+        AssertOperationEqual(expectedThird, actualThird);
+    }
 
-        [Fact]
-        public void CanParseAndRules()
-        {
-            var rules = ParseRules(GenerateXmlWithRuleContent("n = 2 and n = 1 and n = 0 @integer 1, 21, 31, 41, 51, 61, 71, 81, 101, 1001, …"));
-            var rule = Assert.Single(rules);
-            var condition = Assert.Single(rule.Conditions);
+    [Fact]
+    public void CanParseAndRules()
+    {
+        var rules = ParseRules(GenerateXmlWithRuleContent("n = 2 and n = 1 and n = 0 @integer 1, 21, 31, 41, 51, 61, 71, 81, 101, 1001, …"));
+        var rule = Assert.Single(rules);
+        var condition = Assert.Single(rule.Conditions);
 
-            var orCondition = Assert.Single(condition.OrConditions);
-            Assert.Equal(3, orCondition.AndConditions.Count);
+        var orCondition = Assert.Single(condition.OrConditions);
+        Assert.Equal(3, orCondition.AndConditions.Count);
 
-            var actualFirst = orCondition.AndConditions[0];
-            var expectedFirst = new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), Relation.Equals, new[] { new NumberOperand(2) });
-            AssertOperationEqual(expectedFirst, actualFirst);
+        var actualFirst = orCondition.AndConditions[0];
+        var expectedFirst = new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), Relation.Equals, new[] { new NumberOperand(2) });
+        AssertOperationEqual(expectedFirst, actualFirst);
 
-            var actualSecond = orCondition.AndConditions[1];
-            var expectedSecond = new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), Relation.Equals, new[] { new NumberOperand(1) });
-            AssertOperationEqual(expectedSecond, actualSecond);
+        var actualSecond = orCondition.AndConditions[1];
+        var expectedSecond = new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), Relation.Equals, new[] { new NumberOperand(1) });
+        AssertOperationEqual(expectedSecond, actualSecond);
 
-            var actualThird = orCondition.AndConditions[2];
-            var expectedThird = new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), Relation.Equals, new[] { new NumberOperand(0) });
-            AssertOperationEqual(expectedThird, actualThird);
-        }
+        var actualThird = orCondition.AndConditions[2];
+        var expectedThird = new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), Relation.Equals, new[] { new NumberOperand(0) });
+        AssertOperationEqual(expectedThird, actualThird);
+    }
 
-        [Fact]
-        public void CanParseModuloInLeftOperator()
-        {
-            var rules = ParseRules(
-                GenerateXmlWithRuleContent("n % 5 = 3 @integer 1, 21, 31, 41, 51, 61, 71, 81, 101, 1001, …"));
-            var rule = Assert.Single(rules);
-            var condition = Assert.Single(rule.Conditions);
-            var orCondition = Assert.Single(condition.OrConditions);
-            var actual = Assert.Single(orCondition.AndConditions);
-            var modulo = new ModuloOperand(OperandSymbol.AbsoluteValue, 5);
-            var expected = new Operation(modulo, Relation.Equals, new[] { new NumberOperand(3) });
+    [Fact]
+    public void CanParseModuloInLeftOperator()
+    {
+        var rules = ParseRules(
+            GenerateXmlWithRuleContent("n % 5 = 3 @integer 1, 21, 31, 41, 51, 61, 71, 81, 101, 1001, …"));
+        var rule = Assert.Single(rules);
+        var condition = Assert.Single(rule.Conditions);
+        var orCondition = Assert.Single(condition.OrConditions);
+        var actual = Assert.Single(orCondition.AndConditions);
+        var modulo = new ModuloOperand(OperandSymbol.AbsoluteValue, 5);
+        var expected = new Operation(modulo, Relation.Equals, new[] { new NumberOperand(3) });
 
-            AssertOperationEqual(expected, actual);
-        }
+        AssertOperationEqual(expected, actual);
+    }
 
-        [Fact]
-        public void CanParseRangeInRightOperator()
-        {
-            var rules = ParseRules(
-                GenerateXmlWithRuleContent("n = 3..5 @integer 1, 21, 31, 41, 51, 61, 71, 81, 101, 1001, …"));
-            var rule = Assert.Single(rules);
-            var condition = Assert.Single(rule.Conditions);
-            var orCondition = Assert.Single(condition.OrConditions);
-            var actual = Assert.Single(orCondition.AndConditions);
-            var range = new[] { new RangeOperand(3, 5) };
-            var expected = new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), Relation.Equals, range);
+    [Fact]
+    public void CanParseRangeInRightOperator()
+    {
+        var rules = ParseRules(
+            GenerateXmlWithRuleContent("n = 3..5 @integer 1, 21, 31, 41, 51, 61, 71, 81, 101, 1001, …"));
+        var rule = Assert.Single(rules);
+        var condition = Assert.Single(rule.Conditions);
+        var orCondition = Assert.Single(condition.OrConditions);
+        var actual = Assert.Single(orCondition.AndConditions);
+        var range = new[] { new RangeOperand(3, 5) };
+        var expected = new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), Relation.Equals, range);
 
-            AssertOperationEqual(expected, actual);
-        }
+        AssertOperationEqual(expected, actual);
+    }
 
-        [Fact]
-        public void CanParseCommaSeparatedInRightOperator()
-        {
-            var rules = ParseRules(
-                GenerateXmlWithRuleContent("n = 3,5,8, 10 @integer 1, 21, 31, 41, 51, 61, 71, 81, 101, 1001, …"));
-            var rule = Assert.Single(rules);
-            var condition = Assert.Single(rule.Conditions);
-            var orCondition = Assert.Single(condition.OrConditions);
-            var actual = Assert.Single(orCondition.AndConditions);
-            var range = new[] { new NumberOperand(3), new NumberOperand(5), new NumberOperand(8), new NumberOperand(10) };
-            var expected = new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), Relation.Equals, range);
+    [Fact]
+    public void CanParseCommaSeparatedInRightOperator()
+    {
+        var rules = ParseRules(
+            GenerateXmlWithRuleContent("n = 3,5,8, 10 @integer 1, 21, 31, 41, 51, 61, 71, 81, 101, 1001, …"));
+        var rule = Assert.Single(rules);
+        var condition = Assert.Single(rule.Conditions);
+        var orCondition = Assert.Single(condition.OrConditions);
+        var actual = Assert.Single(orCondition.AndConditions);
+        var range = new[] { new NumberOperand(3), new NumberOperand(5), new NumberOperand(8), new NumberOperand(10) };
+        var expected = new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), Relation.Equals, range);
 
-            AssertOperationEqual(expected, actual);
-        }
+        AssertOperationEqual(expected, actual);
+    }
 
-        [Fact]
-        public void CanParseMixedCommaSeparatedAndRangeInRightOperator()
-        {
-            var rules = ParseRules(
-                GenerateXmlWithRuleContent("n = 3,5..7,12,15 @integer 1, 21, 31, 41, 51, 61, 71, 81, 101, 1001, …"));
-            var rule = Assert.Single(rules);
-            var condition = Assert.Single(rule.Conditions);
-            var orCondition = Assert.Single(condition.OrConditions);
-            var actual = Assert.Single(orCondition.AndConditions);
-            var range = new IRightOperand[] { new NumberOperand(3), new RangeOperand(5, 7), new NumberOperand(12), new NumberOperand(15) };
-            var expected = new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), Relation.Equals, range);
+    [Fact]
+    public void CanParseMixedCommaSeparatedAndRangeInRightOperator()
+    {
+        var rules = ParseRules(
+            GenerateXmlWithRuleContent("n = 3,5..7,12,15 @integer 1, 21, 31, 41, 51, 61, 71, 81, 101, 1001, …"));
+        var rule = Assert.Single(rules);
+        var condition = Assert.Single(rule.Conditions);
+        var orCondition = Assert.Single(condition.OrConditions);
+        var actual = Assert.Single(orCondition.AndConditions);
+        var range = new IRightOperand[] { new NumberOperand(3), new RangeOperand(5, 7), new NumberOperand(12), new NumberOperand(15) };
+        var expected = new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), Relation.Equals, range);
 
-            AssertOperationEqual(expected, actual);
-        }
+        AssertOperationEqual(expected, actual);
+    }
 
-        [Theory]
-        [InlineData('n', OperandSymbol.AbsoluteValue)]
-        [InlineData('i', OperandSymbol.IntegerDigits)]
-        [InlineData('v', OperandSymbol.VisibleFractionDigitNumber)]
-        [InlineData('w', OperandSymbol.VisibleFractionDigitNumberWithoutTrailingZeroes)]
-        [InlineData('f', OperandSymbol.VisibleFractionDigits)]
-        [InlineData('t', OperandSymbol.VisibleFractionDigitsWithoutTrailingZeroes)]
-        [InlineData('c', OperandSymbol.ExponentC)]
-        [InlineData('e', OperandSymbol.ExponentE)]
-        public void MapsVariable_ToCorrectOperator(char variable, OperandSymbol symbol)
-        {
-            var rules = ParseRules(
-                GenerateXmlWithRuleContent($"{variable} = 3"));
-            var rule = Assert.Single(rules);
-            var condition = Assert.Single(rule.Conditions);
-            var orCondition = Assert.Single(condition.OrConditions);
-            var actual = Assert.Single(orCondition.AndConditions);
-            var right = new IRightOperand[] { new NumberOperand(3) };
-            var expected = new Operation(new VariableOperand(symbol), Relation.Equals, right);
+    [Theory]
+    [InlineData('n', OperandSymbol.AbsoluteValue)]
+    [InlineData('i', OperandSymbol.IntegerDigits)]
+    [InlineData('v', OperandSymbol.VisibleFractionDigitNumber)]
+    [InlineData('w', OperandSymbol.VisibleFractionDigitNumberWithoutTrailingZeroes)]
+    [InlineData('f', OperandSymbol.VisibleFractionDigits)]
+    [InlineData('t', OperandSymbol.VisibleFractionDigitsWithoutTrailingZeroes)]
+    [InlineData('c', OperandSymbol.ExponentC)]
+    [InlineData('e', OperandSymbol.ExponentE)]
+    public void MapsVariable_ToCorrectOperator(char variable, OperandSymbol symbol)
+    {
+        var rules = ParseRules(
+            GenerateXmlWithRuleContent($"{variable} = 3"));
+        var rule = Assert.Single(rules);
+        var condition = Assert.Single(rule.Conditions);
+        var orCondition = Assert.Single(condition.OrConditions);
+        var actual = Assert.Single(orCondition.AndConditions);
+        var right = new IRightOperand[] { new NumberOperand(3) };
+        var expected = new Operation(new VariableOperand(symbol), Relation.Equals, right);
 
-            AssertOperationEqual(expected, actual);
-        }
+        AssertOperationEqual(expected, actual);
+    }
 
-        private static string GenerateXmlWithRuleContent(string ruleText)
-        {
-            return $@"
+    private static string GenerateXmlWithRuleContent(string ruleText)
+    {
+        return $@"
 <supplementalData>
     <plurals type=""cardinal"">
         <pluralRules locales=""am"">
@@ -255,23 +255,22 @@ namespace Jeffijoe.MessageFormat.Tests.MetadataGenerator
     </plurals>
 </supplementalData>
 ";
-        }
+    }
 
-        private static void AssertOperationEqual(Operation expected, Operation actual)
-        {
-            Assert.Equal(expected.OperandLeft, actual.OperandLeft);
-            Assert.Equal(expected.Relation, actual.Relation);
-            Assert.Equal(expected.OperandRight, actual.OperandRight);
-        }
+    private static void AssertOperationEqual(Operation expected, Operation actual)
+    {
+        Assert.Equal(expected.OperandLeft, actual.OperandLeft);
+        Assert.Equal(expected.Relation, actual.Relation);
+        Assert.Equal(expected.OperandRight, actual.OperandRight);
+    }
 
-        private static IEnumerable<PluralRule> ParseRules(string xmlText)
-        {
-            var xml = new XmlDocument();
-            xml.LoadXml(xmlText);
+    private static IEnumerable<PluralRule> ParseRules(string xmlText)
+    {
+        var xml = new XmlDocument();
+        xml.LoadXml(xmlText);
 
-            var parser = new PluralParser(xml, Array.Empty<string>());
+        var parser = new PluralParser(xml, Array.Empty<string>());
 
-            return parser.Parse();
-        }
+        return parser.Parse();
     }
 }

--- a/src/Jeffijoe.MessageFormat.Tests/MetadataGenerator/PluralContextTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/MetadataGenerator/PluralContextTests.cs
@@ -1,109 +1,108 @@
 ﻿using Jeffijoe.MessageFormat.Formatting.Formatters;
 using Xunit;
 
-namespace Jeffijoe.MessageFormat.Tests.MetadataGenerator
+namespace Jeffijoe.MessageFormat.Tests.MetadataGenerator;
+
+public class PluralContextTests
 {
-    public class PluralContextTests
+    [Theory]
+    [InlineData("-12312.213213", 12312.213213)]
+    [InlineData("12312.213213", 12312.213213)]
+    [InlineData("-12312", 12312)]
+    [InlineData("12312", 12312)]
+    [InlineData("0", 0)]
+    public void Parses_N(string s, double expectedN)
     {
-        [Theory]
-        [InlineData("-12312.213213", 12312.213213)]
-        [InlineData("12312.213213", 12312.213213)]
-        [InlineData("-12312", 12312)]
-        [InlineData("12312", 12312)]
-        [InlineData("0", 0)]
-        public void Parses_N(string s, double expectedN)
-        {
-            var ctx = new PluralContext(s);
+        var ctx = new PluralContext(s);
 
-            Assert.Equal(expectedN, ctx.N);
-        }
+        Assert.Equal(expectedN, ctx.N);
+    }
 
-        [Theory]
-        [InlineData("-12312.213213", -12312)]
-        [InlineData("12312.213213", 12312)]
-        [InlineData("-12312", -12312)]
-        [InlineData("12312", 12312)]
-        [InlineData("0", 0)]
-        public void Parses_I(string s, double expectedI)
-        {
-            var ctx = new PluralContext(s);
+    [Theory]
+    [InlineData("-12312.213213", -12312)]
+    [InlineData("12312.213213", 12312)]
+    [InlineData("-12312", -12312)]
+    [InlineData("12312", 12312)]
+    [InlineData("0", 0)]
+    public void Parses_I(string s, double expectedI)
+    {
+        var ctx = new PluralContext(s);
 
-            Assert.Equal(expectedI, ctx.I);
-        }
+        Assert.Equal(expectedI, ctx.I);
+    }
 
-        [Theory]
-        [InlineData("-12312.213213", 6)]
-        [InlineData("12312.213213", 6)]
-        [InlineData("12312.2132130", 7)]
-        [InlineData("-12312", 0)]
-        [InlineData("12312", 0)]
-        [InlineData("0", 0)]
-        public void Parses_V(string s, double expectedV)
-        {
-            var ctx = new PluralContext(s);
+    [Theory]
+    [InlineData("-12312.213213", 6)]
+    [InlineData("12312.213213", 6)]
+    [InlineData("12312.2132130", 7)]
+    [InlineData("-12312", 0)]
+    [InlineData("12312", 0)]
+    [InlineData("0", 0)]
+    public void Parses_V(string s, double expectedV)
+    {
+        var ctx = new PluralContext(s);
 
-            Assert.Equal(expectedV, ctx.V);
-        }
+        Assert.Equal(expectedV, ctx.V);
+    }
 
-        [Theory]
-        [InlineData("-12312.213213", 6)]
-        [InlineData("12312.213213", 6)]
-        [InlineData("12312.2132130", 6)]
-        [InlineData("-12312", 0)]
-        [InlineData("12312", 0)]
-        [InlineData("0", 0)]
-        public void Parses_W(string s, double expectedW)
-        {
-            var ctx = new PluralContext(s);
+    [Theory]
+    [InlineData("-12312.213213", 6)]
+    [InlineData("12312.213213", 6)]
+    [InlineData("12312.2132130", 6)]
+    [InlineData("-12312", 0)]
+    [InlineData("12312", 0)]
+    [InlineData("0", 0)]
+    public void Parses_W(string s, double expectedW)
+    {
+        var ctx = new PluralContext(s);
 
-            Assert.Equal(expectedW, ctx.W);
-        }
+        Assert.Equal(expectedW, ctx.W);
+    }
 
-        [Theory]
-        [InlineData("-12312.213213", 213213)]
-        [InlineData("12312.213213", 213213)]
-        [InlineData("12312.2132130", 2132130)]
-        [InlineData("-12312", 0)]
-        [InlineData("12312", 0)]
-        [InlineData("0", 0)]
-        public void Parses_F(string s, double expectedF)
-        {
-            var ctx = new PluralContext(s);
+    [Theory]
+    [InlineData("-12312.213213", 213213)]
+    [InlineData("12312.213213", 213213)]
+    [InlineData("12312.2132130", 2132130)]
+    [InlineData("-12312", 0)]
+    [InlineData("12312", 0)]
+    [InlineData("0", 0)]
+    public void Parses_F(string s, double expectedF)
+    {
+        var ctx = new PluralContext(s);
 
-            Assert.Equal(expectedF, ctx.F);
-        }
+        Assert.Equal(expectedF, ctx.F);
+    }
 
-        [Theory]
-        [InlineData("-12312.213213", 213213)]
-        [InlineData("12312.213213", 213213)]
-        [InlineData("12312.2132130", 213213)]
-        [InlineData("-12312", 0)]
-        [InlineData("12312", 0)]
-        [InlineData("0", 0)]
-        public void Parses_T(string s, double expectedT)
-        {
-            var ctx = new PluralContext(s);
+    [Theory]
+    [InlineData("-12312.213213", 213213)]
+    [InlineData("12312.213213", 213213)]
+    [InlineData("12312.2132130", 213213)]
+    [InlineData("-12312", 0)]
+    [InlineData("12312", 0)]
+    [InlineData("0", 0)]
+    public void Parses_T(string s, double expectedT)
+    {
+        var ctx = new PluralContext(s);
 
-            Assert.Equal(expectedT, ctx.T);
-        }
+        Assert.Equal(expectedT, ctx.T);
+    }
 
 
-        /// <summary>
-        /// Exponents not supported yet
-        /// </summary>
-        [Theory]
-        [InlineData("-12312.213213", 0)]
-        [InlineData("12312.213213", 0)]
-        [InlineData("12312.2132130", 0)]
-        [InlineData("-12312", 0)]
-        [InlineData("12312", 0)]
-        [InlineData("0", 0)]
-        public void Parses_C_And_E(string s, double expectedC)
-        {
-            var ctx = new PluralContext(s);
+    /// <summary>
+    /// Exponents not supported yet
+    /// </summary>
+    [Theory]
+    [InlineData("-12312.213213", 0)]
+    [InlineData("12312.213213", 0)]
+    [InlineData("12312.2132130", 0)]
+    [InlineData("-12312", 0)]
+    [InlineData("12312", 0)]
+    [InlineData("0", 0)]
+    public void Parses_C_And_E(string s, double expectedC)
+    {
+        var ctx = new PluralContext(s);
 
-            Assert.Equal(expectedC, ctx.C);
-            Assert.Equal(expectedC, ctx.E);
-        }
+        Assert.Equal(expectedC, ctx.C);
+        Assert.Equal(expectedC, ctx.E);
     }
 }

--- a/src/Jeffijoe.MessageFormat.Tests/MetadataGenerator/PluralMetadataClassGeneratorTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/MetadataGenerator/PluralMetadataClassGeneratorTests.cs
@@ -3,16 +3,16 @@ using Jeffijoe.MessageFormat.MetadataGenerator.Plural.SourceGeneration;
 
 using Xunit;
 
-namespace Jeffijoe.MessageFormat.Tests.MetadataGenerator
+namespace Jeffijoe.MessageFormat.Tests.MetadataGenerator;
+
+public class PluralMetadataClassGeneratorTests
 {
-    public class PluralMetadataClassGeneratorTests
+    [Fact]
+    public void CanGenerateClassFromRules()
     {
-        [Fact]
-        public void CanGenerateClassFromRules()
+        var rules = new[]
         {
-            var rules = new[]
-            {
-                new PluralRule(new[] {"en", "uk"},
+            new PluralRule(new[] {"en", "uk"},
                 new[]
                 {
                     new Condition("one", string.Empty, new []
@@ -23,12 +23,12 @@ namespace Jeffijoe.MessageFormat.Tests.MetadataGenerator
                         })
                     })
                 })
-            };
-            var generator = new PluralRulesMetadataGenerator(rules);
+        };
+        var generator = new PluralRulesMetadataGenerator(rules);
 
-            var actual = generator.GenerateClass();
+        var actual = generator.GenerateClass();
 
-            var expected = @"
+        var expected = @"
 using System;
 using System.Collections.Generic;
 namespace Jeffijoe.MessageFormat.Formatting.Formatters
@@ -62,7 +62,6 @@ namespace Jeffijoe.MessageFormat.Formatting.Formatters
 }
 ".TrimStart();
 
-            Assert.Equal(expected, actual);
-        }
+        Assert.Equal(expected, actual);
     }
 }

--- a/src/Jeffijoe.MessageFormat.Tests/MetadataGenerator/RuleSourceGeneratorTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/MetadataGenerator/RuleSourceGeneratorTests.cs
@@ -6,331 +6,330 @@ using System.Text;
 
 using Xunit;
 
-namespace Jeffijoe.MessageFormat.Tests.MetadataGenerator
+namespace Jeffijoe.MessageFormat.Tests.MetadataGenerator;
+
+public class RuleSourceGeneratorTests
 {
-    public class RuleSourceGeneratorTests
+    [Fact]
+    public void CanGenerateEmptyRule()
     {
-        [Fact]
-        public void CanGenerateEmptyRule()
-        {
-            var generator = new RuleGenerator(new PluralRule(new[] { "en" }, Array.Empty<Condition>()));
+        var generator = new RuleGenerator(new PluralRule(new[] { "en" }, Array.Empty<Condition>()));
 
-            var actual = GenerateText(generator);
-            var expected = $"return \"other\";{Environment.NewLine}";
-            Assert.Equal(expected, actual);
-        }
+        var actual = GenerateText(generator);
+        var expected = $"return \"other\";{Environment.NewLine}";
+        Assert.Equal(expected, actual);
+    }
 
-        [Fact]
-        public void CanGenerateRuleForFractionNumberEquals()
+    [Fact]
+    public void CanGenerateRuleForFractionNumberEquals()
+    {
+        var generator = new RuleGenerator(new PluralRule(new[] { "en" }, new[]
         {
-            var generator = new RuleGenerator(new PluralRule(new[] { "en" }, new[]
+            new Condition("one", string.Empty, new[]
             {
-                new Condition("one", string.Empty, new[]
+                new OrCondition(new []
                 {
-                    new OrCondition(new []
-                    {
-                        new Operation(new VariableOperand(OperandSymbol.VisibleFractionDigitNumber), Relation.Equals, new[] { new NumberOperand(0) })
-                    })
+                    new Operation(new VariableOperand(OperandSymbol.VisibleFractionDigitNumber), Relation.Equals, new[] { new NumberOperand(0) })
                 })
-            }));
+            })
+        }));
 
-            var actual = GenerateText(generator);
-            var expected = @$"
+        var actual = GenerateText(generator);
+        var expected = @$"
 if ((context.V == 0))
     return ""one"";
 
 return ""other"";
 ".TrimStart();
-            Assert.Equal(expected, actual);
-        }
+        Assert.Equal(expected, actual);
+    }
 
-        [Fact]
-        public void CanGenerateRuleForIntegerDigitsEquals()
+    [Fact]
+    public void CanGenerateRuleForIntegerDigitsEquals()
+    {
+        var generator = new RuleGenerator(new PluralRule(new[] { "en" }, new[]
         {
-            var generator = new RuleGenerator(new PluralRule(new[] { "en" }, new[]
+            new Condition("one", string.Empty, new[]
             {
-                new Condition("one", string.Empty, new[]
+                new OrCondition(new []
                 {
-                    new OrCondition(new []
-                    {
-                        new Operation(new VariableOperand(OperandSymbol.IntegerDigits), Relation.Equals, new[] { new NumberOperand(1) })
-                    })
+                    new Operation(new VariableOperand(OperandSymbol.IntegerDigits), Relation.Equals, new[] { new NumberOperand(1) })
                 })
-            }));
+            })
+        }));
 
-            var actual = GenerateText(generator);
-            var expected = @$"
+        var actual = GenerateText(generator);
+        var expected = @$"
 if ((context.I == 1))
     return ""one"";
 
 return ""other"";
 ".TrimStart();
-            Assert.Equal(expected, actual);
-        }
+        Assert.Equal(expected, actual);
+    }
 
-        [Fact]
-        public void CanGenerateRuleForModuloEquals()
+    [Fact]
+    public void CanGenerateRuleForModuloEquals()
+    {
+        var generator = new RuleGenerator(new PluralRule(new[] { "en" }, new[]
         {
-            var generator = new RuleGenerator(new PluralRule(new[] { "en" }, new[]
+            new Condition("one", string.Empty, new[]
             {
-                new Condition("one", string.Empty, new[]
+                new OrCondition(new []
                 {
-                    new OrCondition(new []
-                    {
-                        new Operation(new ModuloOperand(OperandSymbol.IntegerDigits, 5), Relation.Equals, new[] { new NumberOperand(1) })
-                    })
+                    new Operation(new ModuloOperand(OperandSymbol.IntegerDigits, 5), Relation.Equals, new[] { new NumberOperand(1) })
                 })
-            }));
+            })
+        }));
 
-            var actual = GenerateText(generator);
-            var expected = @$"
+        var actual = GenerateText(generator);
+        var expected = @$"
 if ((context.I % 5 == 1))
     return ""one"";
 
 return ""other"";
 ".TrimStart();
-            Assert.Equal(expected, actual);
-        }
+        Assert.Equal(expected, actual);
+    }
 
-        [Fact]
-        public void CanGenerateRuleForNumberEquals()
+    [Fact]
+    public void CanGenerateRuleForNumberEquals()
+    {
+        var generator = new RuleGenerator(new PluralRule(new[] { "en" }, new[]
         {
-            var generator = new RuleGenerator(new PluralRule(new[] { "en" }, new[]
+            new Condition("one", string.Empty, new[]
             {
-                new Condition("one", string.Empty, new[]
+                new OrCondition(new [] 
                 {
-                    new OrCondition(new [] 
-                    {
-                        new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), Relation.Equals, new[] { new NumberOperand(5) })
-                    })
+                    new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), Relation.Equals, new[] { new NumberOperand(5) })
                 })
-            }));
+            })
+        }));
 
-            var actual = GenerateText(generator);
-            var expected = @$"
+        var actual = GenerateText(generator);
+        var expected = @$"
 if ((context.N == 5))
     return ""one"";
 
 return ""other"";
 ".TrimStart();
-            Assert.Equal(expected, actual);
-        }
+        Assert.Equal(expected, actual);
+    }
 
-        [Fact]
-        public void CanGenerateRuleForNumberNotEquals()
+    [Fact]
+    public void CanGenerateRuleForNumberNotEquals()
+    {
+        var generator = new RuleGenerator(new PluralRule(new[] { "en" }, new[]
         {
-            var generator = new RuleGenerator(new PluralRule(new[] { "en" }, new[]
+            new Condition("one", string.Empty, new[]
             {
-                new Condition("one", string.Empty, new[]
+                new OrCondition(new []
                 {
-                    new OrCondition(new []
-                    {
-                        new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), Relation.NotEquals, new[] { new NumberOperand(5) })
-                    })
+                    new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), Relation.NotEquals, new[] { new NumberOperand(5) })
                 })
-            }));
+            })
+        }));
 
-            var actual = GenerateText(generator);
-            var expected = @$"
+        var actual = GenerateText(generator);
+        var expected = @$"
 if ((context.N != 5))
     return ""one"";
 
 return ""other"";
 ".TrimStart();
-            Assert.Equal(expected, actual);
-        }
+        Assert.Equal(expected, actual);
+    }
 
-        [Fact]
-        public void CanGenerateRuleForNumberRange()
+    [Fact]
+    public void CanGenerateRuleForNumberRange()
+    {
+        var generator = new RuleGenerator(new PluralRule(new[] { "en" }, new[]
         {
-            var generator = new RuleGenerator(new PluralRule(new[] { "en" }, new[]
+            new Condition("one", string.Empty, new[]
             {
-                new Condition("one", string.Empty, new[]
+                new OrCondition(new []
                 {
-                    new OrCondition(new []
-                    {
-                        new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), Relation.Equals, new IRightOperand[] { new RangeOperand(5, 6), new NumberOperand(10) })
-                    })
+                    new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), Relation.Equals, new IRightOperand[] { new RangeOperand(5, 6), new NumberOperand(10) })
                 })
-            }));
+            })
+        }));
 
-            var actual = GenerateText(generator);
-            var expected = @$"
+        var actual = GenerateText(generator);
+        var expected = @$"
 if ((context.N >= 5 && context.N <= 6 || context.N == 10))
     return ""one"";
 
 return ""other"";
 ".TrimStart();
-            Assert.Equal(expected, actual);
-        }
+        Assert.Equal(expected, actual);
+    }
 
-        [Fact]
-        public void CanGenerateRuleForNegativeNumberRange()
+    [Fact]
+    public void CanGenerateRuleForNegativeNumberRange()
+    {
+        var generator = new RuleGenerator(new PluralRule(new[] { "en" }, new[]
         {
-            var generator = new RuleGenerator(new PluralRule(new[] { "en" }, new[]
+            new Condition("one", string.Empty, new[]
             {
-                new Condition("one", string.Empty, new[]
+                new OrCondition(new []
                 {
-                    new OrCondition(new []
-                    {
-                        new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), Relation.NotEquals, new IRightOperand[] { new RangeOperand(5, 6), new NumberOperand(10) })
-                    })
+                    new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), Relation.NotEquals, new IRightOperand[] { new RangeOperand(5, 6), new NumberOperand(10) })
                 })
-            }));
+            })
+        }));
 
-            var actual = GenerateText(generator);
-            var expected = @$"
+        var actual = GenerateText(generator);
+        var expected = @$"
 if (((context.N < 5 || context.N > 6) && context.N != 10))
     return ""one"";
 
 return ""other"";
 ".TrimStart();
-            Assert.Equal(expected, actual);
-        }
+        Assert.Equal(expected, actual);
+    }
 
-        [Fact]
-        public void CanGenerateRuleForAndRules()
+    [Fact]
+    public void CanGenerateRuleForAndRules()
+    {
+        var generator = new RuleGenerator(new PluralRule(new[] { "en" }, new[]
         {
-            var generator = new RuleGenerator(new PluralRule(new[] { "en" }, new[]
+            new Condition("one", string.Empty, new[]
             {
-                new Condition("one", string.Empty, new[]
+                new OrCondition(new []
                 {
-                    new OrCondition(new []
-                    {
-                        new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), Relation.Equals, new[] { new NumberOperand(4) }),
-                        new Operation(new VariableOperand(OperandSymbol.VisibleFractionDigitNumber), Relation.Equals, new[] { new NumberOperand(0) })
-                    })
+                    new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), Relation.Equals, new[] { new NumberOperand(4) }),
+                    new Operation(new VariableOperand(OperandSymbol.VisibleFractionDigitNumber), Relation.Equals, new[] { new NumberOperand(0) })
                 })
-            }));
+            })
+        }));
 
-            var actual = GenerateText(generator);
-            var expected = @$"
+        var actual = GenerateText(generator);
+        var expected = @$"
 if ((context.N == 4) && (context.V == 0))
     return ""one"";
 
 return ""other"";
 ".TrimStart();
-            Assert.Equal(expected, actual);
-        }
+        Assert.Equal(expected, actual);
+    }
 
-        [Fact]
-        public void CanGenerateRuleForMixedRangeAndNumberRangeRules()
+    [Fact]
+    public void CanGenerateRuleForMixedRangeAndNumberRangeRules()
+    {
+        var generator = new RuleGenerator(new PluralRule(new[] { "en" }, new[]
         {
-            var generator = new RuleGenerator(new PluralRule(new[] { "en" }, new[]
+            new Condition("one", string.Empty, new[]
             {
-                new Condition("one", string.Empty, new[]
+                new OrCondition(new []
                 {
-                    new OrCondition(new []
-                    {
-                        new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), Relation.Equals, new[] { new RangeOperand(4, 5) }),
-                        new Operation(new VariableOperand(OperandSymbol.VisibleFractionDigitNumber), Relation.Equals, new[] { new NumberOperand(0) })
-                    })
+                    new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), Relation.Equals, new[] { new RangeOperand(4, 5) }),
+                    new Operation(new VariableOperand(OperandSymbol.VisibleFractionDigitNumber), Relation.Equals, new[] { new NumberOperand(0) })
                 })
-            }));
+            })
+        }));
 
-            var actual = GenerateText(generator);
-            var expected = @$"
+        var actual = GenerateText(generator);
+        var expected = @$"
 if ((context.N >= 4 && context.N <= 5) && (context.V == 0))
     return ""one"";
 
 return ""other"";
 ".TrimStart();
-            Assert.Equal(expected, actual);
-        }
+        Assert.Equal(expected, actual);
+    }
 
-        [Fact]
-        public void CanGenerateRuleForMultipleOrRules()
+    [Fact]
+    public void CanGenerateRuleForMultipleOrRules()
+    {
+        var generator = new RuleGenerator(new PluralRule(new[] { "en" }, new[]
         {
-            var generator = new RuleGenerator(new PluralRule(new[] { "en" }, new[]
+            new Condition("one", string.Empty, new[]
             {
-                new Condition("one", string.Empty, new[]
+                new OrCondition(new []
                 {
-                    new OrCondition(new []
-                    {
-                        new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), Relation.Equals, new[] { new NumberOperand(4) })
-                    }),
-                    new OrCondition(new []
-                    {
-                        new Operation(new VariableOperand(OperandSymbol.VisibleFractionDigitNumber), Relation.Equals, new[] { new NumberOperand(0) })
-                    })
+                    new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), Relation.Equals, new[] { new NumberOperand(4) })
+                }),
+                new OrCondition(new []
+                {
+                    new Operation(new VariableOperand(OperandSymbol.VisibleFractionDigitNumber), Relation.Equals, new[] { new NumberOperand(0) })
                 })
-            }));
+            })
+        }));
 
-            var actual = GenerateText(generator);
-            var expected = @$"
+        var actual = GenerateText(generator);
+        var expected = @$"
 if ((context.N == 4) || (context.V == 0))
     return ""one"";
 
 return ""other"";
 ".TrimStart();
-            Assert.Equal(expected, actual);
-        }
+        Assert.Equal(expected, actual);
+    }
 
-        [Fact]
-        public void CanGenerateRuleForMixedAndOrRules()
+    [Fact]
+    public void CanGenerateRuleForMixedAndOrRules()
+    {
+        var generator = new RuleGenerator(new PluralRule(new[] { "en" }, new[]
         {
-            var generator = new RuleGenerator(new PluralRule(new[] { "en" }, new[]
+            new Condition("one", string.Empty, new[]
             {
-                new Condition("one", string.Empty, new[]
+                new OrCondition(new []
                 {
-                    new OrCondition(new []
-                    {
-                        new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), Relation.Equals, new[] { new NumberOperand(4) }),
-                        new Operation(new VariableOperand(OperandSymbol.VisibleFractionDigitNumber), Relation.NotEquals, new[] { new NumberOperand(0) })
-                    }),
-                    new OrCondition(new []
-                    {
-                        new Operation(new VariableOperand(OperandSymbol.VisibleFractionDigitNumber), Relation.Equals, new[] { new NumberOperand(0) })
-                    })
+                    new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), Relation.Equals, new[] { new NumberOperand(4) }),
+                    new Operation(new VariableOperand(OperandSymbol.VisibleFractionDigitNumber), Relation.NotEquals, new[] { new NumberOperand(0) })
+                }),
+                new OrCondition(new []
+                {
+                    new Operation(new VariableOperand(OperandSymbol.VisibleFractionDigitNumber), Relation.Equals, new[] { new NumberOperand(0) })
                 })
-            }));
+            })
+        }));
 
-            var actual = GenerateText(generator);
-            var expected = @$"
+        var actual = GenerateText(generator);
+        var expected = @$"
 if ((context.N == 4) && (context.V != 0) || (context.V == 0))
     return ""one"";
 
 return ""other"";
 ".TrimStart();
-            Assert.Equal(expected, actual);
-        }
+        Assert.Equal(expected, actual);
+    }
 
-        [Fact]
-        public void CanGenerateRuleForMixedAndOrRangeRules()
+    [Fact]
+    public void CanGenerateRuleForMixedAndOrRangeRules()
+    {
+        var generator = new RuleGenerator(new PluralRule(new[] { "en" }, new[]
         {
-            var generator = new RuleGenerator(new PluralRule(new[] { "en" }, new[]
+            new Condition("one", string.Empty, new[]
             {
-                new Condition("one", string.Empty, new[]
+                new OrCondition(new []
                 {
-                    new OrCondition(new []
-                    {
-                        new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), Relation.Equals, new[] { new RangeOperand(4, 5) }),
-                        new Operation(new VariableOperand(OperandSymbol.VisibleFractionDigitNumber), Relation.NotEquals, new[] { new NumberOperand(0) })
-                    }),
-                    new OrCondition(new []
-                    {
-                        new Operation(new VariableOperand(OperandSymbol.VisibleFractionDigitNumber), Relation.Equals, new[] { new NumberOperand(0) })
-                    })
+                    new Operation(new VariableOperand(OperandSymbol.AbsoluteValue), Relation.Equals, new[] { new RangeOperand(4, 5) }),
+                    new Operation(new VariableOperand(OperandSymbol.VisibleFractionDigitNumber), Relation.NotEquals, new[] { new NumberOperand(0) })
+                }),
+                new OrCondition(new []
+                {
+                    new Operation(new VariableOperand(OperandSymbol.VisibleFractionDigitNumber), Relation.Equals, new[] { new NumberOperand(0) })
                 })
-            }));
+            })
+        }));
 
-            var actual = GenerateText(generator);
-            var expected = @$"
+        var actual = GenerateText(generator);
+        var expected = @$"
 if ((context.N >= 4 && context.N <= 5) && (context.V != 0) || (context.V == 0))
     return ""one"";
 
 return ""other"";
 ".TrimStart();
-            Assert.Equal(expected, actual);
-        }
+        Assert.Equal(expected, actual);
+    }
 
-        private string GenerateText(RuleGenerator generator)
-        {
-            var sb = new StringBuilder();
+    private string GenerateText(RuleGenerator generator)
+    {
+        var sb = new StringBuilder();
 
-            generator.WriteTo(sb, 0);
+        generator.WriteTo(sb, 0);
 
-            return sb.ToString();
-        }
+        return sb.ToString();
     }
 }

--- a/src/Jeffijoe.MessageFormat.Tests/Parsing/FormatterRequestCollectionTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Parsing/FormatterRequestCollectionTests.cs
@@ -10,84 +10,83 @@ using Jeffijoe.MessageFormat.Parsing;
 
 using Xunit;
 
-namespace Jeffijoe.MessageFormat.Tests.Parsing
+namespace Jeffijoe.MessageFormat.Tests.Parsing;
+
+/// <summary>
+/// The formatter request collection tests.
+/// </summary>
+public class FormatterRequestCollectionTests
 {
+    #region Public Methods and Operators
+
     /// <summary>
-    /// The formatter request collection tests.
+    /// The clone.
     /// </summary>
-    public class FormatterRequestCollectionTests
+    [Fact]
+    public void Clone()
     {
-        #region Public Methods and Operators
+        var subject = new FormatterRequestCollection();
+        subject.Add(
+            new FormatterRequest(
+                new Literal(0, 9, 1, 1, new string('a', 10)), 
+                "test", 
+                "test", 
+                "test"));
+        subject.Add(
+            new FormatterRequest(
+                new Literal(10, 19, 1, 1, new string('a', 10)), 
+                "test", 
+                "test", 
+                "test"));
+        subject.Add(
+            new FormatterRequest(
+                new Literal(20, 29, 1, 1, new string('a', 10)), 
+                "test", 
+                "test", 
+                "test"));
 
-        /// <summary>
-        /// The clone.
-        /// </summary>
-        [Fact]
-        public void Clone()
+        var cloned = subject.Clone();
+        Assert.Equal(subject.Count, cloned.Count());
+
+        foreach (var clonedReq in cloned)
         {
-            var subject = new FormatterRequestCollection();
-            subject.Add(
-                new FormatterRequest(
-                    new Literal(0, 9, 1, 1, new string('a', 10)), 
-                    "test", 
-                    "test", 
-                    "test"));
-            subject.Add(
-                new FormatterRequest(
-                    new Literal(10, 19, 1, 1, new string('a', 10)), 
-                    "test", 
-                    "test", 
-                    "test"));
-            subject.Add(
-                new FormatterRequest(
-                    new Literal(20, 29, 1, 1, new string('a', 10)), 
-                    "test", 
-                    "test", 
-                    "test"));
-
-            var cloned = subject.Clone();
-            Assert.Equal(subject.Count, cloned.Count());
-
-            foreach (var clonedReq in cloned)
-            {
-                Assert.DoesNotContain(subject, x => ReferenceEquals(x, clonedReq));
-                Assert.DoesNotContain(subject, x => x.SourceLiteral == clonedReq.SourceLiteral);
-                Assert.Contains(subject, x => x.SourceLiteral.StartIndex == clonedReq.SourceLiteral.StartIndex);
-            }
+            Assert.DoesNotContain(subject, x => ReferenceEquals(x, clonedReq));
+            Assert.DoesNotContain(subject, x => x.SourceLiteral == clonedReq.SourceLiteral);
+            Assert.Contains(subject, x => x.SourceLiteral.StartIndex == clonedReq.SourceLiteral.StartIndex);
         }
-
-        /// <summary>
-        /// The shift indices.
-        /// </summary>
-        [Fact]
-        public void ShiftIndices()
-        {
-            var subject = new FormatterRequestCollection();
-            subject.Add(
-                new FormatterRequest(
-                    new Literal(0, 9, 1, 1, new string('a', 10)), 
-                    "test", 
-                    "test", 
-                    "test"));
-            subject.Add(
-                new FormatterRequest(
-                    new Literal(10, 19, 1, 1, new string('a', 10)), 
-                    "test", 
-                    "test", 
-                    "test"));
-            subject.Add(
-                new FormatterRequest(
-                    new Literal(20, 29, 1, 1, new string('a', 10)), 
-                    "test", 
-                    "test", 
-                    "test"));
-            subject.ShiftIndices(1, 4);
-            Assert.Equal(0, subject[0].SourceLiteral.StartIndex);
-            Assert.Equal(10, subject[1].SourceLiteral.StartIndex);
-
-            Assert.Equal(14, subject[2].SourceLiteral.StartIndex);
-        }
-
-        #endregion
     }
+
+    /// <summary>
+    /// The shift indices.
+    /// </summary>
+    [Fact]
+    public void ShiftIndices()
+    {
+        var subject = new FormatterRequestCollection();
+        subject.Add(
+            new FormatterRequest(
+                new Literal(0, 9, 1, 1, new string('a', 10)), 
+                "test", 
+                "test", 
+                "test"));
+        subject.Add(
+            new FormatterRequest(
+                new Literal(10, 19, 1, 1, new string('a', 10)), 
+                "test", 
+                "test", 
+                "test"));
+        subject.Add(
+            new FormatterRequest(
+                new Literal(20, 29, 1, 1, new string('a', 10)), 
+                "test", 
+                "test", 
+                "test"));
+        subject.ShiftIndices(1, 4);
+        Assert.Equal(0, subject[0].SourceLiteral.StartIndex);
+        Assert.Equal(10, subject[1].SourceLiteral.StartIndex);
+
+        Assert.Equal(14, subject[2].SourceLiteral.StartIndex);
+    }
+
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat.Tests/Parsing/LiteralParserTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Parsing/LiteralParserTests.cs
@@ -12,187 +12,186 @@ using Jeffijoe.MessageFormat.Parsing;
 
 using Xunit;
 
-namespace Jeffijoe.MessageFormat.Tests.Parsing
+namespace Jeffijoe.MessageFormat.Tests.Parsing;
+
+/// <summary>
+/// The literal parser tests.
+/// </summary>
+public class LiteralParserTests
 {
+    #region Public Methods and Operators
+
     /// <summary>
-    /// The literal parser tests.
+    /// The parse literals_bracket_mismatch.
     /// </summary>
-    public class LiteralParserTests
+    /// <param name="source">
+    /// The source.
+    /// </param>
+    /// <param name="expectedOpenBraceCount">
+    /// The expected open brace count.
+    /// </param>
+    /// <param name="expectedCloseBraceCount">
+    /// The expected close brace count.
+    /// </param>
+    [Theory]
+    [InlineData("{", 1, 0)]
+    [InlineData("}", 0, 1)]
+    [InlineData("A beginning {", 1, 0)]
+    [InlineData("An ending }", 0, 1)]
+    [InlineData("One { and multiple }}", 1, 2)]
+    [InlineData("A few {{{{ and one }", 4, 1)]
+    [InlineData("A few {{{{ and one '}'}", 4, 1)]
+    [InlineData("A few '{'{{{{ and one '}'}", 4, 1)]
+    public void ParseLiterals_bracket_mismatch(
+        string source,
+        int expectedOpenBraceCount,
+        int expectedCloseBraceCount)
     {
-        #region Public Methods and Operators
+        var sb = new StringBuilder(source);
+        var subject = new LiteralParser();
+        var ex = Assert.Throws<UnbalancedBracesException>(() => subject.ParseLiterals(sb));
+        Assert.Equal(expectedOpenBraceCount, ex.OpenBraceCount);
+        Assert.Equal(expectedCloseBraceCount, ex.CloseBraceCount);
+    }
 
-        /// <summary>
-        /// The parse literals_bracket_mismatch.
-        /// </summary>
-        /// <param name="source">
-        /// The source.
-        /// </param>
-        /// <param name="expectedOpenBraceCount">
-        /// The expected open brace count.
-        /// </param>
-        /// <param name="expectedCloseBraceCount">
-        /// The expected close brace count.
-        /// </param>
-        [Theory]
-        [InlineData("{", 1, 0)]
-        [InlineData("}", 0, 1)]
-        [InlineData("A beginning {", 1, 0)]
-        [InlineData("An ending }", 0, 1)]
-        [InlineData("One { and multiple }}", 1, 2)]
-        [InlineData("A few {{{{ and one }", 4, 1)]
-        [InlineData("A few {{{{ and one '}'}", 4, 1)]
-        [InlineData("A few '{'{{{{ and one '}'}", 4, 1)]
-        public void ParseLiterals_bracket_mismatch(
-            string source,
-            int expectedOpenBraceCount,
-            int expectedCloseBraceCount)
-        {
-            var sb = new StringBuilder(source);
-            var subject = new LiteralParser();
-            var ex = Assert.Throws<UnbalancedBracesException>(() => subject.ParseLiterals(sb));
-            Assert.Equal(expectedOpenBraceCount, ex.OpenBraceCount);
-            Assert.Equal(expectedCloseBraceCount, ex.CloseBraceCount);
-        }
+    /// <summary>
+    /// The parse literals_count.
+    /// </summary>
+    /// <param name="source">
+    /// The source.
+    /// </param>
+    /// <param name="expectedMatchCount">
+    /// The expected match count.
+    /// </param>
+    [Theory]
+    [InlineData("Hello, {something smells {really} weird.}", 1)]
+    [InlineData("Hello, {something smells {really} weird.}, {Hi}", 2)]
+    [InlineData("Hello, {something smells {really} weird.}, '{Hi}'", 1)]
+    public void ParseLiterals_count(string source, int expectedMatchCount)
+    {
+        var sb = new StringBuilder(source);
+        var subject = new LiteralParser();
+        var actual = subject.ParseLiterals(sb);
+        Assert.Equal(expectedMatchCount, actual.Count());
+    }
 
-        /// <summary>
-        /// The parse literals_count.
-        /// </summary>
-        /// <param name="source">
-        /// The source.
-        /// </param>
-        /// <param name="expectedMatchCount">
-        /// The expected match count.
-        /// </param>
-        [Theory]
-        [InlineData("Hello, {something smells {really} weird.}", 1)]
-        [InlineData("Hello, {something smells {really} weird.}, {Hi}", 2)]
-        [InlineData("Hello, {something smells {really} weird.}, '{Hi}'", 1)]
-        public void ParseLiterals_count(string source, int expectedMatchCount)
-        {
-            var sb = new StringBuilder(source);
-            var subject = new LiteralParser();
-            var actual = subject.ParseLiterals(sb);
-            Assert.Equal(expectedMatchCount, actual.Count());
-        }
-
-        /// <summary>
-        /// The parse unclosed_escape_sequence.
-        /// </summary>
-        /// <param name="source">
-        /// The source.
-        /// </param>
-        /// <param name="expectedLineNumber">
-        /// The expected line number.
-        /// </param>
-        /// <param name="expectedColumnNumber">
-        /// The expected column number.
-        /// </param>
-        [Theory]
-        [InlineData("'{", 1, 1)]
-        [InlineData("'}", 1, 1)]
-        [InlineData("a {b {c} d}, '{open escape sequence}", 1, 14)]
-        [InlineData(@"Hello,
+    /// <summary>
+    /// The parse unclosed_escape_sequence.
+    /// </summary>
+    /// <param name="source">
+    /// The source.
+    /// </param>
+    /// <param name="expectedLineNumber">
+    /// The expected line number.
+    /// </param>
+    /// <param name="expectedColumnNumber">
+    /// The expected column number.
+    /// </param>
+    [Theory]
+    [InlineData("'{", 1, 1)]
+    [InlineData("'}", 1, 1)]
+    [InlineData("a {b {c} d}, '{open escape sequence}", 1, 14)]
+    [InlineData(@"Hello,
 '{World}", 2, 1)]
-        public void ParseLiterals_unclosed_escape_sequence(
-            string source,
-            int expectedLineNumber,
-            int expectedColumnNumber)
-        {
-            var sb = new StringBuilder(source);
-            var subject = new LiteralParser();
-            var ex = Assert.Throws<MalformedLiteralException>(() => subject.ParseLiterals(sb));
-            Assert.Equal(expectedLineNumber, ex.LineNumber);
-            Assert.Equal(expectedColumnNumber, ex.ColumnNumber);
-        }
+    public void ParseLiterals_unclosed_escape_sequence(
+        string source,
+        int expectedLineNumber,
+        int expectedColumnNumber)
+    {
+        var sb = new StringBuilder(source);
+        var subject = new LiteralParser();
+        var ex = Assert.Throws<MalformedLiteralException>(() => subject.ParseLiterals(sb));
+        Assert.Equal(expectedLineNumber, ex.LineNumber);
+        Assert.Equal(expectedColumnNumber, ex.ColumnNumber);
+    }
 
-        /// <summary>
-        /// The parse literals_position_and_inner_text.
-        /// </summary>
-        /// <param name="source">
-        /// The source.
-        /// </param>
-        /// <param name="position">
-        /// The position.
-        /// </param>
-        /// <param name="expectedInnerText">
-        /// The expected inner text.
-        /// </param>
-        [Theory]
-        [InlineData("Hello, {something smells {really} weird.}", new[] { 7, 40 }, "something smells {really} weird.")]
-        [InlineData("Pretty {sweet}, right?", new[] { 7, 13 }, "sweet")]
-        [InlineData(@"{
+    /// <summary>
+    /// The parse literals_position_and_inner_text.
+    /// </summary>
+    /// <param name="source">
+    /// The source.
+    /// </param>
+    /// <param name="position">
+    /// The position.
+    /// </param>
+    /// <param name="expectedInnerText">
+    /// The expected inner text.
+    /// </param>
+    [Theory]
+    [InlineData("Hello, {something smells {really} weird.}", new[] { 7, 40 }, "something smells {really} weird.")]
+    [InlineData("Pretty {sweet}, right?", new[] { 7, 13 }, "sweet")]
+    [InlineData(@"{
 sweet
 
 }, right?", new[] { 0, 9 }, @"
 sweet
 
 ")]
-        [InlineData(@"{
+    [InlineData(@"{
 '{sweet}'
 
 }, right?", new[] { 0, 13 }, @"
 '{sweet}'
 
 ")]
-        public void ParseLiterals_position_and_inner_text(string source, int[] position, string expectedInnerText)
-        {
-            // It seems that depending on platform this is compiled on, the actual representation of new lines in the
-            // string literals can differ, which can make this test fail due to differences.
-            // This will normalize those changes.
-            expectedInnerText = expectedInnerText.Replace("\r\n", "\n");
+    public void ParseLiterals_position_and_inner_text(string source, int[] position, string expectedInnerText)
+    {
+        // It seems that depending on platform this is compiled on, the actual representation of new lines in the
+        // string literals can differ, which can make this test fail due to differences.
+        // This will normalize those changes.
+        expectedInnerText = expectedInnerText.Replace("\r\n", "\n");
 
-            var sb = new StringBuilder(source);
-            var subject = new LiteralParser();
-            var actual = subject.ParseLiterals(sb);
-            var first = actual.First();
-            string innerText = first.InnerText;
-            Assert.Equal(expectedInnerText, innerText);
-            Assert.Equal(position[0], first.StartIndex);
+        var sb = new StringBuilder(source);
+        var subject = new LiteralParser();
+        var actual = subject.ParseLiterals(sb);
+        var first = actual.First();
+        string innerText = first.InnerText;
+        Assert.Equal(expectedInnerText, innerText);
+        Assert.Equal(position[0], first.StartIndex);
 
-            // Makes up for line-ending differences due to Git.
-            var expectedEndIndex = position[1] + source.Count(c => c == '\r');
-            var expectedSourceColumnNumber = first.StartIndex + 1;
-            Assert.Equal(expectedEndIndex, first.EndIndex);
+        // Makes up for line-ending differences due to Git.
+        var expectedEndIndex = position[1] + source.Count(c => c == '\r');
+        var expectedSourceColumnNumber = first.StartIndex + 1;
+        Assert.Equal(expectedEndIndex, first.EndIndex);
 
-            Assert.Equal(expectedSourceColumnNumber, first.SourceColumnNumber);
-        }
+        Assert.Equal(expectedSourceColumnNumber, first.SourceColumnNumber);
+    }
 
-        /// <summary>
-        /// The parse literals_source_line_and_column_number.
-        /// </summary>
-        /// <param name="source">
-        /// The source.
-        /// </param>
-        /// <param name="lineNumber">
-        /// The line number.
-        /// </param>
-        /// <param name="columnNumber">
-        /// The column number.
-        /// </param>
-        [Theory]
-        [InlineData(@"Hi, this is
+    /// <summary>
+    /// The parse literals_source_line_and_column_number.
+    /// </summary>
+    /// <param name="source">
+    /// The source.
+    /// </param>
+    /// <param name="lineNumber">
+    /// The line number.
+    /// </param>
+    /// <param name="columnNumber">
+    /// The column number.
+    /// </param>
+    [Theory]
+    [InlineData(@"Hi, this is
 
 {a tricky one}
 
 yeeah!
 ", 3, 1)]
-        [InlineData(@"Hi, this is
+    [InlineData(@"Hi, this is
 
   
   {a tricky one}
 
 yeeah!
 ", 4, 3)]
-        public void ParseLiterals_source_line_and_column_number(string source, int lineNumber, int columnNumber)
-        {
-            var sb = new StringBuilder(source);
-            var subject = new LiteralParser();
-            var actual = subject.ParseLiterals(sb);
-            var first = actual.First();
-            Assert.Equal(lineNumber, first.SourceLineNumber);
-            Assert.Equal(columnNumber, first.SourceColumnNumber);
-        }
-
-        #endregion
+    public void ParseLiterals_source_line_and_column_number(string source, int lineNumber, int columnNumber)
+    {
+        var sb = new StringBuilder(source);
+        var subject = new LiteralParser();
+        var actual = subject.ParseLiterals(sb);
+        var first = actual.First();
+        Assert.Equal(lineNumber, first.SourceLineNumber);
+        Assert.Equal(columnNumber, first.SourceColumnNumber);
     }
+
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat.Tests/Parsing/LiteralTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Parsing/LiteralTests.cs
@@ -8,31 +8,30 @@ using Jeffijoe.MessageFormat.Parsing;
 
 using Xunit;
 
-namespace Jeffijoe.MessageFormat.Tests.Parsing
+namespace Jeffijoe.MessageFormat.Tests.Parsing;
+
+/// <summary>
+/// The literal tests.
+/// </summary>
+public class LiteralTests
 {
+    #region Public Methods and Operators
+
     /// <summary>
-    /// The literal tests.
+    /// The shift indices.
     /// </summary>
-    public class LiteralTests
+    [Fact]
+    public void ShiftIndices()
     {
-        #region Public Methods and Operators
+        var subject = new Literal(20, 29, 1, 1, new string('a', 10));
+        var other = new Literal(5, 10, 1, 1, new string('a', 6));
 
-        /// <summary>
-        /// The shift indices.
-        /// </summary>
-        [Fact]
-        public void ShiftIndices()
-        {
-            var subject = new Literal(20, 29, 1, 1, new string('a', 10));
-            var other = new Literal(5, 10, 1, 1, new string('a', 6));
+        subject.ShiftIndices(2, other);
 
-            subject.ShiftIndices(2, other);
-
-            // I honestly have no explanation for this, but it works with the formatter. Magic?
-            Assert.Equal(18, subject.StartIndex);
-            Assert.Equal(27, subject.EndIndex);
-        }
-
-        #endregion
+        // I honestly have no explanation for this, but it works with the formatter. Magic?
+        Assert.Equal(18, subject.StartIndex);
+        Assert.Equal(27, subject.EndIndex);
     }
+
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat.Tests/Parsing/PatternParserGetKeyTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Parsing/PatternParserGetKeyTests.cs
@@ -9,139 +9,138 @@ using Jeffijoe.MessageFormat.Parsing;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Jeffijoe.MessageFormat.Tests.Parsing
+namespace Jeffijoe.MessageFormat.Tests.Parsing;
+
+/// <summary>
+/// The pattern parser_ get key_ tests.
+/// </summary>
+public class PatternParserGetKeyTests
 {
+    #region Fields
+
     /// <summary>
-    /// The pattern parser_ get key_ tests.
+    /// The output helper.
     /// </summary>
-    public class PatternParserGetKeyTests
+    private ITestOutputHelper outputHelper;
+
+    #endregion
+
+    #region Constructors and Destructors
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PatternParserGetKeyTests"/> class.
+    /// </summary>
+    /// <param name="outputHelper">
+    /// The output helper.
+    /// </param>
+    public PatternParserGetKeyTests(ITestOutputHelper outputHelper)
     {
-        #region Fields
-
-        /// <summary>
-        /// The output helper.
-        /// </summary>
-        private ITestOutputHelper outputHelper;
-
-        #endregion
-
-        #region Constructors and Destructors
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PatternParserGetKeyTests"/> class.
-        /// </summary>
-        /// <param name="outputHelper">
-        /// The output helper.
-        /// </param>
-        public PatternParserGetKeyTests(ITestOutputHelper outputHelper)
-        {
-            this.outputHelper = outputHelper;
-        }
-
-        #endregion
-
-        #region Public Properties
-
-        /// <summary>
-        /// Gets the get key_throws_with_invalid_characters_ case.
-        /// </summary>
-        public static IEnumerable<object[]> GetKeyThrowsWithInvalidCharactersCase
-        {
-            get
-            {
-                yield return new object[] { new Literal(3, 10, 1, 3, "Hellåw,"), 1, 8 };
-                yield return new object[] { new Literal(0, 0, 3, 3, ","), 3, 4 };
-                yield return new object[] { new Literal(0, 0, 3, 3, " hello dawg"), 0, 0 };
-                yield return new object[] { new Literal(0, 0, 3, 3, "hello dawg "), 0, 0 };
-                yield return new object[] { new Literal(0, 0, 3, 3, " hello dawg"), 0, 0 };
-                yield return new object[] { new Literal(0, 0, 3, 3, " hello\r\ndawg"), 0, 0 };
-            }
-        }
-
-        #endregion
-
-        #region Public Methods and Operators
-
-        /// <summary>
-        /// The read literal section.
-        /// </summary>
-        /// <param name="source">
-        /// The source.
-        /// </param>
-        /// <param name="expected">
-        /// The expected.
-        /// </param>
-        /// <param name="expectedLastIndex">
-        /// The expected last index.
-        /// </param>
-        [Theory]
-        [InlineData("SupDawg, yeah", "SupDawg", 7)]
-        [InlineData("hello", "hello", 4)]
-        [InlineData(" hello ", "hello", 6)]
-        [InlineData("\r\nhello ", "hello", 7)]
-        [InlineData("0,", "0", 1)]
-        [InlineData("0, ", "0", 1)]
-        [InlineData("0 ,", "0", 2)]
-        [InlineData("0", "0", 0)]
-        public void ReadLiteralSection(string source, string expected, int expectedLastIndex)
-        {
-            var literal = new Literal(10, 10, 1, 1, source);
-            int lastIndex;
-            Assert.Equal(expected, PatternParser.ReadLiteralSection(literal, 0, false, out lastIndex));
-            Assert.Equal(expectedLastIndex, lastIndex);
-        }
-
-        /// <summary>
-        /// The read literal section_throws_with_invalid_characters.
-        /// </summary>
-        /// <param name="literal">
-        /// The literal.
-        /// </param>
-        /// <param name="expectedLine">
-        /// The expected line.
-        /// </param>
-        /// <param name="expectedColumn">
-        /// The expected column.
-        /// </param>
-        [Theory]
-        [MemberData(nameof(GetKeyThrowsWithInvalidCharactersCase))]
-        public void ReadLiteralSection_throws_with_invalid_characters(
-            Literal literal, 
-            int expectedLine, 
-            int expectedColumn)
-        {
-            var ex =
-                Assert.Throws<MalformedLiteralException>(
-                    () => PatternParser.ReadLiteralSection(literal, 0, false, out _));
-            Assert.Equal(expectedLine, ex.LineNumber);
-            Assert.Equal(expectedColumn, ex.ColumnNumber);
-            this.outputHelper.WriteLine(ex.Message);
-        }
-
-        /// <summary>
-        /// The read literal section_with_offset.
-        /// </summary>
-        /// <param name="source">
-        /// The source.
-        /// </param>
-        /// <param name="expected">
-        /// The expected.
-        /// </param>
-        /// <param name="offset">
-        /// The offset.
-        /// </param>
-        [Theory]
-        [InlineData("SupDawg, yeah", "yeah", 8)]
-        [InlineData("SupDawg,yeah", "yeah", 8)]
-        [InlineData("SupDawg,yeah ", "yeah", 8)]
-        [InlineData("SupDawg, ", null, 8)]
-        [InlineData("SupDawg,", null, 8)]
-        public void ReadLiteralSection_with_offset(string source, string? expected, int offset)
-        {
-            var literal = new Literal(10, 10, 1, 1, source);
-            Assert.Equal(expected, PatternParser.ReadLiteralSection(literal, offset, true, out _));
-        }
-
-        #endregion
+        this.outputHelper = outputHelper;
     }
+
+    #endregion
+
+    #region Public Properties
+
+    /// <summary>
+    /// Gets the get key_throws_with_invalid_characters_ case.
+    /// </summary>
+    public static IEnumerable<object[]> GetKeyThrowsWithInvalidCharactersCase
+    {
+        get
+        {
+            yield return new object[] { new Literal(3, 10, 1, 3, "Hellåw,"), 1, 8 };
+            yield return new object[] { new Literal(0, 0, 3, 3, ","), 3, 4 };
+            yield return new object[] { new Literal(0, 0, 3, 3, " hello dawg"), 0, 0 };
+            yield return new object[] { new Literal(0, 0, 3, 3, "hello dawg "), 0, 0 };
+            yield return new object[] { new Literal(0, 0, 3, 3, " hello dawg"), 0, 0 };
+            yield return new object[] { new Literal(0, 0, 3, 3, " hello\r\ndawg"), 0, 0 };
+        }
+    }
+
+    #endregion
+
+    #region Public Methods and Operators
+
+    /// <summary>
+    /// The read literal section.
+    /// </summary>
+    /// <param name="source">
+    /// The source.
+    /// </param>
+    /// <param name="expected">
+    /// The expected.
+    /// </param>
+    /// <param name="expectedLastIndex">
+    /// The expected last index.
+    /// </param>
+    [Theory]
+    [InlineData("SupDawg, yeah", "SupDawg", 7)]
+    [InlineData("hello", "hello", 4)]
+    [InlineData(" hello ", "hello", 6)]
+    [InlineData("\r\nhello ", "hello", 7)]
+    [InlineData("0,", "0", 1)]
+    [InlineData("0, ", "0", 1)]
+    [InlineData("0 ,", "0", 2)]
+    [InlineData("0", "0", 0)]
+    public void ReadLiteralSection(string source, string expected, int expectedLastIndex)
+    {
+        var literal = new Literal(10, 10, 1, 1, source);
+        int lastIndex;
+        Assert.Equal(expected, PatternParser.ReadLiteralSection(literal, 0, false, out lastIndex));
+        Assert.Equal(expectedLastIndex, lastIndex);
+    }
+
+    /// <summary>
+    /// The read literal section_throws_with_invalid_characters.
+    /// </summary>
+    /// <param name="literal">
+    /// The literal.
+    /// </param>
+    /// <param name="expectedLine">
+    /// The expected line.
+    /// </param>
+    /// <param name="expectedColumn">
+    /// The expected column.
+    /// </param>
+    [Theory]
+    [MemberData(nameof(GetKeyThrowsWithInvalidCharactersCase))]
+    public void ReadLiteralSection_throws_with_invalid_characters(
+        Literal literal, 
+        int expectedLine, 
+        int expectedColumn)
+    {
+        var ex =
+            Assert.Throws<MalformedLiteralException>(
+                () => PatternParser.ReadLiteralSection(literal, 0, false, out _));
+        Assert.Equal(expectedLine, ex.LineNumber);
+        Assert.Equal(expectedColumn, ex.ColumnNumber);
+        this.outputHelper.WriteLine(ex.Message);
+    }
+
+    /// <summary>
+    /// The read literal section_with_offset.
+    /// </summary>
+    /// <param name="source">
+    /// The source.
+    /// </param>
+    /// <param name="expected">
+    /// The expected.
+    /// </param>
+    /// <param name="offset">
+    /// The offset.
+    /// </param>
+    [Theory]
+    [InlineData("SupDawg, yeah", "yeah", 8)]
+    [InlineData("SupDawg,yeah", "yeah", 8)]
+    [InlineData("SupDawg,yeah ", "yeah", 8)]
+    [InlineData("SupDawg, ", null, 8)]
+    [InlineData("SupDawg,", null, 8)]
+    public void ReadLiteralSection_with_offset(string source, string? expected, int offset)
+    {
+        var literal = new Literal(10, 10, 1, 1, source);
+        Assert.Equal(expected, PatternParser.ReadLiteralSection(literal, offset, true, out _));
+    }
+
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat.Tests/Parsing/PatternParserParseTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Parsing/PatternParserParseTests.cs
@@ -12,102 +12,101 @@ using Jeffijoe.MessageFormat.Tests.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Jeffijoe.MessageFormat.Tests.Parsing
+namespace Jeffijoe.MessageFormat.Tests.Parsing;
+
+/// <summary>
+/// The pattern parser_ parse_ tests.
+/// </summary>
+public class PatternParserParseTests
 {
+    #region Fields
+
     /// <summary>
-    /// The pattern parser_ parse_ tests.
+    /// The output helper.
     /// </summary>
-    public class PatternParserParseTests
+    private readonly ITestOutputHelper outputHelper;
+
+    #endregion
+
+    #region Constructors and Destructors
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PatternParserParseTests"/> class.
+    /// </summary>
+    /// <param name="outputHelper">
+    /// The output helper.
+    /// </param>
+    public PatternParserParseTests(ITestOutputHelper outputHelper)
     {
-        #region Fields
-
-        /// <summary>
-        /// The output helper.
-        /// </summary>
-        private readonly ITestOutputHelper outputHelper;
-
-        #endregion
-
-        #region Constructors and Destructors
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PatternParserParseTests"/> class.
-        /// </summary>
-        /// <param name="outputHelper">
-        /// The output helper.
-        /// </param>
-        public PatternParserParseTests(ITestOutputHelper outputHelper)
-        {
-            this.outputHelper = outputHelper;
-        }
-
-        #endregion
-
-        #region Public Methods and Operators
-
-        /// <summary>
-        /// The parse.
-        /// </summary>
-        /// <param name="source">
-        /// The source.
-        /// </param>
-        /// <param name="expectedKey">
-        /// The expected key.
-        /// </param>
-        /// <param name="expectedFormat">
-        /// The expected format.
-        /// </param>
-        /// <param name="expectedArgs">
-        /// The expected args.
-        /// </param>
-        [Theory]
-        [InlineData("test, select, args", "test", "select", "args")]
-        [InlineData("test, select, stuff {dawg}", "test", "select", "stuff {dawg}")]
-        [InlineData("test, select, stuff {dawg's}", "test", "select", "stuff {dawg's}")]
-        [InlineData("test, select, stuff {dawg''s}", "test", "select", "stuff {dawg''s}")]
-        [InlineData("test, select, stuff '{{dawg}}'", "test", "select", "stuff '{{dawg}}'")]
-        [InlineData("test, select, stuff {dawg, select, {name is '{'{name}'}'}}", "test", "select",
-            "stuff {dawg, select, {name is '{'{name}'}'}}")]
-        public void Parse(string source, string expectedKey, string expectedFormat, string expectedArgs)
-        {
-            var literalParser = FakeLiteralParser.Of(source);
-            var sb = new StringBuilder(source);
-            var subject = new PatternParser(literalParser);
-
-            // Warm up (JIT)
-            Benchmark.Start("Parsing formatter patterns (first time before JIT)", this.outputHelper);
-            subject.Parse(sb);
-            Benchmark.End(this.outputHelper);
-            Benchmark.Start("Parsing formatter patterns (after warm-up)", this.outputHelper);
-            var actual = subject.Parse(sb);
-            Benchmark.End(this.outputHelper);
-            Assert.Single(actual);
-            var first = actual[0];
-            Assert.Equal(expectedKey, first.Variable);
-            Assert.Equal(expectedFormat, first.FormatterName);
-            Assert.Equal(expectedArgs, first.FormatterArguments);
-        }
-
-        /// <summary>
-        /// The parse_exits_early_when_no_literals_have_been_found.
-        /// </summary>
-        [Fact]
-        public void Parse_exits_early_when_no_literals_have_been_found()
-        {
-            var subject = new PatternParser();
-            Assert.Empty(subject.Parse(new StringBuilder()));
-        }
-        
-        /// <summary>
-        /// The parse_throws_when_only_whitespace_is_present_in_section
-        /// </summary>
-        [Fact]
-        public void Parse_throws_when_only_whitespace_is_present_in_section()
-        {
-            var subject = new PatternParser();
-            Assert.Throws<MalformedLiteralException>(() => subject.Parse(new StringBuilder("{  }")));
-        }
-        
-        #endregion
+        this.outputHelper = outputHelper;
     }
+
+    #endregion
+
+    #region Public Methods and Operators
+
+    /// <summary>
+    /// The parse.
+    /// </summary>
+    /// <param name="source">
+    /// The source.
+    /// </param>
+    /// <param name="expectedKey">
+    /// The expected key.
+    /// </param>
+    /// <param name="expectedFormat">
+    /// The expected format.
+    /// </param>
+    /// <param name="expectedArgs">
+    /// The expected args.
+    /// </param>
+    [Theory]
+    [InlineData("test, select, args", "test", "select", "args")]
+    [InlineData("test, select, stuff {dawg}", "test", "select", "stuff {dawg}")]
+    [InlineData("test, select, stuff {dawg's}", "test", "select", "stuff {dawg's}")]
+    [InlineData("test, select, stuff {dawg''s}", "test", "select", "stuff {dawg''s}")]
+    [InlineData("test, select, stuff '{{dawg}}'", "test", "select", "stuff '{{dawg}}'")]
+    [InlineData("test, select, stuff {dawg, select, {name is '{'{name}'}'}}", "test", "select",
+        "stuff {dawg, select, {name is '{'{name}'}'}}")]
+    public void Parse(string source, string expectedKey, string expectedFormat, string expectedArgs)
+    {
+        var literalParser = FakeLiteralParser.Of(source);
+        var sb = new StringBuilder(source);
+        var subject = new PatternParser(literalParser);
+
+        // Warm up (JIT)
+        Benchmark.Start("Parsing formatter patterns (first time before JIT)", this.outputHelper);
+        subject.Parse(sb);
+        Benchmark.End(this.outputHelper);
+        Benchmark.Start("Parsing formatter patterns (after warm-up)", this.outputHelper);
+        var actual = subject.Parse(sb);
+        Benchmark.End(this.outputHelper);
+        Assert.Single(actual);
+        var first = actual[0];
+        Assert.Equal(expectedKey, first.Variable);
+        Assert.Equal(expectedFormat, first.FormatterName);
+        Assert.Equal(expectedArgs, first.FormatterArguments);
+    }
+
+    /// <summary>
+    /// The parse_exits_early_when_no_literals_have_been_found.
+    /// </summary>
+    [Fact]
+    public void Parse_exits_early_when_no_literals_have_been_found()
+    {
+        var subject = new PatternParser();
+        Assert.Empty(subject.Parse(new StringBuilder()));
+    }
+        
+    /// <summary>
+    /// The parse_throws_when_only_whitespace_is_present_in_section
+    /// </summary>
+    [Fact]
+    public void Parse_throws_when_only_whitespace_is_present_in_section()
+    {
+        var subject = new PatternParser();
+        Assert.Throws<MalformedLiteralException>(() => subject.Parse(new StringBuilder("{  }")));
+    }
+        
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat.Tests/Parsing/PatternParserWithRealLiteralParser.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Parsing/PatternParserWithRealLiteralParser.cs
@@ -13,70 +13,69 @@ using Jeffijoe.MessageFormat.Tests.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Jeffijoe.MessageFormat.Tests.Parsing
+namespace Jeffijoe.MessageFormat.Tests.Parsing;
+
+/// <summary>
+/// The pattern parser_with_real_ literal parser.
+/// </summary>
+public class PatternParserWithRealLiteralParser
 {
+    #region Fields
+
     /// <summary>
-    /// The pattern parser_with_real_ literal parser.
+    /// The output helper.
     /// </summary>
-    public class PatternParserWithRealLiteralParser
+    private readonly ITestOutputHelper outputHelper;
+
+    #endregion
+
+    #region Constructors and Destructors
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PatternParserWithRealLiteralParser"/> class.
+    /// </summary>
+    /// <param name="outputHelper">
+    /// The output helper.
+    /// </param>
+    public PatternParserWithRealLiteralParser(ITestOutputHelper outputHelper)
     {
-        #region Fields
+        this.outputHelper = outputHelper;
+    }
 
-        /// <summary>
-        /// The output helper.
-        /// </summary>
-        private readonly ITestOutputHelper outputHelper;
+    #endregion
 
-        #endregion
+    #region Public Methods and Operators
 
-        #region Constructors and Destructors
+    /// <summary>
+    /// The parse.
+    /// </summary>
+    [Fact]
+    public void Parse()
+    {
+        var subject = new PatternParser(new LiteralParser());
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PatternParserWithRealLiteralParser"/> class.
-        /// </summary>
-        /// <param name="outputHelper">
-        /// The output helper.
-        /// </param>
-        public PatternParserWithRealLiteralParser(ITestOutputHelper outputHelper)
-        {
-            this.outputHelper = outputHelper;
-        }
-
-        #endregion
-
-        #region Public Methods and Operators
-
-        /// <summary>
-        /// The parse.
-        /// </summary>
-        [Fact]
-        public void Parse()
-        {
-            var subject = new PatternParser(new LiteralParser());
-
-            const string Source = @"Hi, {Name, select,
+        const string Source = @"Hi, {Name, select,
                                 male={guy} female={gal}}, you have {count, plural, 
                                 zero {no friends}, other {# friends}
                                 }";
-            Benchmark.Start("First run (warm-up)", this.outputHelper);
-            subject.Parse(new StringBuilder(Source));
-            Benchmark.End(this.outputHelper);
+        Benchmark.Start("First run (warm-up)", this.outputHelper);
+        subject.Parse(new StringBuilder(Source));
+        Benchmark.End(this.outputHelper);
 
-            Benchmark.Start("Next one (warmed up)", this.outputHelper);
-            var actual = subject.Parse(new StringBuilder(Source));
-            Benchmark.End(this.outputHelper);
-            Assert.Equal(2, actual.Count());
-            var formatterParam = actual.First();
-            Assert.Equal("Name", formatterParam.Variable);
-            Assert.Equal("select", formatterParam.FormatterName);
-            Assert.Equal("male={guy} female={gal}", formatterParam.FormatterArguments);
+        Benchmark.Start("Next one (warmed up)", this.outputHelper);
+        var actual = subject.Parse(new StringBuilder(Source));
+        Benchmark.End(this.outputHelper);
+        Assert.Equal(2, actual.Count());
+        var formatterParam = actual.First();
+        Assert.Equal("Name", formatterParam.Variable);
+        Assert.Equal("select", formatterParam.FormatterName);
+        Assert.Equal("male={guy} female={gal}", formatterParam.FormatterArguments);
 
-            formatterParam = actual.ElementAt(1);
-            Assert.Equal("count", formatterParam.Variable);
-            Assert.Equal("plural", formatterParam.FormatterName);
-            Assert.Equal("zero {no friends}, other {# friends}", formatterParam.FormatterArguments);
-        }
-
-        #endregion
+        formatterParam = actual.ElementAt(1);
+        Assert.Equal("count", formatterParam.Variable);
+        Assert.Equal("plural", formatterParam.FormatterName);
+        Assert.Equal("zero {no friends}, other {# friends}", formatterParam.FormatterArguments);
     }
+
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat.Tests/TestHelpers/Benchmark.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/TestHelpers/Benchmark.cs
@@ -8,51 +8,50 @@ using System.Diagnostics;
 
 using Xunit.Abstractions;
 
-namespace Jeffijoe.MessageFormat.Tests.TestHelpers
+namespace Jeffijoe.MessageFormat.Tests.TestHelpers;
+
+/// <summary>
+///     Benchmark helper.
+/// </summary>
+public static class Benchmark
 {
+    #region Static Fields
+
     /// <summary>
-    ///     Benchmark helper.
+    ///     The stopwatch.
     /// </summary>
-    public static class Benchmark
+    private static readonly Stopwatch Sw = new Stopwatch();
+
+    #endregion
+
+    #region Public Methods and Operators
+
+    /// <summary>
+    /// Ends the benchmark and prints the elapsed time to the console.
+    /// </summary>
+    /// <param name="outputHelper">
+    /// The output helper.
+    /// </param>
+    public static void End(ITestOutputHelper outputHelper)
     {
-        #region Static Fields
-
-        /// <summary>
-        ///     The stopwatch.
-        /// </summary>
-        private static readonly Stopwatch Sw = new Stopwatch();
-
-        #endregion
-
-        #region Public Methods and Operators
-
-        /// <summary>
-        /// Ends the benchmark and prints the elapsed time to the console.
-        /// </summary>
-        /// <param name="outputHelper">
-        /// The output helper.
-        /// </param>
-        public static void End(ITestOutputHelper outputHelper)
-        {
-            Sw.Stop();
-            outputHelper.WriteLine("Result: {0}ms ({1} ticks)", Sw.ElapsedMilliseconds, Sw.ElapsedTicks);
-        }
-
-        /// <summary>
-        /// Starts the benchmark, and writes the passed message to the output helper.
-        /// </summary>
-        /// <param name="messageForConsole">
-        /// The message for console.
-        /// </param>
-        /// <param name="outputHelper">
-        /// The output helper.
-        /// </param>
-        public static void Start(string messageForConsole, ITestOutputHelper outputHelper)
-        {
-            outputHelper.WriteLine(messageForConsole);
-            Sw.Restart();
-        }
-
-        #endregion
+        Sw.Stop();
+        outputHelper.WriteLine("Result: {0}ms ({1} ticks)", Sw.ElapsedMilliseconds, Sw.ElapsedTicks);
     }
+
+    /// <summary>
+    /// Starts the benchmark, and writes the passed message to the output helper.
+    /// </summary>
+    /// <param name="messageForConsole">
+    /// The message for console.
+    /// </param>
+    /// <param name="outputHelper">
+    /// The output helper.
+    /// </param>
+    public static void Start(string messageForConsole, ITestOutputHelper outputHelper)
+    {
+        outputHelper.WriteLine(messageForConsole);
+        Sw.Restart();
+    }
+
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat.Tests/TestHelpers/FakeFormatter.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/TestHelpers/FakeFormatter.cs
@@ -1,53 +1,52 @@
 using System.Collections.Generic;
 using Jeffijoe.MessageFormat.Formatting;
 
-namespace Jeffijoe.MessageFormat.Tests.TestHelpers
+namespace Jeffijoe.MessageFormat.Tests.TestHelpers;
+
+/// <summary>
+///     Fake formatter used for testing.
+/// </summary>
+internal class FakeFormatter : IFormatter
 {
     /// <summary>
-    ///     Fake formatter used for testing.
+    ///     What to return when <see cref="Format"/> is called.
     /// </summary>
-    internal class FakeFormatter : IFormatter
+    private readonly string formatResult;
+
+    /// <summary>
+    ///     Whether we should announce that we can format the input.
+    /// </summary>
+    private bool canFormat;
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="FakeFormatter"/> class.
+    /// </summary>
+    /// <param name="canFormat">Whether to return <c>true</c> for <see cref="CanFormat"/>.</param>
+    /// <param name="formatResult">The result to return.</param>
+    public FakeFormatter(bool canFormat = false, string formatResult = "formatted")
     {
-        /// <summary>
-        ///     What to return when <see cref="Format"/> is called.
-        /// </summary>
-        private readonly string formatResult;
-
-        /// <summary>
-        ///     Whether we should announce that we can format the input.
-        /// </summary>
-        private bool canFormat;
-
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="FakeFormatter"/> class.
-        /// </summary>
-        /// <param name="canFormat">Whether to return <c>true</c> for <see cref="CanFormat"/>.</param>
-        /// <param name="formatResult">The result to return.</param>
-        public FakeFormatter(bool canFormat = false, string formatResult = "formatted")
-        {
-            this.canFormat = canFormat;
-            this.formatResult = formatResult;
-        }
-
-        /// <inheritdoc />
-        public bool VariableMustExist => false;
-
-        /// <inheritdoc />
-        public bool CanFormat(FormatterRequest request) => this.canFormat;
-
-        /// <summary>
-        ///     Sets the value of what <see cref="CanFormat"/> returns.
-        /// </summary>
-        /// <param name="value"></param>
-        public void SetCanFormat(bool value) => this.canFormat = value;
-
-        /// <inheritdoc />
-        public string Format(
-            string locale,
-            FormatterRequest request,
-            IReadOnlyDictionary<string, object?> args,
-            object? value,
-            IMessageFormatter messageFormatter) =>
-            formatResult;
+        this.canFormat = canFormat;
+        this.formatResult = formatResult;
     }
+
+    /// <inheritdoc />
+    public bool VariableMustExist => false;
+
+    /// <inheritdoc />
+    public bool CanFormat(FormatterRequest request) => this.canFormat;
+
+    /// <summary>
+    ///     Sets the value of what <see cref="CanFormat"/> returns.
+    /// </summary>
+    /// <param name="value"></param>
+    public void SetCanFormat(bool value) => this.canFormat = value;
+
+    /// <inheritdoc />
+    public string Format(
+        string locale,
+        FormatterRequest request,
+        IReadOnlyDictionary<string, object?> args,
+        object? value,
+        IMessageFormatter messageFormatter) =>
+        formatResult;
 }

--- a/src/Jeffijoe.MessageFormat.Tests/TestHelpers/FakeLiteralParser.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/TestHelpers/FakeLiteralParser.cs
@@ -2,40 +2,39 @@ using System.Collections.Generic;
 using System.Text;
 using Jeffijoe.MessageFormat.Parsing;
 
-namespace Jeffijoe.MessageFormat.Tests.TestHelpers
+namespace Jeffijoe.MessageFormat.Tests.TestHelpers;
+
+/// <summary>
+///     Fake literal parser.
+/// </summary>
+internal class FakeLiteralParser : ILiteralParser
 {
     /// <summary>
-    ///     Fake literal parser.
+    ///     The literal to return.
     /// </summary>
-    internal class FakeLiteralParser : ILiteralParser
+    private readonly Literal literal;
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="FakeLiteralParser"/> class.
+    /// </summary>
+    /// <param name="literal"></param>
+    public FakeLiteralParser(Literal literal)
     {
-        /// <summary>
-        ///     The literal to return.
-        /// </summary>
-        private readonly Literal literal;
-
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="FakeLiteralParser"/> class.
-        /// </summary>
-        /// <param name="literal"></param>
-        public FakeLiteralParser(Literal literal)
-        {
-            this.literal = literal;
-        }
-
-        /// <inheritdoc />
-        public IEnumerable<Literal> ParseLiterals(StringBuilder sb)
-        {
-            yield return literal;
-        }
-
-        /// <summary>
-        ///     Creates a fake literal parser that returns a single literal with
-        ///     the specified inner text.
-        /// </summary>
-        /// <param name="innerText"></param>
-        /// <returns></returns>
-        public static ILiteralParser Of(string innerText) =>
-            new FakeLiteralParser(new Literal(0, innerText.Length, 1, 1, innerText));
+        this.literal = literal;
     }
+
+    /// <inheritdoc />
+    public IEnumerable<Literal> ParseLiterals(StringBuilder sb)
+    {
+        yield return literal;
+    }
+
+    /// <summary>
+    ///     Creates a fake literal parser that returns a single literal with
+    ///     the specified inner text.
+    /// </summary>
+    /// <param name="innerText"></param>
+    /// <returns></returns>
+    public static ILiteralParser Of(string innerText) =>
+        new FakeLiteralParser(new Literal(0, innerText.Length, 1, 1, innerText));
 }

--- a/src/Jeffijoe.MessageFormat.Tests/TestHelpers/FakeMessageFormatter.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/TestHelpers/FakeMessageFormatter.cs
@@ -1,16 +1,15 @@
 using System.Collections.Generic;
 
-namespace Jeffijoe.MessageFormat.Tests.TestHelpers
+namespace Jeffijoe.MessageFormat.Tests.TestHelpers;
+
+/// <summary>
+///     Used for testing. Will just pass through the input pattern.
+/// </summary>
+internal class FakeMessageFormatter : IMessageFormatter
 {
-    /// <summary>
-    ///     Used for testing. Will just pass through the input pattern.
-    /// </summary>
-    internal class FakeMessageFormatter : IMessageFormatter
-    {
-        public CustomValueFormatter? CustomValueFormatter { get; set; }
+    public CustomValueFormatter? CustomValueFormatter { get; set; }
 
-        public string FormatMessage(string pattern, IReadOnlyDictionary<string, object?> argsMap) => pattern;
+    public string FormatMessage(string pattern, IReadOnlyDictionary<string, object?> argsMap) => pattern;
 
-        public string FormatMessage(string pattern, object args) => pattern;
-    }
+    public string FormatMessage(string pattern, object args) => pattern;
 }

--- a/src/Jeffijoe.MessageFormat.Tests/TestHelpers/TrackingPatternParser.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/TestHelpers/TrackingPatternParser.cs
@@ -1,36 +1,35 @@
 using System.Text;
 using Jeffijoe.MessageFormat.Parsing;
 
-namespace Jeffijoe.MessageFormat.Tests.TestHelpers
+namespace Jeffijoe.MessageFormat.Tests.TestHelpers;
+
+/// <summary>
+///     Tracks the amount of times Parse is called.
+/// </summary>
+internal class TrackingPatternParser : IPatternParser
 {
     /// <summary>
-    ///     Tracks the amount of times Parse is called.
+    ///     The real parser.
     /// </summary>
-    internal class TrackingPatternParser : IPatternParser
+    private readonly PatternParser parser;
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="TrackingPatternParser"/> class.
+    /// </summary>
+    public TrackingPatternParser()
     {
-        /// <summary>
-        ///     The real parser.
-        /// </summary>
-        private readonly PatternParser parser;
+        parser = new PatternParser();
+    }
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="TrackingPatternParser"/> class.
-        /// </summary>
-        public TrackingPatternParser()
-        {
-            parser = new PatternParser();
-        }
+    /// <summary>
+    ///     The amount of times Parse was called.
+    /// </summary>
+    public int ParseCount { get; private set; }
 
-        /// <summary>
-        ///     The amount of times Parse was called.
-        /// </summary>
-        public int ParseCount { get; private set; }
-
-        /// <inheritdoc />
-        public IFormatterRequestCollection Parse(StringBuilder source)
-        {
-            ParseCount++;
-            return parser.Parse(source);
-        }
+    /// <inheritdoc />
+    public IFormatterRequestCollection Parse(StringBuilder source)
+    {
+        ParseCount++;
+        return parser.Parse(source);
     }
 }

--- a/src/Jeffijoe.MessageFormat/FormatterNotFoundException.cs
+++ b/src/Jeffijoe.MessageFormat/FormatterNotFoundException.cs
@@ -7,50 +7,49 @@ using System;
 
 using Jeffijoe.MessageFormat.Formatting;
 
-namespace Jeffijoe.MessageFormat
+namespace Jeffijoe.MessageFormat;
+
+/// <summary>
+///     Thrown when a formatter could not be found for a specific request.
+/// </summary>
+public class FormatterNotFoundException : Exception
 {
+    #region Constructors and Destructors
+
     /// <summary>
-    ///     Thrown when a formatter could not be found for a specific request.
+    ///     Initializes a new instance of the <see cref="FormatterNotFoundException" /> class.
     /// </summary>
-    public class FormatterNotFoundException : Exception
+    /// <param name="request">
+    ///     The request.
+    /// </param>
+    public FormatterNotFoundException(FormatterRequest request)
+        : base(BuildMessage(request))
     {
-        #region Constructors and Destructors
-
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="FormatterNotFoundException" /> class.
-        /// </summary>
-        /// <param name="request">
-        ///     The request.
-        /// </param>
-        public FormatterNotFoundException(FormatterRequest request)
-            : base(BuildMessage(request))
-        {
-        }
-
-        #endregion
-
-        #region Methods
-
-        /// <summary>
-        ///     Builds the message.
-        /// </summary>
-        /// <param name="request">
-        ///     The request.
-        /// </param>
-        /// <returns>
-        ///     The <see cref="string" />.
-        /// </returns>
-        private static string BuildMessage(FormatterRequest request)
-        {
-            return
-                string.Format(
-                    "Format '{0}' could not be resolved.\r\n" + "Line {1}, position {2}\r\n" + "Source literal: '{3}'", 
-                    request.FormatterName, 
-                    request.SourceLiteral.SourceLineNumber, 
-                    request.SourceLiteral.SourceColumnNumber, 
-                    request.SourceLiteral.InnerText);
-        }
-
-        #endregion
     }
+
+    #endregion
+
+    #region Methods
+
+    /// <summary>
+    ///     Builds the message.
+    /// </summary>
+    /// <param name="request">
+    ///     The request.
+    /// </param>
+    /// <returns>
+    ///     The <see cref="string" />.
+    /// </returns>
+    private static string BuildMessage(FormatterRequest request)
+    {
+        return
+            string.Format(
+                "Format '{0}' could not be resolved.\r\n" + "Line {1}, position {2}\r\n" + "Source literal: '{3}'", 
+                request.FormatterName, 
+                request.SourceLiteral.SourceLineNumber, 
+                request.SourceLiteral.SourceColumnNumber, 
+                request.SourceLiteral.InnerText);
+    }
+
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat/Formatting/BaseFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/BaseFormatter.cs
@@ -57,21 +57,22 @@ namespace Jeffijoe.MessageFormat.Formatting
                 return Enumerable.Empty<FormatterExtension>();
             }
             
-            int length = request.FormatterArguments.Length;
+            var length = request.FormatterArguments.Length;
             index = 0;
             const char Colon = ':';
-            bool foundExtension = false;
+            const char OpenBrace = '{';
+            var foundExtension = false;
 
             var extension = StringBuilderPool.Get();
             var value = StringBuilderPool.Get();
             try
             {
-                for (int i = 0; i < length; i++)
+                for (var i = 0; i < length; i++)
                 {
                     var c = request.FormatterArguments[i];
 
                     // Whitespace is tolerated at the beginning.
-                    bool isWhiteSpace = char.IsWhiteSpace(c);
+                    var isWhiteSpace = char.IsWhiteSpace(c);
                     if (isWhiteSpace)
                     {
                         // We've reached the end
@@ -104,6 +105,12 @@ namespace Jeffijoe.MessageFormat.Formatting
                     {
                         value.Append(c);
                         continue;
+                    }
+
+                    if (c == OpenBrace)
+                    {
+                        // It's not an extension.
+                        break;
                     }
 
                     extension.Append(c);

--- a/src/Jeffijoe.MessageFormat/Formatting/BaseFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/BaseFormatter.cs
@@ -7,328 +7,327 @@ using System.Collections.Generic;
 using System.Linq;
 using Jeffijoe.MessageFormat.Parsing;
 
-namespace Jeffijoe.MessageFormat.Formatting
+namespace Jeffijoe.MessageFormat.Formatting;
+
+/// <summary>
+///     Base formatter with helpers for extracting data from the formatter request.
+/// </summary>
+public abstract class BaseFormatter
 {
+    #region Constants
+
     /// <summary>
-    ///     Base formatter with helpers for extracting data from the formatter request.
+    ///     The other.
     /// </summary>
-    public abstract class BaseFormatter
+    protected const string OtherKey = "other";
+
+    #endregion
+
+    #region Methods
+
+    /// <summary>
+    ///     Parses the arguments.
+    /// </summary>
+    /// <param name="request">
+    ///     The request.
+    /// </param>
+    /// <returns>
+    ///     The <see cref="ParsedArguments" />.
+    /// </returns>
+    protected internal ParsedArguments ParseArguments(FormatterRequest request)
     {
-        #region Constants
+        int index;
+        var extensions = this.ParseExtensions(request, out index);
+        var keyedBlocks = this.ParseKeyedBlocks(request, index);
+        return new ParsedArguments(keyedBlocks, extensions);
+    }
 
-        /// <summary>
-        ///     The other.
-        /// </summary>
-        protected const string OtherKey = "other";
-
-        #endregion
-
-        #region Methods
-
-        /// <summary>
-        ///     Parses the arguments.
-        /// </summary>
-        /// <param name="request">
-        ///     The request.
-        /// </param>
-        /// <returns>
-        ///     The <see cref="ParsedArguments" />.
-        /// </returns>
-        protected internal ParsedArguments ParseArguments(FormatterRequest request)
+    /// <summary>
+    ///     Parses the extensions.
+    /// </summary>
+    /// <param name="request">The request.</param>
+    /// <param name="index">The index.</param>
+    /// <returns>The formatter extensions.</returns>
+    protected internal IEnumerable<FormatterExtension> ParseExtensions(FormatterRequest request, out int index)
+    {
+        var result = new List<FormatterExtension>();
+        if (request.FormatterArguments == null)
         {
-            int index;
-            var extensions = this.ParseExtensions(request, out index);
-            var keyedBlocks = this.ParseKeyedBlocks(request, index);
-            return new ParsedArguments(keyedBlocks, extensions);
+            index = -1;
+            return Enumerable.Empty<FormatterExtension>();
         }
-
-        /// <summary>
-        ///     Parses the extensions.
-        /// </summary>
-        /// <param name="request">The request.</param>
-        /// <param name="index">The index.</param>
-        /// <returns>The formatter extensions.</returns>
-        protected internal IEnumerable<FormatterExtension> ParseExtensions(FormatterRequest request, out int index)
-        {
-            var result = new List<FormatterExtension>();
-            if (request.FormatterArguments == null)
-            {
-                index = -1;
-                return Enumerable.Empty<FormatterExtension>();
-            }
             
-            var length = request.FormatterArguments.Length;
-            index = 0;
-            const char Colon = ':';
-            const char OpenBrace = '{';
-            var foundExtension = false;
+        var length = request.FormatterArguments.Length;
+        index = 0;
+        const char Colon = ':';
+        const char OpenBrace = '{';
+        var foundExtension = false;
 
-            var extension = StringBuilderPool.Get();
-            var value = StringBuilderPool.Get();
-            try
+        var extension = StringBuilderPool.Get();
+        var value = StringBuilderPool.Get();
+        try
+        {
+            for (var i = 0; i < length; i++)
             {
-                for (var i = 0; i < length; i++)
+                var c = request.FormatterArguments[i];
+
+                // Whitespace is tolerated at the beginning.
+                var isWhiteSpace = char.IsWhiteSpace(c);
+                if (isWhiteSpace)
                 {
-                    var c = request.FormatterArguments[i];
-
-                    // Whitespace is tolerated at the beginning.
-                    var isWhiteSpace = char.IsWhiteSpace(c);
-                    if (isWhiteSpace)
+                    // We've reached the end
+                    if (value.Length > 0)
                     {
-                        // We've reached the end
-                        if (value.Length > 0)
-                        {
-                            foundExtension = false;
-                            result.Add(new FormatterExtension(extension.ToString(), value.ToString()));
-                            extension.Clear();
-                            value.Clear();
-                            index = i;
-                            continue;
-                        }
-
-                        if (extension.Length > 0)
-                        {
-                            // It's not an extension, so we're done looking.
-                            break;
-                        }
-
+                        foundExtension = false;
+                        result.Add(new FormatterExtension(extension.ToString(), value.ToString()));
+                        extension.Clear();
+                        value.Clear();
+                        index = i;
                         continue;
                     }
 
-                    if (c == Colon)
+                    if (extension.Length > 0)
                     {
-                        foundExtension = true;
-                        continue;
-                    }
-
-                    if (foundExtension)
-                    {
-                        value.Append(c);
-                        continue;
-                    }
-
-                    if (c == OpenBrace)
-                    {
-                        // It's not an extension.
+                        // It's not an extension, so we're done looking.
                         break;
                     }
 
-                    extension.Append(c);
+                    continue;
                 }
 
-                return result;
+                if (c == Colon)
+                {
+                    foundExtension = true;
+                    continue;
+                }
+
+                if (foundExtension)
+                {
+                    value.Append(c);
+                    continue;
+                }
+
+                if (c == OpenBrace)
+                {
+                    // It's not an extension.
+                    break;
+                }
+
+                extension.Append(c);
             }
-            finally
-            {
-                StringBuilderPool.Return(extension);
-                StringBuilderPool.Return(value);
-            }
+
+            return result;
+        }
+        finally
+        {
+            StringBuilderPool.Return(extension);
+            StringBuilderPool.Return(value);
+        }
+    }
+
+    /// <summary>
+    ///     Parses the keyed blocks.
+    /// </summary>
+    /// <param name="request">
+    ///     The request.
+    /// </param>
+    /// <param name="startIndex">
+    ///     The start index.
+    /// </param>
+    /// <returns>
+    ///     The keyed blocks.
+    /// </returns>
+    protected internal IEnumerable<KeyedBlock> ParseKeyedBlocks(FormatterRequest request, int startIndex)
+    {
+        const char OpenBrace = '{';
+        const char CloseBrace = '}';
+        const char EscapingChar = '\'';
+
+        var result = new List<KeyedBlock>();
+        var braceBalance = 0;
+        var foundWhitespaceAfterKey = false;
+        var insideEscapeSequence = false;
+        if (request.FormatterArguments == null)
+        {
+            return Enumerable.Empty<KeyedBlock>();
         }
 
-        /// <summary>
-        ///     Parses the keyed blocks.
-        /// </summary>
-        /// <param name="request">
-        ///     The request.
-        /// </param>
-        /// <param name="startIndex">
-        ///     The start index.
-        /// </param>
-        /// <returns>
-        ///     The keyed blocks.
-        /// </returns>
-        protected internal IEnumerable<KeyedBlock> ParseKeyedBlocks(FormatterRequest request, int startIndex)
+        var key = StringBuilderPool.Get();
+        var block = StringBuilderPool.Get();
+
+        try
         {
-            const char OpenBrace = '{';
-            const char CloseBrace = '}';
-            const char EscapingChar = '\'';
-
-            var result = new List<KeyedBlock>();
-            var braceBalance = 0;
-            var foundWhitespaceAfterKey = false;
-            var insideEscapeSequence = false;
-            if (request.FormatterArguments == null)
+            for (int i = startIndex; i < request.FormatterArguments.Length; i++)
             {
-                return Enumerable.Empty<KeyedBlock>();
-            }
+                var c = request.FormatterArguments[i];
+                var isWhitespace = char.IsWhiteSpace(c);
 
-            var key = StringBuilderPool.Get();
-            var block = StringBuilderPool.Get();
-
-            try
-            {
-                for (int i = startIndex; i < request.FormatterArguments.Length; i++)
+                if (c == EscapingChar)
                 {
-                    var c = request.FormatterArguments[i];
-                    var isWhitespace = char.IsWhiteSpace(c);
-
-                    if (c == EscapingChar)
+                    if (braceBalance == 0)
                     {
-                        if (braceBalance == 0)
-                        {
-                            throw new MalformedLiteralException(
-                                "Expected a key, but found start of a escape sequence.",
-                                0,
-                                0,
-                                request.FormatterArguments);
-                        }
+                        throw new MalformedLiteralException(
+                            "Expected a key, but found start of a escape sequence.",
+                            0,
+                            0,
+                            request.FormatterArguments);
+                    }
 
-                        if (i == request.FormatterArguments.Length - 1)
-                        {
-                            if (!insideEscapeSequence)
-                                block.Append(EscapingChar);
-
-                            // The last char can't open a new escape sequence, it can only close one
-                            if (insideEscapeSequence)
-                            {
-                                insideEscapeSequence = false;
-                            }
-
-                            continue;
-                        }
-
-                        var nextChar = request.FormatterArguments[i + 1];
-                        if (nextChar == EscapingChar)
-                        {
+                    if (i == request.FormatterArguments.Length - 1)
+                    {
+                        if (!insideEscapeSequence)
                             block.Append(EscapingChar);
-                            block.Append(EscapingChar);
-                            ++i;
-                            continue;
-                        }
 
+                        // The last char can't open a new escape sequence, it can only close one
                         if (insideEscapeSequence)
                         {
-                            block.Append(EscapingChar);
                             insideEscapeSequence = false;
-                            continue;
                         }
 
-                        if (nextChar == '{' || nextChar == '}' || nextChar == '#')
-                        {
-                            block.Append(EscapingChar);
-                            block.Append(nextChar);
-                            insideEscapeSequence = true;
-                            ++i;
-                            continue;
-                        }
+                        continue;
+                    }
 
+                    var nextChar = request.FormatterArguments[i + 1];
+                    if (nextChar == EscapingChar)
+                    {
                         block.Append(EscapingChar);
+                        block.Append(EscapingChar);
+                        ++i;
                         continue;
                     }
 
                     if (insideEscapeSequence)
                     {
-                        block.Append(c);
+                        block.Append(EscapingChar);
+                        insideEscapeSequence = false;
                         continue;
                     }
 
-                    if (c == OpenBrace)
+                    if (nextChar == '{' || nextChar == '}' || nextChar == '#')
                     {
-                        if (key.Length == 0)
-                        {
-                            throw new MalformedLiteralException(
-                                "Expected a key, but found start of a new block.",
-                                0,
-                                0,
-                                request.FormatterArguments);
-                        }
-
-                        braceBalance++;
-                        if (braceBalance > 1)
-                        {
-                            block.Append(c);
-                        }
-
+                        block.Append(EscapingChar);
+                        block.Append(nextChar);
+                        insideEscapeSequence = true;
+                        ++i;
                         continue;
                     }
 
-                    if (c == CloseBrace)
-                    {
-                        if (key.Length == 0)
-                        {
-                            throw new MalformedLiteralException(
-                                "Expected a key, but found end of a block.",
-                                0,
-                                0,
-                                request.FormatterArguments);
-                        }
-
-                        if (braceBalance == 0)
-                        {
-                            throw new MalformedLiteralException(
-                                "Found end of a block, but no block has been started, or the"
-                                + " block has already been closed. " +
-                                "This could indicate an unescaped brace somewhere.",
-                                0,
-                                0,
-                                request.FormatterArguments);
-                        }
-
-                        braceBalance--;
-                        if (braceBalance == 0)
-                        {
-                            result.Add(new KeyedBlock(key.ToString(), block.ToString()));
-                            block.Clear();
-                            key.Clear();
-                            foundWhitespaceAfterKey = false;
-                            continue;
-                        }
-                    }
-
-                    // If we are inside a block, append to the block buffer
-                    if (braceBalance > 0)
-                    {
-                        block.Append(c);
-                        continue;
-                    }
-
-                    // Else, we are buffering our key
-                    if (isWhitespace == false)
-                    {
-                        if (foundWhitespaceAfterKey)
-                        {
-                            throw new MalformedLiteralException(
-                                "Any whitespace after a key should be followed by the beginning of a block.",
-                                0,
-                                0,
-                                request.FormatterArguments);
-                        }
-
-                        key.Append(c);
-                    }
-                    else if (key.Length > 0)
-                    {
-                        foundWhitespaceAfterKey = true;
-                    }
+                    block.Append(EscapingChar);
+                    continue;
                 }
 
                 if (insideEscapeSequence)
                 {
-                    throw new MalformedLiteralException(
-                        "There is an unclosed escape sequence.",
-                        0,
-                        0,
-                        request.FormatterArguments);
+                    block.Append(c);
+                    continue;
                 }
 
+                if (c == OpenBrace)
+                {
+                    if (key.Length == 0)
+                    {
+                        throw new MalformedLiteralException(
+                            "Expected a key, but found start of a new block.",
+                            0,
+                            0,
+                            request.FormatterArguments);
+                    }
+
+                    braceBalance++;
+                    if (braceBalance > 1)
+                    {
+                        block.Append(c);
+                    }
+
+                    continue;
+                }
+
+                if (c == CloseBrace)
+                {
+                    if (key.Length == 0)
+                    {
+                        throw new MalformedLiteralException(
+                            "Expected a key, but found end of a block.",
+                            0,
+                            0,
+                            request.FormatterArguments);
+                    }
+
+                    if (braceBalance == 0)
+                    {
+                        throw new MalformedLiteralException(
+                            "Found end of a block, but no block has been started, or the"
+                            + " block has already been closed. " +
+                            "This could indicate an unescaped brace somewhere.",
+                            0,
+                            0,
+                            request.FormatterArguments);
+                    }
+
+                    braceBalance--;
+                    if (braceBalance == 0)
+                    {
+                        result.Add(new KeyedBlock(key.ToString(), block.ToString()));
+                        block.Clear();
+                        key.Clear();
+                        foundWhitespaceAfterKey = false;
+                        continue;
+                    }
+                }
+
+                // If we are inside a block, append to the block buffer
                 if (braceBalance > 0)
                 {
-                    throw new MalformedLiteralException(
-                        "There are more open braces than there are close braces.",
-                        0,
-                        0,
-                        request.FormatterArguments);
+                    block.Append(c);
+                    continue;
                 }
 
-                return result;
-            }
-            finally
-            {
-                StringBuilderPool.Return(key);
-                StringBuilderPool.Return(block);
-            }
-        }
+                // Else, we are buffering our key
+                if (isWhitespace == false)
+                {
+                    if (foundWhitespaceAfterKey)
+                    {
+                        throw new MalformedLiteralException(
+                            "Any whitespace after a key should be followed by the beginning of a block.",
+                            0,
+                            0,
+                            request.FormatterArguments);
+                    }
 
-        #endregion
+                    key.Append(c);
+                }
+                else if (key.Length > 0)
+                {
+                    foundWhitespaceAfterKey = true;
+                }
+            }
+
+            if (insideEscapeSequence)
+            {
+                throw new MalformedLiteralException(
+                    "There is an unclosed escape sequence.",
+                    0,
+                    0,
+                    request.FormatterArguments);
+            }
+
+            if (braceBalance > 0)
+            {
+                throw new MalformedLiteralException(
+                    "There are more open braces than there are close braces.",
+                    0,
+                    0,
+                    request.FormatterArguments);
+            }
+
+            return result;
+        }
+        finally
+        {
+            StringBuilderPool.Return(key);
+            StringBuilderPool.Return(block);
+        }
     }
+
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat/Formatting/FormatterExtension.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/FormatterExtension.cs
@@ -2,51 +2,50 @@
 // - FormatterExtension.cs
 // Author: Jeff Hansen <jeff@jeffijoe.com>
 // Copyright (C) Jeff Hansen 2014. All rights reserved.
-namespace Jeffijoe.MessageFormat.Formatting
+namespace Jeffijoe.MessageFormat.Formatting;
+
+/// <summary>
+///     Contains extensions to be used by formatters.
+///     Example, the offset extension for the Plural Format.
+/// </summary>
+public class FormatterExtension
 {
+    #region Constructors and Destructors
+
     /// <summary>
-    ///     Contains extensions to be used by formatters.
-    ///     Example, the offset extension for the Plural Format.
+    ///     Initializes a new instance of the <see cref="FormatterExtension" /> class.
     /// </summary>
-    public class FormatterExtension
+    /// <param name="extension">
+    ///     The extension.
+    /// </param>
+    /// <param name="value">
+    ///     The value.
+    /// </param>
+    public FormatterExtension(string extension, string value)
     {
-        #region Constructors and Destructors
-
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="FormatterExtension" /> class.
-        /// </summary>
-        /// <param name="extension">
-        ///     The extension.
-        /// </param>
-        /// <param name="value">
-        ///     The value.
-        /// </param>
-        public FormatterExtension(string extension, string value)
-        {
-            this.Extension = extension;
-            this.Value = value;
-        }
-
-        #endregion
-
-        #region Public Properties
-
-        /// <summary>
-        ///     Gets the extension.
-        /// </summary>
-        /// <value>
-        ///     The extension.
-        /// </value>
-        public string Extension { get; private set; }
-
-        /// <summary>
-        ///     Gets the value.
-        /// </summary>
-        /// <value>
-        ///     The value.
-        /// </value>
-        public string Value { get; private set; }
-
-        #endregion
+        this.Extension = extension;
+        this.Value = value;
     }
+
+    #endregion
+
+    #region Public Properties
+
+    /// <summary>
+    ///     Gets the extension.
+    /// </summary>
+    /// <value>
+    ///     The extension.
+    /// </value>
+    public string Extension { get; private set; }
+
+    /// <summary>
+    ///     Gets the value.
+    /// </summary>
+    /// <value>
+    ///     The value.
+    /// </value>
+    public string Value { get; private set; }
+
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat/Formatting/FormatterLibrary.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/FormatterLibrary.cs
@@ -6,55 +6,54 @@
 using System.Collections.Generic;
 using Jeffijoe.MessageFormat.Formatting.Formatters;
 
-namespace Jeffijoe.MessageFormat.Formatting
+namespace Jeffijoe.MessageFormat.Formatting;
+
+/// <summary>
+///     Manages formatters to use.
+/// </summary>
+public class FormatterLibrary : List<IFormatter>, IFormatterLibrary
 {
+    #region Constructors and Destructors
+
     /// <summary>
-    ///     Manages formatters to use.
+    ///     Initializes a new instance of the <see cref="FormatterLibrary" /> class, and adds the default formatters.
     /// </summary>
-    public class FormatterLibrary : List<IFormatter>, IFormatterLibrary
+    public FormatterLibrary()
     {
-        #region Constructors and Destructors
-
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="FormatterLibrary" /> class, and adds the default formatters.
-        /// </summary>
-        public FormatterLibrary()
-        {
-            this.Add(new VariableFormatter());
-            this.Add(new SelectFormatter());
-            this.Add(new PluralFormatter());
-            this.Add(new NumberFormatter());
-            this.Add(new DateFormatter());
-            this.Add(new TimeFormatter());
-        }
-
-        #endregion
-
-        #region Public Methods and Operators
-
-        /// <summary>
-        ///     Gets the formatter to use. If none was found, throws an exception.
-        /// </summary>
-        /// <param name="request">
-        ///     The request.
-        /// </param>
-        /// <returns>
-        ///     The <see cref="IFormatter" />.
-        /// </returns>
-        /// <exception cref="FormatterNotFoundException">
-        ///     Thrown when the formatter was not found.
-        /// </exception>
-        public IFormatter GetFormatter(FormatterRequest request)
-        {
-            foreach (var formatter in this)
-            {
-                if (formatter.CanFormat(request))
-                    return formatter;
-            }
-
-            throw new FormatterNotFoundException(request);
-        }
-
-        #endregion
+        this.Add(new VariableFormatter());
+        this.Add(new SelectFormatter());
+        this.Add(new PluralFormatter());
+        this.Add(new NumberFormatter());
+        this.Add(new DateFormatter());
+        this.Add(new TimeFormatter());
     }
+
+    #endregion
+
+    #region Public Methods and Operators
+
+    /// <summary>
+    ///     Gets the formatter to use. If none was found, throws an exception.
+    /// </summary>
+    /// <param name="request">
+    ///     The request.
+    /// </param>
+    /// <returns>
+    ///     The <see cref="IFormatter" />.
+    /// </returns>
+    /// <exception cref="FormatterNotFoundException">
+    ///     Thrown when the formatter was not found.
+    /// </exception>
+    public IFormatter GetFormatter(FormatterRequest request)
+    {
+        foreach (var formatter in this)
+        {
+            if (formatter.CanFormat(request))
+                return formatter;
+        }
+
+        throw new FormatterNotFoundException(request);
+    }
+
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat/Formatting/FormatterRequest.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/FormatterRequest.cs
@@ -5,93 +5,92 @@
 
 using Jeffijoe.MessageFormat.Parsing;
 
-namespace Jeffijoe.MessageFormat.Formatting
+namespace Jeffijoe.MessageFormat.Formatting;
+
+/// <summary>
+///     Formatter request.
+/// </summary>
+public class FormatterRequest
 {
+    #region Constructors and Destructors
+
     /// <summary>
-    ///     Formatter request.
+    ///     Initializes a new instance of the <see cref="FormatterRequest" /> class.
     /// </summary>
-    public class FormatterRequest
+    /// <param name="sourceLiteral">
+    ///     The source literal.
+    /// </param>
+    /// <param name="variable">
+    ///     The variable.
+    /// </param>
+    /// <param name="formatterName">
+    ///     Name of the formatter.
+    /// </param>
+    /// <param name="formatterArguments">
+    ///     The formatter arguments.
+    /// </param>
+    public FormatterRequest(Literal sourceLiteral, string variable, string? formatterName, string? formatterArguments)
     {
-        #region Constructors and Destructors
-
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="FormatterRequest" /> class.
-        /// </summary>
-        /// <param name="sourceLiteral">
-        ///     The source literal.
-        /// </param>
-        /// <param name="variable">
-        ///     The variable.
-        /// </param>
-        /// <param name="formatterName">
-        ///     Name of the formatter.
-        /// </param>
-        /// <param name="formatterArguments">
-        ///     The formatter arguments.
-        /// </param>
-        public FormatterRequest(Literal sourceLiteral, string variable, string? formatterName, string? formatterArguments)
-        {
-            this.SourceLiteral = sourceLiteral;
-            this.Variable = variable;
-            this.FormatterName = formatterName;
-            this.FormatterArguments = formatterArguments;
-        }
-
-        #endregion
-
-        #region Public Properties
-
-        /// <summary>
-        ///     Gets the formatter arguments that the formatter implementation will parse. Can be null.
-        /// </summary>
-        /// <value>
-        ///     The formatter arguments.
-        /// </value>
-        public string? FormatterArguments { get; }
-
-        /// <summary>
-        ///     Gets the name of the formatter to use . e.g. 'select', 'plural'. Can be null.
-        /// </summary>
-        /// <value>
-        ///     The name of the formatter.
-        /// </value>
-        public string? FormatterName { get; }
-
-        /// <summary>
-        ///     Gets the source literal.
-        /// </summary>
-        /// <value>
-        ///     The source literal.
-        /// </value>
-        public Literal SourceLiteral { get; }
-
-        /// <summary>
-        ///     Gets the variable name. Never null.
-        /// </summary>
-        /// <value>
-        ///     The variable.
-        /// </value>
-        public string Variable { get; }
-
-        #endregion
-
-        #region Public Methods and Operators
-
-        /// <summary>
-        ///     Clones this instance.
-        /// </summary>
-        /// <returns>
-        ///     The <see cref="FormatterRequest" />.
-        /// </returns>
-        public FormatterRequest Clone()
-        {
-            return new FormatterRequest(
-                this.SourceLiteral.Clone(), 
-                this.Variable, 
-                this.FormatterName, 
-                this.FormatterArguments);
-        }
-
-        #endregion
+        this.SourceLiteral = sourceLiteral;
+        this.Variable = variable;
+        this.FormatterName = formatterName;
+        this.FormatterArguments = formatterArguments;
     }
+
+    #endregion
+
+    #region Public Properties
+
+    /// <summary>
+    ///     Gets the formatter arguments that the formatter implementation will parse. Can be null.
+    /// </summary>
+    /// <value>
+    ///     The formatter arguments.
+    /// </value>
+    public string? FormatterArguments { get; }
+
+    /// <summary>
+    ///     Gets the name of the formatter to use . e.g. 'select', 'plural'. Can be null.
+    /// </summary>
+    /// <value>
+    ///     The name of the formatter.
+    /// </value>
+    public string? FormatterName { get; }
+
+    /// <summary>
+    ///     Gets the source literal.
+    /// </summary>
+    /// <value>
+    ///     The source literal.
+    /// </value>
+    public Literal SourceLiteral { get; }
+
+    /// <summary>
+    ///     Gets the variable name. Never null.
+    /// </summary>
+    /// <value>
+    ///     The variable.
+    /// </value>
+    public string Variable { get; }
+
+    #endregion
+
+    #region Public Methods and Operators
+
+    /// <summary>
+    ///     Clones this instance.
+    /// </summary>
+    /// <returns>
+    ///     The <see cref="FormatterRequest" />.
+    /// </returns>
+    public FormatterRequest Clone()
+    {
+        return new FormatterRequest(
+            this.SourceLiteral.Clone(), 
+            this.Variable, 
+            this.FormatterName, 
+            this.FormatterArguments);
+    }
+
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat/Formatting/Formatters/PluralContext.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/Formatters/PluralContext.cs
@@ -1,15 +1,44 @@
 ﻿using System;
 using System.Globalization;
 
-namespace Jeffijoe.MessageFormat.Formatting.Formatters
+namespace Jeffijoe.MessageFormat.Formatting.Formatters;
+
+internal readonly struct PluralContext
 {
-    internal readonly struct PluralContext
+    public PluralContext(int number)
     {
-        public PluralContext(int number)
+        Number = number;
+        N = Math.Abs(number);
+        I = number;
+        V = 0;
+        W = 0;
+        F = 0;
+        T = 0;
+        C = 0;
+        E = 0;
+    }
+        
+    public PluralContext(decimal number) : this(number.ToString(CultureInfo.InvariantCulture), (double) number)
+    {
+    }
+
+    public PluralContext(double number) : this(number.ToString(CultureInfo.InvariantCulture), number)
+    {
+    }
+
+    public PluralContext(string number) : this(number, double.Parse(number, CultureInfo.InvariantCulture))
+    {
+    }
+
+    private PluralContext(string number, double parsed)
+    {
+        Number = parsed;
+        N = Math.Abs(parsed);
+        I = (int) parsed;
+
+        var dotIndex = number.IndexOf('.');
+        if (dotIndex == -1)
         {
-            Number = number;
-            N = Math.Abs(number);
-            I = number;
             V = 0;
             W = 0;
             F = 0;
@@ -17,70 +46,40 @@ namespace Jeffijoe.MessageFormat.Formatting.Formatters
             C = 0;
             E = 0;
         }
-        
-        public PluralContext(decimal number) : this(number.ToString(CultureInfo.InvariantCulture), (double) number)
+        else
         {
-        }
-
-        public PluralContext(double number) : this(number.ToString(CultureInfo.InvariantCulture), number)
-        {
-        }
-
-        public PluralContext(string number) : this(number, double.Parse(number, CultureInfo.InvariantCulture))
-        {
-        }
-
-        private PluralContext(string number, double parsed)
-        {
-            Number = parsed;
-            N = Math.Abs(parsed);
-            I = (int) parsed;
-
-            var dotIndex = number.IndexOf('.');
-            if (dotIndex == -1)
-            {
-                V = 0;
-                W = 0;
-                F = 0;
-                T = 0;
-                C = 0;
-                E = 0;
-            }
-            else
-            {
 #if NET5_0_OR_GREATER
                 var fractionSpan = number.AsSpan(dotIndex + 1, number.Length - dotIndex - 1);
                 var fractionSpanWithoutZeroes = fractionSpan.TrimEnd('0');
 #else
-                var fractionSpan = number.Substring(dotIndex + 1, number.Length - dotIndex - 1);
-                var fractionSpanWithoutZeroes = fractionSpan.TrimEnd('0');
+            var fractionSpan = number.Substring(dotIndex + 1, number.Length - dotIndex - 1);
+            var fractionSpanWithoutZeroes = fractionSpan.TrimEnd('0');
 #endif
 
-                V = fractionSpan.Length;
-                W = fractionSpanWithoutZeroes.Length;
-                F = int.Parse(fractionSpan);
-                T = int.Parse(fractionSpanWithoutZeroes);
-                C = 0;
-                E = 0;
-            }
+            V = fractionSpan.Length;
+            W = fractionSpanWithoutZeroes.Length;
+            F = int.Parse(fractionSpan);
+            T = int.Parse(fractionSpanWithoutZeroes);
+            C = 0;
+            E = 0;
         }
-
-        public double Number { get; }
-
-        public double N { get; }
-
-        public int I { get; }
-
-        public int V { get; }
-
-        public int W { get; }
-
-        public int F { get; }
-
-        public int T { get; }
-
-        public int C { get; }
-
-        public int E { get; }
     }
+
+    public double Number { get; }
+
+    public double N { get; }
+
+    public int I { get; }
+
+    public int V { get; }
+
+    public int W { get; }
+
+    public int F { get; }
+
+    public int T { get; }
+
+    public int C { get; }
+
+    public int E { get; }
 }

--- a/src/Jeffijoe.MessageFormat/Formatting/Formatters/PluralFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/Formatters/PluralFormatter.cs
@@ -8,339 +8,338 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
-namespace Jeffijoe.MessageFormat.Formatting.Formatters
+namespace Jeffijoe.MessageFormat.Formatting.Formatters;
+
+/// <summary>
+///     Plural Formatter
+/// </summary>
+public class PluralFormatter : BaseFormatter, IFormatter
 {
+    #region Constructors and Destructors
+
     /// <summary>
-    ///     Plural Formatter
+    ///     Initializes a new instance of the <see cref="PluralFormatter" /> class.
     /// </summary>
-    public class PluralFormatter : BaseFormatter, IFormatter
+    public PluralFormatter()
     {
-        #region Constructors and Destructors
+        this.Pluralizers = new Dictionary<string, Pluralizer>();
+        this.AddStandardPluralizers();
+    }
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="PluralFormatter" /> class.
-        /// </summary>
-        public PluralFormatter()
+    #endregion
+
+    #region Public Properties
+
+    /// <summary>
+    ///     This formatter requires the input variable to exist.
+    /// </summary>
+    public bool VariableMustExist => true;
+
+
+    /// <summary>
+    ///     Gets the pluralizers dictionary. Key is the locale.
+    /// </summary>
+    /// <value>
+    ///     The pluralizers.
+    /// </value>
+    public IDictionary<string, Pluralizer> Pluralizers { get; private set; }
+
+    #endregion
+
+    #region Public Methods and Operators
+
+    /// <summary>
+    ///     Determines whether this instance can format a message based on the specified parameters.
+    /// </summary>
+    /// <param name="request">
+    ///     The parameters.
+    /// </param>
+    /// <returns>
+    ///     The <see cref="bool" />.
+    /// </returns>
+    public bool CanFormat(FormatterRequest request)
+    {
+        return request.FormatterName == "plural";
+    }
+
+    /// <summary>
+    ///     Using the specified parameters and arguments, a formatted string shall be returned.
+    ///     The <see cref="IMessageFormatter" /> is being provided as well, to enable
+    ///     nested formatting. This is only called if <see cref="CanFormat" /> returns true.
+    ///     The args will always contain the <see cref="FormatterRequest.Variable" />.
+    /// </summary>
+    /// <param name="locale">
+    ///     The locale being used. It is up to the formatter what they do with this information.
+    /// </param>
+    /// <param name="request">
+    ///     The parameters.
+    /// </param>
+    /// <param name="args">
+    ///     The arguments.
+    /// </param>
+    /// <param name="value">The value of <see cref="FormatterRequest.Variable"/> from the given args dictionary. Can be null.</param>
+    /// <param name="messageFormatter">
+    ///     The message formatter.
+    /// </param>
+    /// <returns>
+    ///     The <see cref="string" />.
+    /// </returns>
+    public string Format(string locale,
+        FormatterRequest request,
+        IReadOnlyDictionary<string, object?> args,
+        object? value,
+        IMessageFormatter messageFormatter)
+    {
+        var arguments = this.ParseArguments(request);
+        double offset = 0;
+        var offsetExtension = arguments.Extensions.FirstOrDefault(x => x.Extension == "offset");
+        if (offsetExtension != null)
         {
-            this.Pluralizers = new Dictionary<string, Pluralizer>();
-            this.AddStandardPluralizers();
+            offset = Convert.ToDouble(offsetExtension.Value);
         }
 
-        #endregion
+        var ctx = CreatePluralContext(value, offset);
+        var pluralized = this.Pluralize(locale, arguments, ctx, offset);
+        var result = this.ReplaceNumberLiterals(pluralized, ctx.Number);
+        var formatted = messageFormatter.FormatMessage(result, args);
+        return formatted;
+    }
 
-        #region Public Properties
+    #endregion
 
-        /// <summary>
-        ///     This formatter requires the input variable to exist.
-        /// </summary>
-        public bool VariableMustExist => true;
+    #region Methods
 
-
-        /// <summary>
-        ///     Gets the pluralizers dictionary. Key is the locale.
-        /// </summary>
-        /// <value>
-        ///     The pluralizers.
-        /// </value>
-        public IDictionary<string, Pluralizer> Pluralizers { get; private set; }
-
-        #endregion
-
-        #region Public Methods and Operators
-
-        /// <summary>
-        ///     Determines whether this instance can format a message based on the specified parameters.
-        /// </summary>
-        /// <param name="request">
-        ///     The parameters.
-        /// </param>
-        /// <returns>
-        ///     The <see cref="bool" />.
-        /// </returns>
-        public bool CanFormat(FormatterRequest request)
+    /// <summary>
+    ///     Returns the correct plural block.
+    /// </summary>
+    /// <param name="locale">
+    ///     The locale.
+    /// </param>
+    /// <param name="arguments">
+    ///     The parsed arguments string.
+    /// </param>
+    /// <param name="context">
+    ///     The plural context.
+    /// </param>
+    /// <param name="offset">
+    ///     The offset (already applied in context).
+    /// </param>
+    /// <returns>
+    ///     The <see cref="string" />.
+    /// </returns>
+    /// <exception cref="MessageFormatterException">
+    ///     The 'other' option was not found in pattern.
+    /// </exception>
+    [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1126:PrefixCallsCorrectly",
+        Justification = "Reviewed. Suppression is OK here.")]
+    internal string Pluralize(string locale, ParsedArguments arguments, PluralContext context, double offset)
+    {
+        string pluralForm;
+        if (this.Pluralizers.TryGetValue(locale, out var pluralizer))
         {
-            return request.FormatterName == "plural";
+            pluralForm = pluralizer(context.Number);
         }
-
-        /// <summary>
-        ///     Using the specified parameters and arguments, a formatted string shall be returned.
-        ///     The <see cref="IMessageFormatter" /> is being provided as well, to enable
-        ///     nested formatting. This is only called if <see cref="CanFormat" /> returns true.
-        ///     The args will always contain the <see cref="FormatterRequest.Variable" />.
-        /// </summary>
-        /// <param name="locale">
-        ///     The locale being used. It is up to the formatter what they do with this information.
-        /// </param>
-        /// <param name="request">
-        ///     The parameters.
-        /// </param>
-        /// <param name="args">
-        ///     The arguments.
-        /// </param>
-        /// <param name="value">The value of <see cref="FormatterRequest.Variable"/> from the given args dictionary. Can be null.</param>
-        /// <param name="messageFormatter">
-        ///     The message formatter.
-        /// </param>
-        /// <returns>
-        ///     The <see cref="string" />.
-        /// </returns>
-        public string Format(string locale,
-            FormatterRequest request,
-            IReadOnlyDictionary<string, object?> args,
-            object? value,
-            IMessageFormatter messageFormatter)
+        else if (PluralRulesMetadata.TryGetRuleByLocale(locale, out var contextPluralizer))
         {
-            var arguments = this.ParseArguments(request);
-            double offset = 0;
-            var offsetExtension = arguments.Extensions.FirstOrDefault(x => x.Extension == "offset");
-            if (offsetExtension != null)
-            {
-                offset = Convert.ToDouble(offsetExtension.Value);
-            }
-
-            var ctx = CreatePluralContext(value, offset);
-            var pluralized = this.Pluralize(locale, arguments, ctx, offset);
-            var result = this.ReplaceNumberLiterals(pluralized, ctx.Number);
-            var formatted = messageFormatter.FormatMessage(result, args);
-            return formatted;
+            pluralForm= contextPluralizer(context);
         }
-
-        #endregion
-
-        #region Methods
-
-        /// <summary>
-        ///     Returns the correct plural block.
-        /// </summary>
-        /// <param name="locale">
-        ///     The locale.
-        /// </param>
-        /// <param name="arguments">
-        ///     The parsed arguments string.
-        /// </param>
-        /// <param name="context">
-        ///     The plural context.
-        /// </param>
-        /// <param name="offset">
-        ///     The offset (already applied in context).
-        /// </param>
-        /// <returns>
-        ///     The <see cref="string" />.
-        /// </returns>
-        /// <exception cref="MessageFormatterException">
-        ///     The 'other' option was not found in pattern.
-        /// </exception>
-        [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1126:PrefixCallsCorrectly",
-            Justification = "Reviewed. Suppression is OK here.")]
-        internal string Pluralize(string locale, ParsedArguments arguments, PluralContext context, double offset)
+        else
         {
-            string pluralForm;
-            if (this.Pluralizers.TryGetValue(locale, out var pluralizer))
-            {
-                pluralForm = pluralizer(context.Number);
-            }
-            else if (PluralRulesMetadata.TryGetRuleByLocale(locale, out var contextPluralizer))
-            {
-                pluralForm= contextPluralizer(context);
-            }
-            else
-            {
-                pluralForm = this.Pluralizers["en"](context.Number);
-            }
+            pluralForm = this.Pluralizers["en"](context.Number);
+        }
             
-            KeyedBlock? other = null;
-            foreach (var keyedBlock in arguments.KeyedBlocks)
+        KeyedBlock? other = null;
+        foreach (var keyedBlock in arguments.KeyedBlocks)
+        {
+            if (keyedBlock.Key == OtherKey)
             {
-                if (keyedBlock.Key == OtherKey)
-                {
-                    other = keyedBlock;
-                }
+                other = keyedBlock;
+            }
 
-                if (keyedBlock.Key.StartsWith("="))
-                {
-                    var numberLiteral = Convert.ToDouble(keyedBlock.Key.Substring(1));
+            if (keyedBlock.Key.StartsWith("="))
+            {
+                var numberLiteral = Convert.ToDouble(keyedBlock.Key.Substring(1));
 
-                    // ReSharper disable once CompareOfFloatsByEqualityOperator
-                    if (numberLiteral == context.Number + offset)
-                    {
-                        return keyedBlock.BlockText;
-                    }
-                }
-
-                if (keyedBlock.Key == pluralForm)
+                // ReSharper disable once CompareOfFloatsByEqualityOperator
+                if (numberLiteral == context.Number + offset)
                 {
                     return keyedBlock.BlockText;
                 }
             }
 
-            if (other == null)
+            if (keyedBlock.Key == pluralForm)
             {
-                throw new MessageFormatterException("'other' option not found in pattern.");
+                return keyedBlock.BlockText;
             }
-
-            return other.BlockText;
         }
 
-        /// <summary>
-        ///     Replaces the number literals with the actual number.
-        /// </summary>
-        /// <param name="pluralized">
-        ///     The pluralized.
-        /// </param>
-        /// <param name="n">
-        ///     The n.
-        /// </param>
-        /// <returns>
-        ///     The <see cref="string" />.
-        /// </returns>
-        internal string ReplaceNumberLiterals(string pluralized, double n)
+        if (other == null)
         {
-            var sb = StringBuilderPool.Get();
+            throw new MessageFormatterException("'other' option not found in pattern.");
+        }
 
-            try
+        return other.BlockText;
+    }
+
+    /// <summary>
+    ///     Replaces the number literals with the actual number.
+    /// </summary>
+    /// <param name="pluralized">
+    ///     The pluralized.
+    /// </param>
+    /// <param name="n">
+    ///     The n.
+    /// </param>
+    /// <returns>
+    ///     The <see cref="string" />.
+    /// </returns>
+    internal string ReplaceNumberLiterals(string pluralized, double n)
+    {
+        var sb = StringBuilderPool.Get();
+
+        try
+        {
+            // I've done this a few times now..
+            const char OpenBrace = '{';
+            const char CloseBrace = '}';
+            const char Pound = '#';
+            const char EscapeChar = '\'';
+            var braceBalance = 0;
+            var insideEscapeSequence = false;
+            for (int i = 0; i < pluralized.Length; i++)
             {
-                // I've done this a few times now..
-                const char OpenBrace = '{';
-                const char CloseBrace = '}';
-                const char Pound = '#';
-                const char EscapeChar = '\'';
-                var braceBalance = 0;
-                var insideEscapeSequence = false;
-                for (int i = 0; i < pluralized.Length; i++)
+                var c = pluralized[i];
+
+                if (c == EscapeChar)
                 {
-                    var c = pluralized[i];
+                    // Append it anyway because the escae
+                    sb.Append(EscapeChar);
 
-                    if (c == EscapeChar)
+                    if (i == pluralized.Length - 1)
                     {
-                        // Append it anyway because the escae
-                        sb.Append(EscapeChar);
-
-                        if (i == pluralized.Length - 1)
-                        {
-                            // The last char can't open a new escape sequence, it can only close one
-                            if (insideEscapeSequence)
-                            {
-                                insideEscapeSequence = false;
-                            }
-
-                            continue;
-                        }
-
-                        var nextChar = pluralized[i + 1];
-                        if (nextChar == EscapeChar)
-                        {
-                            sb.Append(EscapeChar);
-                            ++i;
-                            continue;
-                        }
-
+                        // The last char can't open a new escape sequence, it can only close one
                         if (insideEscapeSequence)
                         {
                             insideEscapeSequence = false;
-                            continue;
                         }
 
-                        if (nextChar is '{' or '}' or '#')
-                        {
-                            sb.Append(nextChar);
-                            insideEscapeSequence = true;
-                            ++i;
-                        }
+                        continue;
+                    }
 
+                    var nextChar = pluralized[i + 1];
+                    if (nextChar == EscapeChar)
+                    {
+                        sb.Append(EscapeChar);
+                        ++i;
                         continue;
                     }
 
                     if (insideEscapeSequence)
                     {
-                        sb.Append(c);
+                        insideEscapeSequence = false;
                         continue;
                     }
 
-                    if (c == OpenBrace)
+                    if (nextChar is '{' or '}' or '#')
                     {
-                        braceBalance++;
-                    }
-                    else if (c == CloseBrace)
-                    {
-                        braceBalance--;
-                    }
-                    else if (c == Pound)
-                    {
-                        if (braceBalance == 0)
-                        {
-                            sb.Append(n);
-                            continue;
-                        }
+                        sb.Append(nextChar);
+                        insideEscapeSequence = true;
+                        ++i;
                     }
 
+                    continue;
+                }
+
+                if (insideEscapeSequence)
+                {
                     sb.Append(c);
+                    continue;
                 }
 
-                return sb.ToString();
-            }
-            finally
-            {
-                StringBuilderPool.Return(sb);
-            }
-        }
-
-        /// <summary>
-        ///     Adds the standard pluralizers.
-        /// </summary>
-        private void AddStandardPluralizers()
-        {
-            this.Pluralizers.Add(
-                "en",
-                n =>
+                if (c == OpenBrace)
                 {
-                    // ReSharper disable CompareOfFloatsByEqualityOperator
-                    if (n == 0)
+                    braceBalance++;
+                }
+                else if (c == CloseBrace)
+                {
+                    braceBalance--;
+                }
+                else if (c == Pound)
+                {
+                    if (braceBalance == 0)
                     {
-                        return "zero";
+                        sb.Append(n);
+                        continue;
                     }
-
-                    if (n == 1)
-                    {
-                        return "one";
-                    }
-
-                    // ReSharper restore CompareOfFloatsByEqualityOperator
-                    return "other";
-                });
-        }
-
-        /// <summary>
-        ///     Creates a <see cref="PluralContext"/> for the specified value.
-        /// </summary>
-        /// <param name="value"></param>
-        /// <param name="offset"></param>
-        /// <returns></returns>
-        [ExcludeFromCodeCoverage]
-        private static PluralContext CreatePluralContext(object? value, double offset)
-        {
-            if (offset == 0)
-            {
-                if (value is string v)
-                {
-                    return new PluralContext(v);
                 }
 
-                if (value is int i)
-                {
-                    return new PluralContext(i);
-                }
-
-                if (value is decimal d)
-                {
-                    return new PluralContext(d);
-                }
-
-                return new PluralContext(Convert.ToDouble(value));
+                sb.Append(c);
             }
 
-            return new PluralContext(Convert.ToDouble(value) - offset);
+            return sb.ToString();
         }
-
-        #endregion
+        finally
+        {
+            StringBuilderPool.Return(sb);
+        }
     }
+
+    /// <summary>
+    ///     Adds the standard pluralizers.
+    /// </summary>
+    private void AddStandardPluralizers()
+    {
+        this.Pluralizers.Add(
+            "en",
+            n =>
+            {
+                // ReSharper disable CompareOfFloatsByEqualityOperator
+                if (n == 0)
+                {
+                    return "zero";
+                }
+
+                if (n == 1)
+                {
+                    return "one";
+                }
+
+                // ReSharper restore CompareOfFloatsByEqualityOperator
+                return "other";
+            });
+    }
+
+    /// <summary>
+    ///     Creates a <see cref="PluralContext"/> for the specified value.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <param name="offset"></param>
+    /// <returns></returns>
+    [ExcludeFromCodeCoverage]
+    private static PluralContext CreatePluralContext(object? value, double offset)
+    {
+        if (offset == 0)
+        {
+            if (value is string v)
+            {
+                return new PluralContext(v);
+            }
+
+            if (value is int i)
+            {
+                return new PluralContext(i);
+            }
+
+            if (value is decimal d)
+            {
+                return new PluralContext(d);
+            }
+
+            return new PluralContext(Convert.ToDouble(value));
+        }
+
+        return new PluralContext(Convert.ToDouble(value) - offset);
+    }
+
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat/Formatting/Formatters/PluralRulesMetadata.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/Formatters/PluralRulesMetadata.cs
@@ -1,8 +1,7 @@
-﻿namespace Jeffijoe.MessageFormat.Formatting.Formatters
+﻿namespace Jeffijoe.MessageFormat.Formatting.Formatters;
+
+[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+internal static partial class PluralRulesMetadata
 {
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    internal static partial class PluralRulesMetadata
-    {
-        public static partial bool TryGetRuleByLocale(string locale, out ContextPluralizer contextPluralizer);
-    }
+    public static partial bool TryGetRuleByLocale(string locale, out ContextPluralizer contextPluralizer);
 }

--- a/src/Jeffijoe.MessageFormat/Formatting/Formatters/Pluralizer.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/Formatters/Pluralizer.cs
@@ -2,19 +2,18 @@
 // - Pluralizer.cs
 // Author: Jeff Hansen <jeff@jeffijoe.com>
 // Copyright (C) Jeff Hansen 2014. All rights reserved.
-namespace Jeffijoe.MessageFormat.Formatting.Formatters
-{
-    /// <summary>
-    ///     Given the specified number, determines what plural form is being used.
-    /// </summary>
-    /// <param name="n">The number used to determine the pluralization rule..</param>
-    /// <returns>The plural form to use.</returns>
-    public delegate string Pluralizer(double n);
+namespace Jeffijoe.MessageFormat.Formatting.Formatters;
 
-    /// <summary>
-    ///     Given the specified number context, determines what plural form is being used.
-    /// </summary>
-    /// <param name="context">The context of the number used to determine the pluralization rule..</param>
-    /// <returns>The plural form to use.</returns>
-    internal delegate string ContextPluralizer(PluralContext context);
-}
+/// <summary>
+///     Given the specified number, determines what plural form is being used.
+/// </summary>
+/// <param name="n">The number used to determine the pluralization rule..</param>
+/// <returns>The plural form to use.</returns>
+public delegate string Pluralizer(double n);
+
+/// <summary>
+///     Given the specified number context, determines what plural form is being used.
+/// </summary>
+/// <param name="context">The context of the number used to determine the pluralization rule..</param>
+/// <returns>The plural form to use.</returns>
+internal delegate string ContextPluralizer(PluralContext context);

--- a/src/Jeffijoe.MessageFormat/Formatting/Formatters/SelectFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/Formatters/SelectFormatter.cs
@@ -65,11 +65,11 @@ namespace Jeffijoe.MessageFormat.Formatting.Formatters
             object? value,
             IMessageFormatter messageFormatter)
         {
+            var str = Convert.ToString(value);
             var parsed = this.ParseArguments(request);
             KeyedBlock? other = null;
             foreach (var keyedBlock in parsed.KeyedBlocks)
             {
-                var str = Convert.ToString(value);
                 if (str == keyedBlock.Key)
                 {
                     return messageFormatter.FormatMessage(keyedBlock.BlockText, args);

--- a/src/Jeffijoe.MessageFormat/Formatting/Formatters/SelectFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/Formatters/SelectFormatter.cs
@@ -7,89 +7,88 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
-namespace Jeffijoe.MessageFormat.Formatting.Formatters
+namespace Jeffijoe.MessageFormat.Formatting.Formatters;
+
+/// <summary>
+///     Implementation of the SelectFormat.
+/// </summary>
+public class SelectFormatter : BaseFormatter, IFormatter
 {
+    #region Public Properties
+
     /// <summary>
-    ///     Implementation of the SelectFormat.
+    ///     This formatter requires the input variable to exist.
     /// </summary>
-    public class SelectFormatter : BaseFormatter, IFormatter
+    [ExcludeFromCodeCoverage]
+    public bool VariableMustExist => true;
+        
+    #endregion
+        
+        
+    #region Public Methods and Operators
+        
+
+    /// <summary>
+    ///     Determines whether this instance can format a message based on the specified parameters.
+    /// </summary>
+    /// <param name="request">
+    ///     The parameters.
+    /// </param>
+    /// <returns>
+    ///     The <see cref="bool" />.
+    /// </returns>
+    public bool CanFormat(FormatterRequest request)
     {
-        #region Public Properties
-
-        /// <summary>
-        ///     This formatter requires the input variable to exist.
-        /// </summary>
-        [ExcludeFromCodeCoverage]
-        public bool VariableMustExist => true;
-        
-        #endregion
-        
-        
-        #region Public Methods and Operators
-        
-
-        /// <summary>
-        ///     Determines whether this instance can format a message based on the specified parameters.
-        /// </summary>
-        /// <param name="request">
-        ///     The parameters.
-        /// </param>
-        /// <returns>
-        ///     The <see cref="bool" />.
-        /// </returns>
-        public bool CanFormat(FormatterRequest request)
-        {
-            return request.FormatterName == "select";
-        }
-
-        /// <summary>
-        /// Using the specified parameters and arguments, a formatted string shall be returned.
-        /// The <see cref="IMessageFormatter" /> is being provided as well, to enable
-        /// nested formatting. This is only called if <see cref="CanFormat" /> returns true.
-        /// The args will always contain the <see cref="FormatterRequest.Variable" />.
-        /// </summary>
-        /// <param name="locale">The locale being used. It is up to the formatter what they do with this information.</param>
-        /// <param name="request">The parameters.</param>
-        /// <param name="args">The arguments.</param>
-        /// <param name="value">The value of <see cref="FormatterRequest.Variable" /> from the given args dictionary. Can be null.</param>
-        /// <param name="messageFormatter">The message formatter.</param>
-        /// <returns>
-        /// The <see cref="string" />.
-        /// </returns>
-        /// <exception cref="MessageFormatterException">'other' option not found in pattern, and variable was not present in collection.</exception>
-        [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1126:PrefixCallsCorrectly",
-            Justification = "Reviewed. Suppression is OK here.")]
-        public string Format(string locale,
-            FormatterRequest request,
-            IReadOnlyDictionary<string, object?> args,
-            object? value,
-            IMessageFormatter messageFormatter)
-        {
-            var str = Convert.ToString(value);
-            var parsed = this.ParseArguments(request);
-            KeyedBlock? other = null;
-            foreach (var keyedBlock in parsed.KeyedBlocks)
-            {
-                if (str == keyedBlock.Key)
-                {
-                    return messageFormatter.FormatMessage(keyedBlock.BlockText, args);
-                }
-
-                if (keyedBlock.Key == OtherKey)
-                {
-                    other = keyedBlock;
-                }
-            }
-
-            if (other == null)
-            {
-                throw new MessageFormatterException(
-                    "'other' option not found in pattern, and variable was not present in collection.");
-            }
-
-            return messageFormatter.FormatMessage(other.BlockText, args);
-        }
-
-        #endregion
+        return request.FormatterName == "select";
     }
+
+    /// <summary>
+    /// Using the specified parameters and arguments, a formatted string shall be returned.
+    /// The <see cref="IMessageFormatter" /> is being provided as well, to enable
+    /// nested formatting. This is only called if <see cref="CanFormat" /> returns true.
+    /// The args will always contain the <see cref="FormatterRequest.Variable" />.
+    /// </summary>
+    /// <param name="locale">The locale being used. It is up to the formatter what they do with this information.</param>
+    /// <param name="request">The parameters.</param>
+    /// <param name="args">The arguments.</param>
+    /// <param name="value">The value of <see cref="FormatterRequest.Variable" /> from the given args dictionary. Can be null.</param>
+    /// <param name="messageFormatter">The message formatter.</param>
+    /// <returns>
+    /// The <see cref="string" />.
+    /// </returns>
+    /// <exception cref="MessageFormatterException">'other' option not found in pattern, and variable was not present in collection.</exception>
+    [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1126:PrefixCallsCorrectly",
+        Justification = "Reviewed. Suppression is OK here.")]
+    public string Format(string locale,
+        FormatterRequest request,
+        IReadOnlyDictionary<string, object?> args,
+        object? value,
+        IMessageFormatter messageFormatter)
+    {
+        var str = Convert.ToString(value);
+        var parsed = this.ParseArguments(request);
+        KeyedBlock? other = null;
+        foreach (var keyedBlock in parsed.KeyedBlocks)
+        {
+            if (str == keyedBlock.Key)
+            {
+                return messageFormatter.FormatMessage(keyedBlock.BlockText, args);
+            }
+
+            if (keyedBlock.Key == OtherKey)
+            {
+                other = keyedBlock;
+            }
+        }
+
+        if (other == null)
+        {
+            throw new MessageFormatterException(
+                "'other' option not found in pattern, and variable was not present in collection.");
+        }
+
+        return messageFormatter.FormatMessage(other.BlockText, args);
+    }
+
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat/Formatting/Formatters/VariableFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/Formatters/VariableFormatter.cs
@@ -8,89 +8,88 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 
-namespace Jeffijoe.MessageFormat.Formatting.Formatters
+namespace Jeffijoe.MessageFormat.Formatting.Formatters;
+
+/// <summary>
+///     Simple variable replacer.
+/// </summary>
+public class VariableFormatter : IFormatter
 {
+    #region Fields
+
+    private readonly ConcurrentDictionary<string, CultureInfo> cultures = new ConcurrentDictionary<string, CultureInfo>();
+
+    #endregion
+
+    #region Public Properties
+
     /// <summary>
-    ///     Simple variable replacer.
+    ///     This formatter requires the input variable to exist.
     /// </summary>
-    public class VariableFormatter : IFormatter
+    public bool VariableMustExist => true;
+        
+    #endregion
+        
+    #region Public Methods and Operators
+
+    /// <summary>
+    ///     Determines whether this instance can format a message based on the specified parameters.
+    /// </summary>
+    /// <param name="request">
+    ///     The parameters.
+    /// </param>
+    /// <returns>
+    ///     The <see cref="bool" />.
+    /// </returns>
+    public bool CanFormat(FormatterRequest request)
     {
-        #region Fields
-
-        private readonly ConcurrentDictionary<string, CultureInfo> cultures = new ConcurrentDictionary<string, CultureInfo>();
-
-        #endregion
-
-        #region Public Properties
-
-        /// <summary>
-        ///     This formatter requires the input variable to exist.
-        /// </summary>
-        public bool VariableMustExist => true;
-        
-        #endregion
-        
-        #region Public Methods and Operators
-
-        /// <summary>
-        ///     Determines whether this instance can format a message based on the specified parameters.
-        /// </summary>
-        /// <param name="request">
-        ///     The parameters.
-        /// </param>
-        /// <returns>
-        ///     The <see cref="bool" />.
-        /// </returns>
-        public bool CanFormat(FormatterRequest request)
-        {
-            return request.FormatterName == null;
-        }
-
-        /// <summary>
-        /// Using the specified parameters and arguments, a formatted string shall be returned.
-        /// The <see cref="IMessageFormatter" /> is being provided as well, to enable
-        /// nested formatting. This is only called if <see cref="CanFormat" /> returns true.
-        /// The args will always contain the <see cref="FormatterRequest.Variable" />.
-        /// </summary>
-        /// <param name="locale">The locale being used. It is up to the formatter what they do with this information.</param>
-        /// <param name="request">The parameters.</param>
-        /// <param name="args">The arguments.</param>
-        /// <param name="value">The value of <see cref="FormatterRequest.Variable" /> from the given args dictionary. Can be null.</param>
-        /// <param name="messageFormatter">The message formatter.</param>
-        /// <returns>
-        /// The <see cref="string" />.
-        /// </returns>
-        public string Format(string locale,
-            FormatterRequest request,
-            IReadOnlyDictionary<string, object?> args,
-            object? value,
-            IMessageFormatter messageFormatter)
-        {
-            switch (value)
-            {
-                case IFormattable formattable:
-                    return formattable.ToString(null, GetCultureInfo(locale));
-                default:
-                    return value?.ToString() ?? string.Empty;
-            }
-        }
-
-        /// <summary>
-        /// Get and cache the culture for a locale.
-        /// </summary>
-        /// <param name="locale">Locale for which to get the culture.</param>
-        /// <returns>
-        /// Culture of locale.
-        /// </returns>
-        private CultureInfo GetCultureInfo(string locale)
-        {
-            if (!this.cultures.ContainsKey(locale))
-            {
-                this.cultures[locale] = new CultureInfo(locale);
-            }
-            return this.cultures[locale];
-        }
-
-        #endregion
+        return request.FormatterName == null;
     }
+
+    /// <summary>
+    /// Using the specified parameters and arguments, a formatted string shall be returned.
+    /// The <see cref="IMessageFormatter" /> is being provided as well, to enable
+    /// nested formatting. This is only called if <see cref="CanFormat" /> returns true.
+    /// The args will always contain the <see cref="FormatterRequest.Variable" />.
+    /// </summary>
+    /// <param name="locale">The locale being used. It is up to the formatter what they do with this information.</param>
+    /// <param name="request">The parameters.</param>
+    /// <param name="args">The arguments.</param>
+    /// <param name="value">The value of <see cref="FormatterRequest.Variable" /> from the given args dictionary. Can be null.</param>
+    /// <param name="messageFormatter">The message formatter.</param>
+    /// <returns>
+    /// The <see cref="string" />.
+    /// </returns>
+    public string Format(string locale,
+        FormatterRequest request,
+        IReadOnlyDictionary<string, object?> args,
+        object? value,
+        IMessageFormatter messageFormatter)
+    {
+        switch (value)
+        {
+            case IFormattable formattable:
+                return formattable.ToString(null, GetCultureInfo(locale));
+            default:
+                return value?.ToString() ?? string.Empty;
+        }
+    }
+
+    /// <summary>
+    /// Get and cache the culture for a locale.
+    /// </summary>
+    /// <param name="locale">Locale for which to get the culture.</param>
+    /// <returns>
+    /// Culture of locale.
+    /// </returns>
+    private CultureInfo GetCultureInfo(string locale)
+    {
+        if (!this.cultures.ContainsKey(locale))
+        {
+            this.cultures[locale] = new CultureInfo(locale);
+        }
+        return this.cultures[locale];
+    }
+
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat/Formatting/IFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/IFormatter.cs
@@ -5,57 +5,56 @@
 
 using System.Collections.Generic;
 
-namespace Jeffijoe.MessageFormat.Formatting
+namespace Jeffijoe.MessageFormat.Formatting;
+
+/// <summary>
+///     A Formatter is what transforms a pattern into a string, using the proper arguments.
+/// </summary>
+public interface IFormatter
 {
+    #region Public Properties
+
     /// <summary>
-    ///     A Formatter is what transforms a pattern into a string, using the proper arguments.
+    ///     Each Formatter must declare whether or not an input variable is required to exist.
+    ///     Most of the time that is the case. 
     /// </summary>
-    public interface IFormatter
-    {
-        #region Public Properties
+    bool VariableMustExist { get; }
 
-        /// <summary>
-        ///     Each Formatter must declare whether or not an input variable is required to exist.
-        ///     Most of the time that is the case. 
-        /// </summary>
-        bool VariableMustExist { get; }
+    #endregion
 
-        #endregion
+    #region Public Methods and Operators
 
-        #region Public Methods and Operators
+    /// <summary>
+    ///     Determines whether this instance can format a message based on the specified parameters.
+    /// </summary>
+    /// <param name="request">
+    ///     The parameters.
+    /// </param>
+    /// <returns>
+    ///     The <see cref="bool" />.
+    /// </returns>
+    bool CanFormat(FormatterRequest request);
 
-        /// <summary>
-        ///     Determines whether this instance can format a message based on the specified parameters.
-        /// </summary>
-        /// <param name="request">
-        ///     The parameters.
-        /// </param>
-        /// <returns>
-        ///     The <see cref="bool" />.
-        /// </returns>
-        bool CanFormat(FormatterRequest request);
+    /// <summary>
+    /// Using the specified parameters and arguments, a formatted string shall be returned.
+    /// The <see cref="IMessageFormatter" /> is being provided as well, to enable
+    /// nested formatting. This is only called if <see cref="CanFormat" /> returns true.
+    /// The args will always contain the <see cref="FormatterRequest.Variable" />.
+    /// </summary>
+    /// <param name="locale">The locale being used. It is up to the formatter what they do with this information.</param>
+    /// <param name="request">The parameters.</param>
+    /// <param name="args">The arguments.</param>
+    /// <param name="value">The value of <see cref="FormatterRequest.Variable"/> from the given args dictionary. Can be null.</param>
+    /// <param name="messageFormatter">The message formatter.</param>
+    /// <returns>
+    /// The <see cref="string" />.
+    /// </returns>
+    string Format(
+        string locale,
+        FormatterRequest request,
+        IReadOnlyDictionary<string, object?> args,
+        object? value,
+        IMessageFormatter messageFormatter);
 
-        /// <summary>
-        /// Using the specified parameters and arguments, a formatted string shall be returned.
-        /// The <see cref="IMessageFormatter" /> is being provided as well, to enable
-        /// nested formatting. This is only called if <see cref="CanFormat" /> returns true.
-        /// The args will always contain the <see cref="FormatterRequest.Variable" />.
-        /// </summary>
-        /// <param name="locale">The locale being used. It is up to the formatter what they do with this information.</param>
-        /// <param name="request">The parameters.</param>
-        /// <param name="args">The arguments.</param>
-        /// <param name="value">The value of <see cref="FormatterRequest.Variable"/> from the given args dictionary. Can be null.</param>
-        /// <param name="messageFormatter">The message formatter.</param>
-        /// <returns>
-        /// The <see cref="string" />.
-        /// </returns>
-        string Format(
-            string locale,
-            FormatterRequest request,
-            IReadOnlyDictionary<string, object?> args,
-            object? value,
-            IMessageFormatter messageFormatter);
-
-        #endregion
-    }
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat/Formatting/IFormatterLibrary.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/IFormatterLibrary.cs
@@ -5,26 +5,25 @@
 
 using System.Collections.Generic;
 
-namespace Jeffijoe.MessageFormat.Formatting
+namespace Jeffijoe.MessageFormat.Formatting;
+
+/// <summary>
+///     Manages formatters to use.
+/// </summary>
+public interface IFormatterLibrary : IList<IFormatter>
 {
+    #region Public Methods and Operators
+
     /// <summary>
-    ///     Manages formatters to use.
+    ///     Gets the formatter to use. If none was found, throws an exception.
     /// </summary>
-    public interface IFormatterLibrary : IList<IFormatter>
-    {
-        #region Public Methods and Operators
+    /// <param name="request">
+    ///     The request.
+    /// </param>
+    /// <returns>
+    ///     The <see cref="IFormatter" />.
+    /// </returns>
+    IFormatter GetFormatter(FormatterRequest request);
 
-        /// <summary>
-        ///     Gets the formatter to use. If none was found, throws an exception.
-        /// </summary>
-        /// <param name="request">
-        ///     The request.
-        /// </param>
-        /// <returns>
-        ///     The <see cref="IFormatter" />.
-        /// </returns>
-        IFormatter GetFormatter(FormatterRequest request);
-
-        #endregion
-    }
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat/Formatting/KeyedBlock.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/KeyedBlock.cs
@@ -2,52 +2,51 @@
 // - KeyedBlock.cs
 // Author: Jeff Hansen <jeff@jeffijoe.com>
 // Copyright (C) Jeff Hansen 2014. All rights reserved.
-namespace Jeffijoe.MessageFormat.Formatting
+namespace Jeffijoe.MessageFormat.Formatting;
+
+/// <summary>
+///     A keyed block contains a key and a block
+///     containing the text that the formatter will return
+///     when the block is being used.
+/// </summary>
+public class KeyedBlock
 {
+    #region Constructors and Destructors
+
     /// <summary>
-    ///     A keyed block contains a key and a block
-    ///     containing the text that the formatter will return
-    ///     when the block is being used.
+    ///     Initializes a new instance of the <see cref="KeyedBlock" /> class.
     /// </summary>
-    public class KeyedBlock
+    /// <param name="key">
+    ///     The key.
+    /// </param>
+    /// <param name="blockText">
+    ///     The block text.
+    /// </param>
+    public KeyedBlock(string key, string blockText)
     {
-        #region Constructors and Destructors
-
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="KeyedBlock" /> class.
-        /// </summary>
-        /// <param name="key">
-        ///     The key.
-        /// </param>
-        /// <param name="blockText">
-        ///     The block text.
-        /// </param>
-        public KeyedBlock(string key, string blockText)
-        {
-            this.Key = key;
-            this.BlockText = blockText;
-        }
-
-        #endregion
-
-        #region Public Properties
-
-        /// <summary>
-        ///     Gets the block text to be returned by the formatter.
-        /// </summary>
-        /// <value>
-        ///     The block text.
-        /// </value>
-        public string BlockText { get; private set; }
-
-        /// <summary>
-        ///     Gets the key used by the formatter to make decisions.
-        /// </summary>
-        /// <value>
-        ///     The key.
-        /// </value>
-        public string Key { get; private set; }
-
-        #endregion
+        this.Key = key;
+        this.BlockText = blockText;
     }
+
+    #endregion
+
+    #region Public Properties
+
+    /// <summary>
+    ///     Gets the block text to be returned by the formatter.
+    /// </summary>
+    /// <value>
+    ///     The block text.
+    /// </value>
+    public string BlockText { get; private set; }
+
+    /// <summary>
+    ///     Gets the key used by the formatter to make decisions.
+    /// </summary>
+    /// <value>
+    ///     The key.
+    /// </value>
+    public string Key { get; private set; }
+
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat/Formatting/ParsedArguments.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/ParsedArguments.cs
@@ -6,50 +6,49 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Jeffijoe.MessageFormat.Formatting
+namespace Jeffijoe.MessageFormat.Formatting;
+
+/// <summary>
+///     Container class for formatter argument parsing result.
+/// </summary>
+public class ParsedArguments
 {
+    #region Constructors and Destructors
+
     /// <summary>
-    ///     Container class for formatter argument parsing result.
+    ///     Initializes a new instance of the <see cref="ParsedArguments" /> class.
     /// </summary>
-    public class ParsedArguments
+    /// <param name="keyedBlocks">
+    ///     The keyed Blocks.
+    /// </param>
+    /// <param name="extensions">
+    ///     The extensions.
+    /// </param>
+    public ParsedArguments(IEnumerable<KeyedBlock> keyedBlocks, IEnumerable<FormatterExtension> extensions)
     {
-        #region Constructors and Destructors
-
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="ParsedArguments" /> class.
-        /// </summary>
-        /// <param name="keyedBlocks">
-        ///     The keyed Blocks.
-        /// </param>
-        /// <param name="extensions">
-        ///     The extensions.
-        /// </param>
-        public ParsedArguments(IEnumerable<KeyedBlock> keyedBlocks, IEnumerable<FormatterExtension> extensions)
-        {
-            this.KeyedBlocks = keyedBlocks.ToList();
-            this.Extensions = extensions.ToList();
-        }
-
-        #endregion
-
-        #region Public Properties
-
-        /// <summary>
-        ///     Gets the extensions.
-        /// </summary>
-        /// <value>
-        ///     The extensions.
-        /// </value>
-        public IEnumerable<FormatterExtension> Extensions { get; private set; }
-
-        /// <summary>
-        ///     Gets the keyed blocks.
-        /// </summary>
-        /// <value>
-        ///     The keyed blocks.
-        /// </value>
-        public IEnumerable<KeyedBlock> KeyedBlocks { get; private set; }
-
-        #endregion
+        this.KeyedBlocks = keyedBlocks.ToList();
+        this.Extensions = extensions.ToList();
     }
+
+    #endregion
+
+    #region Public Properties
+
+    /// <summary>
+    ///     Gets the extensions.
+    /// </summary>
+    /// <value>
+    ///     The extensions.
+    /// </value>
+    public IEnumerable<FormatterExtension> Extensions { get; private set; }
+
+    /// <summary>
+    ///     Gets the keyed blocks.
+    /// </summary>
+    /// <value>
+    ///     The keyed blocks.
+    /// </value>
+    public IEnumerable<KeyedBlock> KeyedBlocks { get; private set; }
+
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat/Formatting/VariableNotFoundException.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/VariableNotFoundException.cs
@@ -3,57 +3,56 @@
 // 
 // Author: Jeff Hansen <jeff@jeffijoe.com>
 // Copyright (C) Jeff Hansen 2015. All rights reserved.
-namespace Jeffijoe.MessageFormat.Formatting
+namespace Jeffijoe.MessageFormat.Formatting;
+
+/// <summary>
+///     Thrown when a variable declared in a pattern was non-existent.
+/// </summary>
+public class VariableNotFoundException : MessageFormatterException
 {
+    #region Constructors and Destructors
+
     /// <summary>
-    ///     Thrown when a variable declared in a pattern was non-existent.
+    /// Initializes a new instance of the <see cref="VariableNotFoundException"/> class.
     /// </summary>
-    public class VariableNotFoundException : MessageFormatterException
+    /// <param name="missingVariable">
+    /// The variable.
+    /// </param>
+    public VariableNotFoundException(string missingVariable)
+        : base(BuildMessage(missingVariable))
     {
-        #region Constructors and Destructors
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="VariableNotFoundException"/> class.
-        /// </summary>
-        /// <param name="missingVariable">
-        /// The variable.
-        /// </param>
-        public VariableNotFoundException(string missingVariable)
-            : base(BuildMessage(missingVariable))
-        {
-            this.MissingVariable = missingVariable;
-        }
-
-        #endregion
-
-        #region Public Properties
-
-        /// <summary>
-        ///     Gets the name of the missing variable.
-        /// </summary>
-        /// <value>
-        ///     The missing variable.
-        /// </value>
-        public string MissingVariable { get; private set; }
-
-        #endregion
-
-        #region Methods
-
-        /// <summary>
-        /// Builds the message.
-        /// </summary>
-        /// <param name="variable">
-        /// The variable.
-        /// </param>
-        /// <returns>
-        /// The <see cref="string"/>.
-        /// </returns>
-        private static string BuildMessage(string variable)
-        {
-            return string.Format("The variable '{0}' was not found in the arguments collection.", variable);
-        }
-
-        #endregion
+        this.MissingVariable = missingVariable;
     }
+
+    #endregion
+
+    #region Public Properties
+
+    /// <summary>
+    ///     Gets the name of the missing variable.
+    /// </summary>
+    /// <value>
+    ///     The missing variable.
+    /// </value>
+    public string MissingVariable { get; private set; }
+
+    #endregion
+
+    #region Methods
+
+    /// <summary>
+    /// Builds the message.
+    /// </summary>
+    /// <param name="variable">
+    /// The variable.
+    /// </param>
+    /// <returns>
+    /// The <see cref="string"/>.
+    /// </returns>
+    private static string BuildMessage(string variable)
+    {
+        return string.Format("The variable '{0}' was not found in the arguments collection.", variable);
+    }
+
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat/Helpers/CharHelper.cs
+++ b/src/Jeffijoe.MessageFormat/Helpers/CharHelper.cs
@@ -2,47 +2,46 @@
 // - CharHelper.cs
 // Author: Jeff Hansen <jeff@jeffijoe.com>
 // Copyright (C) Jeff Hansen 2014. All rights reserved.
-namespace Jeffijoe.MessageFormat.Helpers
+namespace Jeffijoe.MessageFormat.Helpers;
+
+/// <summary>
+///     Char helper
+/// </summary>
+internal static class CharHelper
 {
+    #region Static Fields
+
     /// <summary>
-    ///     Char helper
+    ///     The alphanumberic.
     /// </summary>
-    internal static class CharHelper
+    private static readonly char[] Alphanumberic =
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_".ToCharArray();
+
+    #endregion
+
+    #region Methods
+
+    /// <summary>
+    ///     Determines whether the specified character is alpha numeric.
+    /// </summary>
+    /// <param name="c">
+    ///     The c.
+    /// </param>
+    /// <returns>
+    ///     The <see cref="bool" />.
+    /// </returns>
+    internal static bool IsAlphaNumeric(this char c)
     {
-        #region Static Fields
-
-        /// <summary>
-        ///     The alphanumberic.
-        /// </summary>
-        private static readonly char[] Alphanumberic =
-            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_".ToCharArray();
-
-        #endregion
-
-        #region Methods
-
-        /// <summary>
-        ///     Determines whether the specified character is alpha numeric.
-        /// </summary>
-        /// <param name="c">
-        ///     The c.
-        /// </param>
-        /// <returns>
-        ///     The <see cref="bool" />.
-        /// </returns>
-        internal static bool IsAlphaNumeric(this char c)
+        foreach (var chr in Alphanumberic)
         {
-            foreach (var chr in Alphanumberic)
+            if (chr == c)
             {
-                if (chr == c)
-                {
-                    return true;
-                }
+                return true;
             }
-
-            return false;
         }
 
-        #endregion
+        return false;
     }
+
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat/Helpers/ObjectHelper.cs
+++ b/src/Jeffijoe.MessageFormat/Helpers/ObjectHelper.cs
@@ -8,66 +8,65 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
-namespace Jeffijoe.MessageFormat.Helpers
+namespace Jeffijoe.MessageFormat.Helpers;
+
+/// <summary>
+///     Object helper
+/// </summary>
+internal static class ObjectHelper
 {
+    #region Methods
+
     /// <summary>
-    ///     Object helper
+    ///     Gets the properties from the specified object.
     /// </summary>
-    internal static class ObjectHelper
+    /// <param name="obj">
+    ///     The object.
+    /// </param>
+    /// <returns>
+    ///     The <see cref="IEnumerable" />.
+    /// </returns>
+    internal static IEnumerable<PropertyInfo> GetProperties(object obj)
     {
-        #region Methods
-
-        /// <summary>
-        ///     Gets the properties from the specified object.
-        /// </summary>
-        /// <param name="obj">
-        ///     The object.
-        /// </param>
-        /// <returns>
-        ///     The <see cref="IEnumerable" />.
-        /// </returns>
-        internal static IEnumerable<PropertyInfo> GetProperties(object obj)
+        var properties = new List<PropertyInfo>();
+        var type = obj.GetType();
+        var typeInfo = type.GetTypeInfo();
+        while (true)
         {
-            var properties = new List<PropertyInfo>();
-            var type = obj.GetType();
-            var typeInfo = type.GetTypeInfo();
-            while (true)
+            properties.AddRange(typeInfo.DeclaredProperties);
+            if (typeInfo.BaseType == null)
             {
-                properties.AddRange(typeInfo.DeclaredProperties);
-                if (typeInfo.BaseType == null)
-                {
-                    break;
-                }
-
-                typeInfo = typeInfo.BaseType.GetTypeInfo();
+                break;
             }
 
-            return properties;
+            typeInfo = typeInfo.BaseType.GetTypeInfo();
         }
 
-        /// <summary>
-        ///     Creates a dictionary from the specified object's properties. 1 level only.
-        /// </summary>
-        /// <param name="obj">
-        ///     The object.
-        /// </param>
-        /// <returns>
-        ///     The <see cref="IDictionary" />.
-        /// </returns>
-        internal static Dictionary<string, object?> ToDictionary(this object obj)
-        {
-            // We want to be able to read the property, and it should not be an indexer.
-            var properties = GetProperties(obj).Where(x => x.CanRead && x.GetIndexParameters().Any() == false);
-
-            var result = new Dictionary<string, object?>();
-            foreach (var propertyInfo in properties)
-            {
-                result[propertyInfo.Name] = propertyInfo.GetValue(obj);
-            }
-
-            return result;
-        }
-
-        #endregion
+        return properties;
     }
+
+    /// <summary>
+    ///     Creates a dictionary from the specified object's properties. 1 level only.
+    /// </summary>
+    /// <param name="obj">
+    ///     The object.
+    /// </param>
+    /// <returns>
+    ///     The <see cref="IDictionary" />.
+    /// </returns>
+    internal static Dictionary<string, object?> ToDictionary(this object obj)
+    {
+        // We want to be able to read the property, and it should not be an indexer.
+        var properties = GetProperties(obj).Where(x => x.CanRead && x.GetIndexParameters().Any() == false);
+
+        var result = new Dictionary<string, object?>();
+        foreach (var propertyInfo in properties)
+        {
+            result[propertyInfo.Name] = propertyInfo.GetValue(obj);
+        }
+
+        return result;
+    }
+
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat/Helpers/StringBuilderHelper.cs
+++ b/src/Jeffijoe.MessageFormat/Helpers/StringBuilderHelper.cs
@@ -9,37 +9,37 @@ using System;
 
 using System.Text;
 
-namespace Jeffijoe.MessageFormat.Helpers
-{
-    /// <summary>
-    ///     String Builder helper
-    /// </summary>
-    internal static class StringBuilderHelper
-    {
-        #region Methods
+namespace Jeffijoe.MessageFormat.Helpers;
 
-        /// <summary>
-        ///     Determines whether the specified source contains any of the specified characters.
-        /// </summary>
-        /// <param name="src">
-        ///     The source.
-        /// </param>
-        /// <param name="chars">
-        ///     The chars.
-        /// </param>
-        /// <returns>
-        ///     The <see cref="bool" />.
-        /// </returns>
-        private static bool Contains(this StringBuilder src, params char[] chars)
-        {
+/// <summary>
+///     String Builder helper
+/// </summary>
+internal static class StringBuilderHelper
+{
+    #region Methods
+
+    /// <summary>
+    ///     Determines whether the specified source contains any of the specified characters.
+    /// </summary>
+    /// <param name="src">
+    ///     The source.
+    /// </param>
+    /// <param name="chars">
+    ///     The chars.
+    /// </param>
+    /// <returns>
+    ///     The <see cref="bool" />.
+    /// </returns>
+    private static bool Contains(this StringBuilder src, params char[] chars)
+    {
 #if NET5_0_OR_GREATER
-            foreach (var chunk in src.GetChunks())
+        foreach (var chunk in src.GetChunks())
+        {
+            if (chunk.Span.IndexOfAny(chars) != -1)
             {
-                if (chunk.Span.IndexOfAny(chars) != -1)
-                {
-                    return true;
-                }
+                return true;
             }
+        }
 #else
             for (int i = 0; i < src.Length; i++)
             {
@@ -53,29 +53,29 @@ namespace Jeffijoe.MessageFormat.Helpers
             }
 #endif
 
-            return false;
-        }
+        return false;
+    }
         
-        /// <summary>
-        ///     Determines whether the specified source contains the specified character.
-        /// </summary>
-        /// <param name="src">
-        ///     The source.
-        /// </param>
-        /// <param name="character">
-        ///     The character.
-        /// </param>
-        /// <returns>
-        ///     The <see cref="bool" />.
-        /// </returns>
-        internal static bool Contains(this StringBuilder src, char character)
-        {
+    /// <summary>
+    ///     Determines whether the specified source contains the specified character.
+    /// </summary>
+    /// <param name="src">
+    ///     The source.
+    /// </param>
+    /// <param name="character">
+    ///     The character.
+    /// </param>
+    /// <returns>
+    ///     The <see cref="bool" />.
+    /// </returns>
+    internal static bool Contains(this StringBuilder src, char character)
+    {
 #if NET5_0_OR_GREATER
-            foreach (var chunk in src.GetChunks())
-            {
-                if (chunk.Span.IndexOf(character) != -1)
-                    return true;
-            }
+        foreach (var chunk in src.GetChunks())
+        {
+            if (chunk.Span.IndexOf(character) != -1)
+                return true;
+        }
 #else
             for (int i = 0; i < src.Length; i++)
             {
@@ -86,72 +86,71 @@ namespace Jeffijoe.MessageFormat.Helpers
             }
 #endif
 
-            return false;
+        return false;
+    }
+
+    /// <summary>
+    ///     Determines whether the specified source contains whitespace.
+    /// </summary>
+    /// <param name="src">
+    ///     The source.
+    /// </param>
+    /// <returns>
+    ///     The <see cref="bool" />.
+    /// </returns>
+    internal static bool ContainsWhitespace(this StringBuilder src)
+    {
+        return src.Contains(' ', '\r', '\n', '\t');
+    }
+
+    /// <summary>
+    ///     Trims the whitespace.
+    /// </summary>
+    /// <param name="src">
+    ///     The source.
+    /// </param>
+    /// <returns>
+    ///     The <see cref="StringBuilder" />.
+    /// </returns>
+    internal static StringBuilder TrimWhitespace(this StringBuilder src)
+    {
+        var length = 0;
+
+        for (int i = 0; i < src.Length; i++)
+        {
+            var c = src[i];
+            if (char.IsWhiteSpace(c) == false)
+            {
+                length = i;
+                break;
+            }
         }
 
-        /// <summary>
-        ///     Determines whether the specified source contains whitespace.
-        /// </summary>
-        /// <param name="src">
-        ///     The source.
-        /// </param>
-        /// <returns>
-        ///     The <see cref="bool" />.
-        /// </returns>
-        internal static bool ContainsWhitespace(this StringBuilder src)
+        if (length != 0)
         {
-            return src.Contains(' ', '\r', '\n', '\t');
+            src = src.Remove(0, length);
         }
 
-        /// <summary>
-        ///     Trims the whitespace.
-        /// </summary>
-        /// <param name="src">
-        ///     The source.
-        /// </param>
-        /// <returns>
-        ///     The <see cref="StringBuilder" />.
-        /// </returns>
-        internal static StringBuilder TrimWhitespace(this StringBuilder src)
+        var startIndex = 0;
+        for (int i = src.Length - 1; i >= 0; i--)
         {
-            var length = 0;
-
-            for (int i = 0; i < src.Length; i++)
+            var c = src[i];
+            if (char.IsWhiteSpace(c) == false)
             {
-                var c = src[i];
-                if (char.IsWhiteSpace(c) == false)
-                {
-                    length = i;
-                    break;
-                }
+                startIndex = i + 1;
+                break;
             }
+        }
 
-            if (length != 0)
-            {
-                src = src.Remove(0, length);
-            }
-
-            var startIndex = 0;
-            for (int i = src.Length - 1; i >= 0; i--)
-            {
-                var c = src[i];
-                if (char.IsWhiteSpace(c) == false)
-                {
-                    startIndex = i + 1;
-                    break;
-                }
-            }
-
-            if (startIndex == src.Length)
-            {
-                return src;
-            }
-
-            length = src.Length - startIndex;
-            src.Remove(startIndex, length);
+        if (startIndex == src.Length)
+        {
             return src;
         }
 
-#endregion
+        length = src.Length - startIndex;
+        src.Remove(startIndex, length);
+        return src;
     }
+
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat/IMessageFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/IMessageFormatter.cs
@@ -5,38 +5,37 @@
 
 using System.Collections.Generic;
 
-namespace Jeffijoe.MessageFormat
+namespace Jeffijoe.MessageFormat;
+
+/// <summary>
+///     The magical Message Formatter.
+/// </summary>
+public interface IMessageFormatter
 {
+    #region Public properties
+
     /// <summary>
-    ///     The magical Message Formatter.
+    ///     The custom value formatter to use for formats like `number`, `date`, `time` etc.
     /// </summary>
-    public interface IMessageFormatter
-    {
-        #region Public properties
+    CustomValueFormatter? CustomValueFormatter { get; }
 
-        /// <summary>
-        ///     The custom value formatter to use for formats like `number`, `date`, `time` etc.
-        /// </summary>
-        CustomValueFormatter? CustomValueFormatter { get; }
+    #endregion
 
-        #endregion
+    #region Public Methods and Operators
 
-        #region Public Methods and Operators
+    /// <summary>
+    ///     Formats the message with the specified arguments. It's so magical.
+    /// </summary>
+    /// <param name="pattern">
+    ///     The pattern.
+    /// </param>
+    /// <param name="argsMap">
+    ///     The arguments.
+    /// </param>
+    /// <returns>
+    ///     The <see cref="string" />.
+    /// </returns>
+    string FormatMessage(string pattern, IReadOnlyDictionary<string, object?> argsMap);
 
-        /// <summary>
-        ///     Formats the message with the specified arguments. It's so magical.
-        /// </summary>
-        /// <param name="pattern">
-        ///     The pattern.
-        /// </param>
-        /// <param name="argsMap">
-        ///     The arguments.
-        /// </param>
-        /// <returns>
-        ///     The <see cref="string" />.
-        /// </returns>
-        string FormatMessage(string pattern, IReadOnlyDictionary<string, object?> argsMap);
-
-        #endregion
-    }
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat/Jeffijoe.MessageFormat.csproj
+++ b/src/Jeffijoe.MessageFormat/Jeffijoe.MessageFormat.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="8.0.8" />
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="8.0.10" />
     <PackageReference Include="MinVer" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Jeffijoe.MessageFormat/MessageFormatterException.cs
+++ b/src/Jeffijoe.MessageFormat/MessageFormatterException.cs
@@ -5,26 +5,25 @@
 
 using System;
 
-namespace Jeffijoe.MessageFormat
+namespace Jeffijoe.MessageFormat;
+
+/// <summary>
+///     Thrown when an issue has occured in the message formatting process.
+/// </summary>
+public class MessageFormatterException : Exception
 {
+    #region Constructors and Destructors
+
     /// <summary>
-    ///     Thrown when an issue has occured in the message formatting process.
+    ///     Initializes a new instance of the <see cref="MessageFormatterException" /> class.
     /// </summary>
-    public class MessageFormatterException : Exception
+    /// <param name="message">
+    ///     The message that describes the error.
+    /// </param>
+    public MessageFormatterException(string message)
+        : base(message)
     {
-        #region Constructors and Destructors
-
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="MessageFormatterException" /> class.
-        /// </summary>
-        /// <param name="message">
-        ///     The message that describes the error.
-        /// </param>
-        public MessageFormatterException(string message)
-            : base(message)
-        {
-        }
-
-        #endregion
     }
+
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat/Parsing/FormatterRequestCollection.cs
+++ b/src/Jeffijoe.MessageFormat/Parsing/FormatterRequestCollection.cs
@@ -7,59 +7,58 @@ using System.Collections.Generic;
 
 using Jeffijoe.MessageFormat.Formatting;
 
-namespace Jeffijoe.MessageFormat.Parsing
+namespace Jeffijoe.MessageFormat.Parsing;
+
+/// <summary>
+///     Formatter requests collection.
+/// </summary>
+public class FormatterRequestCollection : List<FormatterRequest>, IFormatterRequestCollection
 {
+    #region Public Methods and Operators
+
     /// <summary>
-    ///     Formatter requests collection.
+    ///     Clones this instance and all of it's items. This lets us reuse pattern parsing result, without having to remember
+    ///     the item's initial state before being modified to match the results of the formatters.
     /// </summary>
-    public class FormatterRequestCollection : List<FormatterRequest>, IFormatterRequestCollection
+    /// <returns>
+    ///     The <see cref="IFormatterRequestCollection" />.
+    /// </returns>
+    public IFormatterRequestCollection Clone()
     {
-        #region Public Methods and Operators
-
-        /// <summary>
-        ///     Clones this instance and all of it's items. This lets us reuse pattern parsing result, without having to remember
-        ///     the item's initial state before being modified to match the results of the formatters.
-        /// </summary>
-        /// <returns>
-        ///     The <see cref="IFormatterRequestCollection" />.
-        /// </returns>
-        public IFormatterRequestCollection Clone()
+        var result = new FormatterRequestCollection();
+        foreach (var request in this)
         {
-            var result = new FormatterRequestCollection();
-            foreach (var request in this)
-            {
-                result.Add(request.Clone());
-            }
-
-            return result;
+            result.Add(request.Clone());
         }
 
-        /// <summary>
-        ///     Updates the indices of all
-        ///     formatter requests' source literals, starting at
-        ///     next request after the specified index in this collection.
-        /// </summary>
-        /// <param name="indexToStartFrom">
-        ///     The index to start from.
-        /// </param>
-        /// <param name="formatterResultLength">
-        ///     Length of the formatter result.
-        ///     Used to compare each literal's inner text length, so we know what to set the
-        ///     indices to on the rest of the requests.
-        /// </param>
-        public void ShiftIndices(int indexToStartFrom, int formatterResultLength)
-        {
-            var start = this[indexToStartFrom];
-
-            // "- 2" will compensate for { and }. (This works, don't ask why).
-            int resultLength = formatterResultLength - 2;
-            for (int i = indexToStartFrom + 1; i < this.Count; i++)
-            {
-                var next = this[i];
-                next.SourceLiteral.ShiftIndices(resultLength, start.SourceLiteral);
-            }
-        }
-
-        #endregion
+        return result;
     }
+
+    /// <summary>
+    ///     Updates the indices of all
+    ///     formatter requests' source literals, starting at
+    ///     next request after the specified index in this collection.
+    /// </summary>
+    /// <param name="indexToStartFrom">
+    ///     The index to start from.
+    /// </param>
+    /// <param name="formatterResultLength">
+    ///     Length of the formatter result.
+    ///     Used to compare each literal's inner text length, so we know what to set the
+    ///     indices to on the rest of the requests.
+    /// </param>
+    public void ShiftIndices(int indexToStartFrom, int formatterResultLength)
+    {
+        var start = this[indexToStartFrom];
+
+        // "- 2" will compensate for { and }. (This works, don't ask why).
+        int resultLength = formatterResultLength - 2;
+        for (int i = indexToStartFrom + 1; i < this.Count; i++)
+        {
+            var next = this[i];
+            next.SourceLiteral.ShiftIndices(resultLength, start.SourceLiteral);
+        }
+    }
+
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat/Parsing/IFormatterRequestCollection.cs
+++ b/src/Jeffijoe.MessageFormat/Parsing/IFormatterRequestCollection.cs
@@ -7,39 +7,38 @@ using System.Collections.Generic;
 
 using Jeffijoe.MessageFormat.Formatting;
 
-namespace Jeffijoe.MessageFormat.Parsing
+namespace Jeffijoe.MessageFormat.Parsing;
+
+/// <summary>
+///     Formatter requests collection.
+/// </summary>
+public interface IFormatterRequestCollection : IReadOnlyList<FormatterRequest>
 {
+    #region Public Methods and Operators
+
     /// <summary>
-    ///     Formatter requests collection.
+    ///     Clones this instance and all of it's items. This lets us reuse pattern parsing result, without having to remember
+    ///     the item's initial state before being modified to match the results of the formatters.
     /// </summary>
-    public interface IFormatterRequestCollection : IReadOnlyList<FormatterRequest>
-    {
-        #region Public Methods and Operators
+    /// <returns>
+    ///     The <see cref="IFormatterRequestCollection" />.
+    /// </returns>
+    IFormatterRequestCollection Clone();
 
-        /// <summary>
-        ///     Clones this instance and all of it's items. This lets us reuse pattern parsing result, without having to remember
-        ///     the item's initial state before being modified to match the results of the formatters.
-        /// </summary>
-        /// <returns>
-        ///     The <see cref="IFormatterRequestCollection" />.
-        /// </returns>
-        IFormatterRequestCollection Clone();
+    /// <summary>
+    ///     Updates the indices of all
+    ///     formatter requests' source literals, starting at
+    ///     the specified index in this collection.
+    /// </summary>
+    /// <param name="indexToStartFrom">
+    ///     The index to start from.
+    /// </param>
+    /// <param name="formatterResultLength">
+    ///     Length of the formatter result.
+    ///     Used to compare each literal's inner text length, so we know what to set the
+    ///     indices to on the rest of the requests.
+    /// </param>
+    void ShiftIndices(int indexToStartFrom, int formatterResultLength);
 
-        /// <summary>
-        ///     Updates the indices of all
-        ///     formatter requests' source literals, starting at
-        ///     the specified index in this collection.
-        /// </summary>
-        /// <param name="indexToStartFrom">
-        ///     The index to start from.
-        /// </param>
-        /// <param name="formatterResultLength">
-        ///     Length of the formatter result.
-        ///     Used to compare each literal's inner text length, so we know what to set the
-        ///     indices to on the rest of the requests.
-        /// </param>
-        void ShiftIndices(int indexToStartFrom, int formatterResultLength);
-
-        #endregion
-    }
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat/Parsing/ILiteralParser.cs
+++ b/src/Jeffijoe.MessageFormat/Parsing/ILiteralParser.cs
@@ -7,26 +7,25 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Text;
 
-namespace Jeffijoe.MessageFormat.Parsing
+namespace Jeffijoe.MessageFormat.Parsing;
+
+/// <summary>
+///     Brace parser contract.
+/// </summary>
+public interface ILiteralParser
 {
+    #region Public Methods and Operators
+
     /// <summary>
-    ///     Brace parser contract.
+    ///     Finds the brace matches.
     /// </summary>
-    public interface ILiteralParser
-    {
-        #region Public Methods and Operators
+    /// <param name="sb">
+    ///     The sb.
+    /// </param>
+    /// <returns>
+    ///     The <see cref="IEnumerable" />.
+    /// </returns>
+    IEnumerable<Literal> ParseLiterals(StringBuilder sb);
 
-        /// <summary>
-        ///     Finds the brace matches.
-        /// </summary>
-        /// <param name="sb">
-        ///     The sb.
-        /// </param>
-        /// <returns>
-        ///     The <see cref="IEnumerable" />.
-        /// </returns>
-        IEnumerable<Literal> ParseLiterals(StringBuilder sb);
-
-        #endregion
-    }
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat/Parsing/IPatternParser.cs
+++ b/src/Jeffijoe.MessageFormat/Parsing/IPatternParser.cs
@@ -5,27 +5,26 @@
 
 using System.Text;
 
-namespace Jeffijoe.MessageFormat.Parsing
+namespace Jeffijoe.MessageFormat.Parsing;
+
+/// <summary>
+///     The pattern parser extracts patterns from a string.
+/// </summary>
+public interface IPatternParser
 {
+    #region Public Methods and Operators
+
     /// <summary>
-    ///     The pattern parser extracts patterns from a string.
+    ///     Parses the source, extracting formatter parameters
+    ///     describing what formatter to use, as well as it's options.
     /// </summary>
-    public interface IPatternParser
-    {
-        #region Public Methods and Operators
+    /// <param name="source">
+    ///     The source.
+    /// </param>
+    /// <returns>
+    ///     The <see cref="IFormatterRequestCollection" />.
+    /// </returns>
+    IFormatterRequestCollection Parse(StringBuilder source);
 
-        /// <summary>
-        ///     Parses the source, extracting formatter parameters
-        ///     describing what formatter to use, as well as it's options.
-        /// </summary>
-        /// <param name="source">
-        ///     The source.
-        /// </param>
-        /// <returns>
-        ///     The <see cref="IFormatterRequestCollection" />.
-        /// </returns>
-        IFormatterRequestCollection Parse(StringBuilder source);
-
-        #endregion
-    }
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat/Parsing/Literal.cs
+++ b/src/Jeffijoe.MessageFormat/Parsing/Literal.cs
@@ -3,128 +3,127 @@
 // Author: Jeff Hansen <jeff@jeffijoe.com>
 // Copyright (C) Jeff Hansen 2014. All rights reserved.
 
-namespace Jeffijoe.MessageFormat.Parsing
+namespace Jeffijoe.MessageFormat.Parsing;
+
+/// <summary>
+///     Represents a position in the source text where we should look for format patterns.
+/// </summary>
+public class Literal
 {
+    #region Constructors and Destructors
+
     /// <summary>
-    ///     Represents a position in the source text where we should look for format patterns.
+    ///     Initializes a new instance of the <see cref="Literal" /> class.
     /// </summary>
-    public class Literal
+    /// <param name="startIndex">
+    ///     The start index.
+    /// </param>
+    /// <param name="endIndex">
+    ///     The end index.
+    /// </param>
+    /// <param name="sourceLineNumber">
+    ///     The source line number.
+    /// </param>
+    /// <param name="sourceColumnNumber">
+    ///     The source column number.
+    /// </param>
+    /// <param name="innerText">
+    ///     The inner text.
+    /// </param>
+    public Literal(
+        int startIndex, 
+        int endIndex, 
+        int sourceLineNumber, 
+        int sourceColumnNumber, 
+        string innerText)
     {
-        #region Constructors and Destructors
-
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="Literal" /> class.
-        /// </summary>
-        /// <param name="startIndex">
-        ///     The start index.
-        /// </param>
-        /// <param name="endIndex">
-        ///     The end index.
-        /// </param>
-        /// <param name="sourceLineNumber">
-        ///     The source line number.
-        /// </param>
-        /// <param name="sourceColumnNumber">
-        ///     The source column number.
-        /// </param>
-        /// <param name="innerText">
-        ///     The inner text.
-        /// </param>
-        public Literal(
-            int startIndex, 
-            int endIndex, 
-            int sourceLineNumber, 
-            int sourceColumnNumber, 
-            string innerText)
-        {
-            this.StartIndex = startIndex;
-            this.EndIndex = endIndex;
-            this.SourceLineNumber = sourceLineNumber;
-            this.SourceColumnNumber = sourceColumnNumber;
-            this.InnerText = innerText;
-        }
-
-        #endregion
-
-        #region Public Properties
-
-        /// <summary>
-        ///     Gets the end index in the source string.
-        /// </summary>
-        /// <value>
-        ///     The end index.
-        /// </value>
-        public int EndIndex { get; private set; }
-
-        /// <summary>
-        ///     Gets the inner text (the content between the braces).
-        /// </summary>
-        /// <value>
-        ///     The inner text.
-        /// </value>
-        public string InnerText { get; private set; }
-
-        /// <summary>
-        ///     Gets the source column number.
-        /// </summary>
-        /// <value>
-        ///     The source column number.
-        /// </value>
-        public int SourceColumnNumber { get; private set; }
-
-        /// <summary>
-        ///     Gets the source line number in the original input string.
-        /// </summary>
-        /// <value>
-        ///     The source line number.
-        /// </value>
-        public int SourceLineNumber { get; private set; }
-
-        /// <summary>
-        ///     Gets the start index in the source string.
-        /// </summary>
-        /// <value>
-        ///     The start index.
-        /// </value>
-        public int StartIndex { get; private set; }
-
-        #endregion
-
-        #region Public Methods and Operators
-
-        /// <summary>
-        ///     Clones this instance.
-        /// </summary>
-        /// <returns>
-        ///     The <see cref="Literal" />.
-        /// </returns>
-        public Literal Clone()
-        {
-            // Assuming that InnerText will never be tampered with.
-            return new Literal(
-                this.StartIndex, 
-                this.EndIndex, 
-                this.SourceLineNumber, 
-                this.SourceColumnNumber, 
-                this.InnerText);
-        }
-
-        /// <summary>
-        ///     Updates the start and end index.
-        /// </summary>
-        /// <param name="resultLength">
-        ///     Length of the result.
-        /// </param>
-        /// <param name="literal">
-        ///     The literal that was just formatted.
-        /// </param>
-        public void ShiftIndices(int resultLength, Literal literal)
-        {
-            int offset = (literal.EndIndex - literal.StartIndex) - 1;
-            this.StartIndex = (this.StartIndex - offset) + resultLength;
-            this.EndIndex = (this.EndIndex - offset) + resultLength;
-        }
-
-        #endregion
+        this.StartIndex = startIndex;
+        this.EndIndex = endIndex;
+        this.SourceLineNumber = sourceLineNumber;
+        this.SourceColumnNumber = sourceColumnNumber;
+        this.InnerText = innerText;
     }
+
+    #endregion
+
+    #region Public Properties
+
+    /// <summary>
+    ///     Gets the end index in the source string.
+    /// </summary>
+    /// <value>
+    ///     The end index.
+    /// </value>
+    public int EndIndex { get; private set; }
+
+    /// <summary>
+    ///     Gets the inner text (the content between the braces).
+    /// </summary>
+    /// <value>
+    ///     The inner text.
+    /// </value>
+    public string InnerText { get; private set; }
+
+    /// <summary>
+    ///     Gets the source column number.
+    /// </summary>
+    /// <value>
+    ///     The source column number.
+    /// </value>
+    public int SourceColumnNumber { get; private set; }
+
+    /// <summary>
+    ///     Gets the source line number in the original input string.
+    /// </summary>
+    /// <value>
+    ///     The source line number.
+    /// </value>
+    public int SourceLineNumber { get; private set; }
+
+    /// <summary>
+    ///     Gets the start index in the source string.
+    /// </summary>
+    /// <value>
+    ///     The start index.
+    /// </value>
+    public int StartIndex { get; private set; }
+
+    #endregion
+
+    #region Public Methods and Operators
+
+    /// <summary>
+    ///     Clones this instance.
+    /// </summary>
+    /// <returns>
+    ///     The <see cref="Literal" />.
+    /// </returns>
+    public Literal Clone()
+    {
+        // Assuming that InnerText will never be tampered with.
+        return new Literal(
+            this.StartIndex, 
+            this.EndIndex, 
+            this.SourceLineNumber, 
+            this.SourceColumnNumber, 
+            this.InnerText);
+    }
+
+    /// <summary>
+    ///     Updates the start and end index.
+    /// </summary>
+    /// <param name="resultLength">
+    ///     Length of the result.
+    /// </param>
+    /// <param name="literal">
+    ///     The literal that was just formatted.
+    /// </param>
+    public void ShiftIndices(int resultLength, Literal literal)
+    {
+        int offset = (literal.EndIndex - literal.StartIndex) - 1;
+        this.StartIndex = (this.StartIndex - offset) + resultLength;
+        this.EndIndex = (this.EndIndex - offset) + resultLength;
+    }
+
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat/Parsing/LiteralParser.cs
+++ b/src/Jeffijoe.MessageFormat/Parsing/LiteralParser.cs
@@ -7,187 +7,186 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Text;
 
-namespace Jeffijoe.MessageFormat.Parsing
+namespace Jeffijoe.MessageFormat.Parsing;
+
+/// <summary>
+///     Parser for extracting brace matches from a string builder.
+/// </summary>
+public class LiteralParser : ILiteralParser
 {
+    #region Public Methods and Operators
+
     /// <summary>
-    ///     Parser for extracting brace matches from a string builder.
+    ///     Finds the brace matches.
     /// </summary>
-    public class LiteralParser : ILiteralParser
+    /// <param name="sb">
+    ///     The sb.
+    /// </param>
+    /// <returns>
+    ///     The <see cref="IEnumerable" />.
+    /// </returns>
+    public IEnumerable<Literal> ParseLiterals(StringBuilder sb)
     {
-        #region Public Methods and Operators
+        const char OpenBrace = '{';
+        const char CloseBrace = '}';
+        const char EscapingChar = '\'';
 
-        /// <summary>
-        ///     Finds the brace matches.
-        /// </summary>
-        /// <param name="sb">
-        ///     The sb.
-        /// </param>
-        /// <returns>
-        ///     The <see cref="IEnumerable" />.
-        /// </returns>
-        public IEnumerable<Literal> ParseLiterals(StringBuilder sb)
+        var result = new List<Literal>();
+        var openBraces = 0;
+        var closeBraces = 0;
+        var start = 0;
+        var braceBalance = 0;
+        var lineNumber = 1;
+        var startLineNumber = 1;
+        var startColumnNumber = 0;
+        var columnNumber = 0;
+        var insideEscapeSequence = false;
+        var currentEscapeSequenceLineNumber = 0;
+        var currentEscapeSequenceColumnNumber = 0;
+        const char Cr = '\r'; // Carriage return
+        const char Lf = '\n'; // Line feed
+
+        var matchTextBuf = StringBuilderPool.Get();
+        try
         {
-            const char OpenBrace = '{';
-            const char CloseBrace = '}';
-            const char EscapingChar = '\'';
-
-            var result = new List<Literal>();
-            var openBraces = 0;
-            var closeBraces = 0;
-            var start = 0;
-            var braceBalance = 0;
-            var lineNumber = 1;
-            var startLineNumber = 1;
-            var startColumnNumber = 0;
-            var columnNumber = 0;
-            var insideEscapeSequence = false;
-            var currentEscapeSequenceLineNumber = 0;
-            var currentEscapeSequenceColumnNumber = 0;
-            const char Cr = '\r'; // Carriage return
-            const char Lf = '\n'; // Line feed
-
-            var matchTextBuf = StringBuilderPool.Get();
-            try
+            for (var i = 0; i < sb.Length; i++)
             {
-                for (var i = 0; i < sb.Length; i++)
+                var c = sb[i];
+                    
+                if (c == Cr)
                 {
-                    var c = sb[i];
+                    continue;
+                }
                     
-                    if (c == Cr)
-                    {
-                        continue;
-                    }
-                    
-                    if (c == Lf)
-                    {
-                        lineNumber++;
-                        columnNumber = 0;
+                if (c == Lf)
+                {
+                    lineNumber++;
+                    columnNumber = 0;
                         
-                    }
-                    else
+                }
+                else
+                {
+                    columnNumber++;    
+                }
+
+                if (c == EscapingChar)
+                {
+                    if (i == sb.Length - 1)
                     {
-                        columnNumber++;    
-                    }
-
-                    if (c == EscapingChar)
-                    {
-                        if (i == sb.Length - 1)
-                        {
-                            if (!insideEscapeSequence)
-                                matchTextBuf.Append(EscapingChar);
-
-                            // The last char can't open a new escape sequence, it can only close one
-                            if (insideEscapeSequence)
-                            {
-                                insideEscapeSequence = false;
-                            }
-
-                            continue;
-                        }
-
-                        matchTextBuf.Append(EscapingChar);
-
-                        var nextChar = sb[i + 1];
-                        if (nextChar == EscapingChar)
-                        {
+                        if (!insideEscapeSequence)
                             matchTextBuf.Append(EscapingChar);
-                            ++i;
-                            continue;
-                        }
 
+                        // The last char can't open a new escape sequence, it can only close one
                         if (insideEscapeSequence)
                         {
                             insideEscapeSequence = false;
-                            continue;
                         }
 
-                        if (nextChar == '{' || nextChar == '}' || nextChar == '#')
-                        {
-                            matchTextBuf.Append(nextChar);
-                            insideEscapeSequence = true;
-                            currentEscapeSequenceLineNumber = lineNumber;
-                            currentEscapeSequenceColumnNumber = columnNumber;
-                            ++i;
-                        }
+                        continue;
+                    }
 
+                    matchTextBuf.Append(EscapingChar);
+
+                    var nextChar = sb[i + 1];
+                    if (nextChar == EscapingChar)
+                    {
+                        matchTextBuf.Append(EscapingChar);
+                        ++i;
                         continue;
                     }
 
                     if (insideEscapeSequence)
                     {
-                        matchTextBuf.Append(c);
+                        insideEscapeSequence = false;
                         continue;
                     }
 
-                    if (c == OpenBrace)
+                    if (nextChar == '{' || nextChar == '}' || nextChar == '#')
                     {
-                        openBraces++;
-                        braceBalance++;
-
-                        // Record starting position of possible new brace match.
-                        if (braceBalance == 1)
-                        {
-                            start = i;
-                            startColumnNumber = columnNumber;
-                            startLineNumber = lineNumber;
-                            matchTextBuf.Clear();
-                        }
+                        matchTextBuf.Append(nextChar);
+                        insideEscapeSequence = true;
+                        currentEscapeSequenceLineNumber = lineNumber;
+                        currentEscapeSequenceColumnNumber = columnNumber;
+                        ++i;
                     }
 
-                    if (c == CloseBrace)
-                    {
-                        closeBraces++;
-                        braceBalance--;
-
-                        // Write the brace to the match buffer if it's not the closing brace
-                        // we are looking for.
-                        if (braceBalance > 0)
-                        {
-                            matchTextBuf.Append(c);
-                        }
-                    }
-                    else
-                    {
-                        if (i > start && braceBalance > 0)
-                        {
-                            matchTextBuf.Append(c);
-                        }
-
-                        continue;
-                    }
-
-                    if (openBraces != closeBraces)
-                    {
-                        continue;
-                    }
-
-                    result.Add(new Literal(start, i, startLineNumber, startColumnNumber, matchTextBuf.ToString()));
-                    matchTextBuf.Clear();
-                    start = 0;
+                    continue;
                 }
 
                 if (insideEscapeSequence)
                 {
-                    throw new MalformedLiteralException(
-                        "There is an unclosed escape sequence.",
-                        currentEscapeSequenceLineNumber,
-                        currentEscapeSequenceColumnNumber,
-                        matchTextBuf.ToString());
+                    matchTextBuf.Append(c);
+                    continue;
+                }
+
+                if (c == OpenBrace)
+                {
+                    openBraces++;
+                    braceBalance++;
+
+                    // Record starting position of possible new brace match.
+                    if (braceBalance == 1)
+                    {
+                        start = i;
+                        startColumnNumber = columnNumber;
+                        startLineNumber = lineNumber;
+                        matchTextBuf.Clear();
+                    }
+                }
+
+                if (c == CloseBrace)
+                {
+                    closeBraces++;
+                    braceBalance--;
+
+                    // Write the brace to the match buffer if it's not the closing brace
+                    // we are looking for.
+                    if (braceBalance > 0)
+                    {
+                        matchTextBuf.Append(c);
+                    }
+                }
+                else
+                {
+                    if (i > start && braceBalance > 0)
+                    {
+                        matchTextBuf.Append(c);
+                    }
+
+                    continue;
                 }
 
                 if (openBraces != closeBraces)
                 {
-                    throw new UnbalancedBracesException(openBraces, closeBraces);
+                    continue;
                 }
 
-                return result;
+                result.Add(new Literal(start, i, startLineNumber, startColumnNumber, matchTextBuf.ToString()));
+                matchTextBuf.Clear();
+                start = 0;
             }
-            finally
-            {
-                StringBuilderPool.Return(matchTextBuf);
-            }
-        }
 
-        #endregion
+            if (insideEscapeSequence)
+            {
+                throw new MalformedLiteralException(
+                    "There is an unclosed escape sequence.",
+                    currentEscapeSequenceLineNumber,
+                    currentEscapeSequenceColumnNumber,
+                    matchTextBuf.ToString());
+            }
+
+            if (openBraces != closeBraces)
+            {
+                throw new UnbalancedBracesException(openBraces, closeBraces);
+            }
+
+            return result;
+        }
+        finally
+        {
+            StringBuilderPool.Return(matchTextBuf);
+        }
     }
+
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat/Parsing/MalformedLiteralException.cs
+++ b/src/Jeffijoe.MessageFormat/Parsing/MalformedLiteralException.cs
@@ -2,108 +2,107 @@
 // - MalformedLiteralException.cs
 // Author: Jeff Hansen <jeff@jeffijoe.com>
 // Copyright (C) Jeff Hansen 2014. All rights reserved.
-namespace Jeffijoe.MessageFormat.Parsing
+namespace Jeffijoe.MessageFormat.Parsing;
+
+/// <summary>
+///     Thrown when the pattern parser finds an invalid character in a literal.
+/// </summary>
+public class MalformedLiteralException : MessageFormatterException
 {
+    #region Constructors and Destructors
+
     /// <summary>
-    ///     Thrown when the pattern parser finds an invalid character in a literal.
+    ///     Initializes a new instance of the <see cref="MalformedLiteralException" /> class.
     /// </summary>
-    public class MalformedLiteralException : MessageFormatterException
+    /// <param name="message">
+    ///     The message that describes the error.
+    /// </param>
+    /// <param name="lineNumber">
+    ///     The line number.
+    /// </param>
+    /// <param name="columnNumber">
+    ///     The column number.
+    /// </param>
+    /// <param name="sourceSnippet">
+    ///     A snippet of the text that contained the error. Can be null.
+    /// </param>
+    internal MalformedLiteralException(
+        string message, 
+        int lineNumber = 0, 
+        int columnNumber = 0, 
+        string? sourceSnippet = null)
+        : base(BuildMessage(message, lineNumber, columnNumber, sourceSnippet))
     {
-        #region Constructors and Destructors
-
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="MalformedLiteralException" /> class.
-        /// </summary>
-        /// <param name="message">
-        ///     The message that describes the error.
-        /// </param>
-        /// <param name="lineNumber">
-        ///     The line number.
-        /// </param>
-        /// <param name="columnNumber">
-        ///     The column number.
-        /// </param>
-        /// <param name="sourceSnippet">
-        ///     A snippet of the text that contained the error. Can be null.
-        /// </param>
-        internal MalformedLiteralException(
-            string message, 
-            int lineNumber = 0, 
-            int columnNumber = 0, 
-            string? sourceSnippet = null)
-            : base(BuildMessage(message, lineNumber, columnNumber, sourceSnippet))
-        {
-            this.LineNumber = lineNumber;
-            this.ColumnNumber = columnNumber;
-            this.SourceSnippet = sourceSnippet;
-        }
-
-        #endregion
-
-        #region Public Properties
-
-        /// <summary>
-        ///     Gets the column number.
-        /// </summary>
-        /// <value>
-        ///     The column number.
-        /// </value>
-        public int ColumnNumber { get; private set; }
-
-        /// <summary>
-        ///     Gets the line number.
-        /// </summary>
-        /// <value>
-        ///     The line number.
-        /// </value>
-        public int LineNumber { get; private set; }
-
-        /// <summary>
-        ///     Gets the source snippet.
-        /// </summary>
-        /// <value>
-        ///     The source snippet.
-        /// </value>
-        public string? SourceSnippet { get; private set; }
-
-        #endregion
-
-        #region Methods
-
-        /// <summary>
-        ///     Builds the message.
-        /// </summary>
-        /// <param name="message">
-        ///     The message.
-        /// </param>
-        /// <param name="lineNumber">
-        ///     The line number.
-        /// </param>
-        /// <param name="columnNumber">
-        ///     The column number.
-        /// </param>
-        /// <param name="sourceSnippet">
-        ///     The source snippet.
-        /// </param>
-        /// <returns>
-        ///     The <see cref="string" />.
-        /// </returns>
-        private static string BuildMessage(string message, int lineNumber, int columnNumber, string? sourceSnippet)
-        {
-            var str = message;
-            if (lineNumber != 0 && columnNumber != 0)
-            {
-                str = string.Format("{0}\r\nLine {1}, column {2}", message, lineNumber, columnNumber);
-            }
-
-            if (string.IsNullOrWhiteSpace(sourceSnippet))
-            {
-                return str;
-            }
-
-            return string.Format("Parser error: {0}\r\nOffending snippet: \"{1}\"", str, sourceSnippet);
-        }
-
-        #endregion
+        this.LineNumber = lineNumber;
+        this.ColumnNumber = columnNumber;
+        this.SourceSnippet = sourceSnippet;
     }
+
+    #endregion
+
+    #region Public Properties
+
+    /// <summary>
+    ///     Gets the column number.
+    /// </summary>
+    /// <value>
+    ///     The column number.
+    /// </value>
+    public int ColumnNumber { get; private set; }
+
+    /// <summary>
+    ///     Gets the line number.
+    /// </summary>
+    /// <value>
+    ///     The line number.
+    /// </value>
+    public int LineNumber { get; private set; }
+
+    /// <summary>
+    ///     Gets the source snippet.
+    /// </summary>
+    /// <value>
+    ///     The source snippet.
+    /// </value>
+    public string? SourceSnippet { get; private set; }
+
+    #endregion
+
+    #region Methods
+
+    /// <summary>
+    ///     Builds the message.
+    /// </summary>
+    /// <param name="message">
+    ///     The message.
+    /// </param>
+    /// <param name="lineNumber">
+    ///     The line number.
+    /// </param>
+    /// <param name="columnNumber">
+    ///     The column number.
+    /// </param>
+    /// <param name="sourceSnippet">
+    ///     The source snippet.
+    /// </param>
+    /// <returns>
+    ///     The <see cref="string" />.
+    /// </returns>
+    private static string BuildMessage(string message, int lineNumber, int columnNumber, string? sourceSnippet)
+    {
+        var str = message;
+        if (lineNumber != 0 && columnNumber != 0)
+        {
+            str = string.Format("{0}\r\nLine {1}, column {2}", message, lineNumber, columnNumber);
+        }
+
+        if (string.IsNullOrWhiteSpace(sourceSnippet))
+        {
+            return str;
+        }
+
+        return string.Format("Parser error: {0}\r\nOffending snippet: \"{1}\"", str, sourceSnippet);
+    }
+
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat/Parsing/PatternParser.cs
+++ b/src/Jeffijoe.MessageFormat/Parsing/PatternParser.cs
@@ -11,218 +11,217 @@ using System.Text;
 using Jeffijoe.MessageFormat.Formatting;
 using Jeffijoe.MessageFormat.Helpers;
 
-namespace Jeffijoe.MessageFormat.Parsing
+namespace Jeffijoe.MessageFormat.Parsing;
+
+/// <summary>
+///     Parser for extracting formatter patterns.
+/// </summary>
+public class PatternParser : IPatternParser
 {
+    #region Fields
+
     /// <summary>
-    ///     Parser for extracting formatter patterns.
+    ///     The _literal parser.
     /// </summary>
-    public class PatternParser : IPatternParser
+    private readonly ILiteralParser literalParser;
+
+    #endregion
+
+    #region Constructors and Destructors
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="PatternParser" /> class.
+    /// </summary>
+    public PatternParser() : this(new LiteralParser())
     {
-        #region Fields
-
-        /// <summary>
-        ///     The _literal parser.
-        /// </summary>
-        private readonly ILiteralParser literalParser;
-
-        #endregion
-
-        #region Constructors and Destructors
-
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="PatternParser" /> class.
-        /// </summary>
-        public PatternParser() : this(new LiteralParser())
-        {
-        }
+    }
         
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="PatternParser" /> class.
-        /// </summary>
-        /// <param name="literalParser">
-        ///     The literal parser.
-        /// </param>
-        public PatternParser(ILiteralParser literalParser)
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="PatternParser" /> class.
+    /// </summary>
+    /// <param name="literalParser">
+    ///     The literal parser.
+    /// </param>
+    public PatternParser(ILiteralParser literalParser)
+    {
+        this.literalParser = literalParser;
+    }
+
+    #endregion
+
+    #region Public Methods and Operators
+
+    /// <summary>
+    ///     Parses the specified source.
+    /// </summary>
+    /// <param name="source">
+    ///     The source.
+    /// </param>
+    /// <returns>
+    ///     The <see cref="IFormatterRequestCollection" />.
+    /// </returns>
+    public IFormatterRequestCollection Parse(StringBuilder source)
+    {
+        var literals = this.literalParser.ParseLiterals(source).ToArray();
+        if (literals.Length == 0)
         {
-            this.literalParser = literalParser;
+            return new FormatterRequestCollection();
         }
 
-        #endregion
-
-        #region Public Methods and Operators
-
-        /// <summary>
-        ///     Parses the specified source.
-        /// </summary>
-        /// <param name="source">
-        ///     The source.
-        /// </param>
-        /// <returns>
-        ///     The <see cref="IFormatterRequestCollection" />.
-        /// </returns>
-        public IFormatterRequestCollection Parse(StringBuilder source)
+        var result = new FormatterRequestCollection();
+        foreach (var literal in literals)
         {
-            var literals = this.literalParser.ParseLiterals(source).ToArray();
-            if (literals.Length == 0)
+            // The first token to follow an opening brace will be the variable name.
+            var variableName = ReadLiteralSection(literal, 0, false, out var lastIndex)!;
+
+            // The next (if any), is the formatter to use. Null is allowed.
+            string? formatterKey = null;
+
+            // The rest of the string is what we pass into the formatter. Can be null.
+            string? formatterArgs = null;
+            if (variableName.Length != literal.InnerText.Length)
             {
-                return new FormatterRequestCollection();
-            }
-
-            var result = new FormatterRequestCollection();
-            foreach (var literal in literals)
-            {
-                // The first token to follow an opening brace will be the variable name.
-                var variableName = ReadLiteralSection(literal, 0, false, out var lastIndex)!;
-
-                // The next (if any), is the formatter to use. Null is allowed.
-                string? formatterKey = null;
-
-                // The rest of the string is what we pass into the formatter. Can be null.
-                string? formatterArgs = null;
-                if (variableName.Length != literal.InnerText.Length)
+                formatterKey = ReadLiteralSection(literal, lastIndex + 1, true, out lastIndex);
+                if (formatterKey != null)
                 {
-                    formatterKey = ReadLiteralSection(literal, lastIndex + 1, true, out lastIndex);
-                    if (formatterKey != null)
-                    {
 #if NET5_0_OR_GREATER
                         formatterArgs =
                             literal.InnerText.AsSpan(lastIndex + 1, literal.InnerText.Length - lastIndex - 1).Trim()
                                 .ToString();
 #else
-                        formatterArgs =
-                            literal.InnerText.Substring(lastIndex + 1, literal.InnerText.Length - lastIndex - 1).Trim();
+                    formatterArgs =
+                        literal.InnerText.Substring(lastIndex + 1, literal.InnerText.Length - lastIndex - 1).Trim();
 #endif
-                    }
                 }
-
-                result.Add(new FormatterRequest(literal, variableName, formatterKey, formatterArgs));
             }
 
-            return result;
+            result.Add(new FormatterRequest(literal, variableName, formatterKey, formatterArgs));
         }
 
-        #endregion
+        return result;
+    }
 
-        #region Methods
+    #endregion
 
-        /// <summary>
-        ///     Gets the key from the literal.
-        /// </summary>
-        /// <param name="literal">
-        ///     The literal.
-        /// </param>
-        /// <param name="offset">
-        ///     The offset.
-        /// </param>
-        /// <param name="allowEmptyResult">
-        ///     if set to <c>true</c>, allows an empty result, in which case the return value is
-        ///     <c>null</c>
-        /// </param>
-        /// <param name="lastIndex">
-        ///     The last index.
-        /// </param>
-        /// <returns>
-        ///     The <see cref="string" />.
-        /// </returns>
-        /// <exception cref="MalformedLiteralException">
-        ///     Parsing the variable key yielded an empty string.
-        /// </exception>
-        internal static string? ReadLiteralSection(Literal literal, int offset, bool allowEmptyResult,
-            out int lastIndex)
+    #region Methods
+
+    /// <summary>
+    ///     Gets the key from the literal.
+    /// </summary>
+    /// <param name="literal">
+    ///     The literal.
+    /// </param>
+    /// <param name="offset">
+    ///     The offset.
+    /// </param>
+    /// <param name="allowEmptyResult">
+    ///     if set to <c>true</c>, allows an empty result, in which case the return value is
+    ///     <c>null</c>
+    /// </param>
+    /// <param name="lastIndex">
+    ///     The last index.
+    /// </param>
+    /// <returns>
+    ///     The <see cref="string" />.
+    /// </returns>
+    /// <exception cref="MalformedLiteralException">
+    ///     Parsing the variable key yielded an empty string.
+    /// </exception>
+    internal static string? ReadLiteralSection(Literal literal, int offset, bool allowEmptyResult,
+        out int lastIndex)
+    {
+        const char Comma = ',';
+
+        var innerText = literal.InnerText;
+        var column = literal.SourceColumnNumber;
+        var foundWhitespace = false;
+        lastIndex = 0;
+        var sb = StringBuilderPool.Get();
+        try
         {
-            const char Comma = ',';
-
-            var innerText = literal.InnerText;
-            var column = literal.SourceColumnNumber;
-            var foundWhitespace = false;
-            lastIndex = 0;
-            var sb = StringBuilderPool.Get();
-            try
+            for (var i = offset; i < innerText.Length; i++)
             {
-                for (var i = offset; i < innerText.Length; i++)
+                var c = innerText[i];
+                column++;
+                lastIndex = i;
+                if (c == Comma)
                 {
-                    var c = innerText[i];
-                    column++;
-                    lastIndex = i;
-                    if (c == Comma)
-                    {
-                        break;
-                    }
-
-                    // Disregard whitespace.
-                    var whitespace = char.IsWhiteSpace(c);
-                    if (!whitespace)
-                    {
-                        if (c.IsAlphaNumeric() == false)
-                        {
-                            var msg = $"Invalid literal character '{c}'.";
-
-                            // Line number can't have changed.
-                            throw new MalformedLiteralException(
-                                msg, 
-                                literal.SourceLineNumber, 
-                                column,
-                                innerText);
-                        }
-                    }
-                    else
-                    {
-                        foundWhitespace = true;
-                    }
-
-                    sb.Append(c);
+                    break;
                 }
 
-                if (sb.Length != 0)
+                // Disregard whitespace.
+                var whitespace = char.IsWhiteSpace(c);
+                if (!whitespace)
                 {
-                    // Trim whitespace from beginning and end of the string, if necessary.
-                    if (!foundWhitespace)
+                    if (c.IsAlphaNumeric() == false)
                     {
-                        return sb.ToString();
-                    }
+                        var msg = $"Invalid literal character '{c}'.";
 
-                    StringBuilder trimmed = sb.TrimWhitespace();
-                    if (trimmed.Length == 0)
-                    {
-                        if (allowEmptyResult)
-                        {
-                            return null;
-                        }
-
+                        // Line number can't have changed.
                         throw new MalformedLiteralException(
-                            "Parsing the literal yielded a string that was pure whitespace.",
-                            literal.SourceLineNumber,
-                            column);
+                            msg, 
+                            literal.SourceLineNumber, 
+                            column,
+                            innerText);
                     }
+                }
+                else
+                {
+                    foundWhitespace = true;
+                }
 
-                    if (trimmed.ContainsWhitespace())
-                    {
-                        throw new MalformedLiteralException(
-                            "Parsed literal must not contain whitespace.",
-                            0,
-                            0,
-                            trimmed.ToString());
-                    }
+                sb.Append(c);
+            }
 
+            if (sb.Length != 0)
+            {
+                // Trim whitespace from beginning and end of the string, if necessary.
+                if (!foundWhitespace)
+                {
                     return sb.ToString();
                 }
 
-                if (allowEmptyResult)
+                StringBuilder trimmed = sb.TrimWhitespace();
+                if (trimmed.Length == 0)
                 {
-                    return null;
+                    if (allowEmptyResult)
+                    {
+                        return null;
+                    }
+
+                    throw new MalformedLiteralException(
+                        "Parsing the literal yielded a string that was pure whitespace.",
+                        literal.SourceLineNumber,
+                        column);
                 }
 
-                throw new MalformedLiteralException(
-                    "Parsing the literal yielded an empty string.",
-                    literal.SourceLineNumber,
-                    column);
-            }
-            finally
-            {
-                StringBuilderPool.Return(sb);
-            }
-        }
+                if (trimmed.ContainsWhitespace())
+                {
+                    throw new MalformedLiteralException(
+                        "Parsed literal must not contain whitespace.",
+                        0,
+                        0,
+                        trimmed.ToString());
+                }
 
-        #endregion
+                return sb.ToString();
+            }
+
+            if (allowEmptyResult)
+            {
+                return null;
+            }
+
+            throw new MalformedLiteralException(
+                "Parsing the literal yielded an empty string.",
+                literal.SourceLineNumber,
+                column);
+        }
+        finally
+        {
+            StringBuilderPool.Return(sb);
+        }
     }
+
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat/Parsing/UnbalancedBracesException.cs
+++ b/src/Jeffijoe.MessageFormat/Parsing/UnbalancedBracesException.cs
@@ -5,82 +5,81 @@
 
 using System;
 
-namespace Jeffijoe.MessageFormat.Parsing
+namespace Jeffijoe.MessageFormat.Parsing;
+
+/// <summary>
+///     Thrown when the amount of open and close braces does not match.
+/// </summary>
+public class UnbalancedBracesException : ArgumentException
 {
+    #region Constructors and Destructors
+
     /// <summary>
-    ///     Thrown when the amount of open and close braces does not match.
+    ///     Initializes a new instance of the <see cref="UnbalancedBracesException" /> class.
     /// </summary>
-    public class UnbalancedBracesException : ArgumentException
+    /// <param name="openBraceCount">
+    ///     The brace counter.
+    /// </param>
+    /// <param name="closeBraceCount">
+    ///     The close brace count.
+    /// </param>
+    internal UnbalancedBracesException(int openBraceCount, int closeBraceCount)
+        : base(BuildMessage(openBraceCount, closeBraceCount))
     {
-        #region Constructors and Destructors
-
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="UnbalancedBracesException" /> class.
-        /// </summary>
-        /// <param name="openBraceCount">
-        ///     The brace counter.
-        /// </param>
-        /// <param name="closeBraceCount">
-        ///     The close brace count.
-        /// </param>
-        internal UnbalancedBracesException(int openBraceCount, int closeBraceCount)
-            : base(BuildMessage(openBraceCount, closeBraceCount))
-        {
-            this.OpenBraceCount = openBraceCount;
-            this.CloseBraceCount = closeBraceCount;
-        }
-
-        #endregion
-
-        #region Public Properties
-
-        /// <summary>
-        ///     Gets the close brace count.
-        /// </summary>
-        /// <value>
-        ///     The close brace count.
-        /// </value>
-        public int CloseBraceCount { get; private set; }
-
-        /// <summary>
-        ///     Gets the brace count.
-        /// </summary>
-        /// <value>
-        ///     The brace count.
-        /// </value>
-        public int OpenBraceCount { get; private set; }
-
-        #endregion
-
-        #region Methods
-
-        /// <summary>
-        ///     Builds the message.
-        /// </summary>
-        /// <param name="openBraceCount">
-        ///     The bracket counter.
-        /// </param>
-        /// <param name="closeBraceCount">
-        ///     The close brace count.
-        /// </param>
-        /// <returns>
-        ///     The <see cref="string" />.
-        /// </returns>
-        /// <exception cref="System.ArgumentException">
-        ///     Bracket counter was 0, which would indicate success.
-        /// </exception>
-        private static string BuildMessage(int openBraceCount, int closeBraceCount)
-        {
-            if (openBraceCount > closeBraceCount)
-            {
-                return "There are " + (openBraceCount - closeBraceCount)
-                       + " more opening braces than there are closing braces.";
-            }
-
-            return "There are " + (closeBraceCount - openBraceCount)
-                   + " more closing braces than there are opening braces.";
-        }
-
-        #endregion
+        this.OpenBraceCount = openBraceCount;
+        this.CloseBraceCount = closeBraceCount;
     }
+
+    #endregion
+
+    #region Public Properties
+
+    /// <summary>
+    ///     Gets the close brace count.
+    /// </summary>
+    /// <value>
+    ///     The close brace count.
+    /// </value>
+    public int CloseBraceCount { get; private set; }
+
+    /// <summary>
+    ///     Gets the brace count.
+    /// </summary>
+    /// <value>
+    ///     The brace count.
+    /// </value>
+    public int OpenBraceCount { get; private set; }
+
+    #endregion
+
+    #region Methods
+
+    /// <summary>
+    ///     Builds the message.
+    /// </summary>
+    /// <param name="openBraceCount">
+    ///     The bracket counter.
+    /// </param>
+    /// <param name="closeBraceCount">
+    ///     The close brace count.
+    /// </param>
+    /// <returns>
+    ///     The <see cref="string" />.
+    /// </returns>
+    /// <exception cref="System.ArgumentException">
+    ///     Bracket counter was 0, which would indicate success.
+    /// </exception>
+    private static string BuildMessage(int openBraceCount, int closeBraceCount)
+    {
+        if (openBraceCount > closeBraceCount)
+        {
+            return "There are " + (openBraceCount - closeBraceCount)
+                                + " more opening braces than there are closing braces.";
+        }
+
+        return "There are " + (closeBraceCount - openBraceCount)
+                            + " more closing braces than there are opening braces.";
+    }
+
+    #endregion
 }

--- a/src/Jeffijoe.MessageFormat/StringBuilderPool.cs
+++ b/src/Jeffijoe.MessageFormat/StringBuilderPool.cs
@@ -1,26 +1,25 @@
 ﻿using System.Text;
 using Microsoft.Extensions.ObjectPool;
 
-namespace Jeffijoe.MessageFormat
+namespace Jeffijoe.MessageFormat;
+
+internal static class StringBuilderPool
 {
-    internal static class StringBuilderPool
+    private static readonly ObjectPool<StringBuilder> SbPool;
+
+    static StringBuilderPool()
     {
-        private static readonly ObjectPool<StringBuilder> SbPool;
+        var shared = new DefaultObjectPoolProvider();
+        SbPool = shared.CreateStringBuilderPool();
+    }
 
-        static StringBuilderPool()
-        {
-            var shared = new DefaultObjectPoolProvider();
-            SbPool = shared.CreateStringBuilderPool();
-        }
+    public static StringBuilder Get()
+    {
+        return SbPool.Get();
+    }
 
-        public static StringBuilder Get()
-        {
-            return SbPool.Get();
-        }
-
-        public static void Return(StringBuilder sb)
-        {
-            SbPool.Return(sb);
-        }
+    public static void Return(StringBuilder sb)
+    {
+        SbPool.Return(sb);
     }
 }

--- a/src/MessageFormat.sln.DotSettings
+++ b/src/MessageFormat.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=jeffijoe/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
When a URL was specified as a keyed block, the extension parser picked up on the `:` and treated it as an extension.

To fix this, the extension parser was updated to exit early when it detects a `{`.

Closes #45 