### PR TITLE
Add RequiresUnreferencedCode attribute for reflection code and add OverloadResolutionPriority attribute to prefer non-object methods

### DIFF
--- a/src/Jeffijoe.MessageFormat/Helpers/ObjectHelper.cs
+++ b/src/Jeffijoe.MessageFormat/Helpers/ObjectHelper.cs
@@ -5,6 +5,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 
@@ -26,6 +27,7 @@ internal static class ObjectHelper
     /// <returns>
     ///     The <see cref="IEnumerable" />.
     /// </returns>
+    [RequiresUnreferencedCode("This method uses reflection to read property information on object")]
     internal static IEnumerable<PropertyInfo> GetProperties(object obj)
     {
         var properties = new List<PropertyInfo>();
@@ -54,6 +56,7 @@ internal static class ObjectHelper
     /// <returns>
     ///     The <see cref="IDictionary" />.
     /// </returns>
+    [RequiresUnreferencedCode("This method uses reflection to convert object into dictionary")]
     internal static Dictionary<string, object?> ToDictionary(this object obj)
     {
         // We want to be able to read the property, and it should not be an indexer.

--- a/src/Jeffijoe.MessageFormat/Jeffijoe.MessageFormat.csproj
+++ b/src/Jeffijoe.MessageFormat/Jeffijoe.MessageFormat.csproj
@@ -11,6 +11,7 @@
   	<LangVersion>latest</LangVersion>
   	<Nullable>enable</Nullable>
   	<TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <PolySharpIncludeRuntimeSupportedAttributes>true</PolySharpIncludeRuntimeSupportedAttributes>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -22,6 +23,10 @@
     <PackageReference Include="MinVer" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="PolySharp" Version="1.15.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 

--- a/src/Jeffijoe.MessageFormat/Jeffijoe.MessageFormat.csproj
+++ b/src/Jeffijoe.MessageFormat/Jeffijoe.MessageFormat.csproj
@@ -4,14 +4,15 @@
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>MessageFormat.snk</AssemblyOriginatorKeyFile>
     <PackageId>MessageFormat</PackageId>
-  	<GenerateAssemblyInfo>True</GenerateAssemblyInfo>
-  	<Authors>Jeff Hansen</Authors>
-  	<PackageTags>messageformat,messageformatter,xamarin,ui,messages,formatting,plural,pluralization,singular,select,strings,stringformat,format</PackageTags>
-  	<RepositoryUrl>https://github.com/jeffijoe/messageformat.net</RepositoryUrl>
-  	<LangVersion>latest</LangVersion>
-  	<Nullable>enable</Nullable>
-  	<TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <GenerateAssemblyInfo>True</GenerateAssemblyInfo>
+    <Authors>Jeff Hansen</Authors>
+    <PackageTags>messageformat,messageformatter,xamarin,ui,messages,formatting,plural,pluralization,singular,select,strings,stringformat,format</PackageTags>
+    <RepositoryUrl>https://github.com/jeffijoe/messageformat.net</RepositoryUrl>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
     <PolySharpIncludeRuntimeSupportedAttributes>true</PolySharpIncludeRuntimeSupportedAttributes>
+    <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Jeffijoe.MessageFormat/MessageFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/MessageFormatter.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Jeffijoe.MessageFormat.Formatting;
 using Jeffijoe.MessageFormat.Formatting.Formatters;
@@ -203,6 +204,7 @@ public class MessageFormatter : IMessageFormatter
     /// <returns>
     ///     The formatted message.
     /// </returns>
+    [OverloadResolutionPriority(-1)]
     [RequiresUnreferencedCode("This method uses the FormatMessage extension which uses reflection to convert object into dictionary")]
     public static string Format(string pattern, object data)
     {

--- a/src/Jeffijoe.MessageFormat/MessageFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/MessageFormatter.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using Jeffijoe.MessageFormat.Formatting;
@@ -202,6 +203,7 @@ public class MessageFormatter : IMessageFormatter
     /// <returns>
     ///     The formatted message.
     /// </returns>
+    [RequiresUnreferencedCode("This method uses the FormatMessage extension which uses reflection to convert object into dictionary")]
     public static string Format(string pattern, object data)
     {
         lock (Lock)

--- a/src/Jeffijoe.MessageFormat/MessageFormatterExtensions.cs
+++ b/src/Jeffijoe.MessageFormat/MessageFormatterExtensions.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using Jeffijoe.MessageFormat.Helpers;
 
 namespace Jeffijoe.MessageFormat;
@@ -47,6 +48,7 @@ public static class MessageFormatterExtensions
     /// <returns>
     ///     The <see cref="string" />.
     /// </returns>
+    [OverloadResolutionPriority(-1)]
     [RequiresUnreferencedCode("This method uses the ToDictionary extension which uses reflection to convert object into dictionary")]
     public static string FormatMessage(this IMessageFormatter formatter, string pattern, object args)
     {

--- a/src/Jeffijoe.MessageFormat/MessageFormatterExtensions.cs
+++ b/src/Jeffijoe.MessageFormat/MessageFormatterExtensions.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Jeffijoe.MessageFormat.Helpers;
 
 namespace Jeffijoe.MessageFormat;
@@ -46,6 +47,7 @@ public static class MessageFormatterExtensions
     /// <returns>
     ///     The <see cref="string" />.
     /// </returns>
+    [RequiresUnreferencedCode("This method uses the ToDictionary extension which uses reflection to convert object into dictionary")]
     public static string FormatMessage(this IMessageFormatter formatter, string pattern, object args)
     {
         return formatter.FormatMessage(pattern, args.ToDictionary());


### PR DESCRIPTION
This PR adds `RequiresUnreferencedCode` attribute on methods that use reflection. This is primarily the convenience methods and extension methods that take an `object` like: `new { hello = "world" }` and turns it into a dictionary with key `hello` which will be equal to the string object `"world"`.

Also added the `IsTrimmable` = `true` property on the project, which allows the compiler to trim the library.

For the extension methods that take the `object` as argument, I've also added the `[OverloadResolutionPriority(-1)]` attribute to make the compiler prefer the non `object` overloads. 

Fixes #49 