### PR TITLE
[BREAKING] Default to `CurrentCulture`, add `culture` parameter to `FormatMessage`, upgrade to .NET 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
         fetch-depth: 100
         
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5.1.0
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
         
     - name: Install dependencies
       working-directory: ./src

--- a/README.md
+++ b/README.md
@@ -127,10 +127,11 @@ var custom = new CustomValueFormatters
 };
 
 // Create a MessageFormatter with the custom value formatter.
-var formatter = new MessageFormatter(culture: CultureInfo.GetCultureInfo("en-US"), customValueFormatter: custom);
+var formatter = new MessageFormatter(customValueFormatter: custom);
 
-// Format a message.
-var message = formatter.FormatMessage("{value, number, $0.0}", new { value = 23 });
+// Format a message, passing the culture to FormatMessage.
+var message = formatter.FormatMessage("{value, number, $0.0}", new { value = 23 },
+    CultureInfo.GetCultureInfo("en-US"));
 // "$23.0"
 ```
 
@@ -158,11 +159,11 @@ mf.CardinalPluralizers.Add("<locale>", n => {
 });
 ````
 
-There's no restrictions on what strings you may return, nor what strings
+There are no restrictions on what strings you may return, nor what strings
 you may use in your pluralization block.
 
 ````csharp
-var mf = new MessageFormatter(true, CultureInfo.GetCultureInfo("en")); // true = use cache
+var mf = new MessageFormatter(); // uses cache by default
 mf.CardinalPluralizers["en"] = n =>
 {
     // ´n´ is the number being pluralized.
@@ -175,7 +176,7 @@ mf.CardinalPluralizers["en"] = n =>
 
 mf.FormatMessage("You have {number, plural, thatsalot {a shitload of notifications} other {# notifications}}", new Dictionary<string, object>{
   {"number", 1001}
-});
+}, CultureInfo.GetCultureInfo("en"));
 ````
 
 ## Escaping literals

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ var custom = new CustomValueFormatters
 };
 
 // Create a MessageFormatter with the custom value formatter.
-var formatter = new MessageFormatter(locale: "en-US", customValueFormatter: custom);
+var formatter = new MessageFormatter(culture: CultureInfo.GetCultureInfo("en-US"), customValueFormatter: custom);
 
 // Format a message.
 var message = formatter.FormatMessage("{value, number, $0.0}", new { value = 23 });
@@ -162,7 +162,7 @@ There's no restrictions on what strings you may return, nor what strings
 you may use in your pluralization block.
 
 ````csharp
-var mf = new MessageFormatter(true, "en"); // true = use cache
+var mf = new MessageFormatter(true, CultureInfo.GetCultureInfo("en")); // true = use cache
 mf.CardinalPluralizers["en"] = n =>
 {
     // ´n´ is the number being pluralized.

--- a/src/Jeffijoe.MessageFormat.MetadataGenerator/Jeffijoe.MessageFormat.MetadataGenerator.csproj
+++ b/src/Jeffijoe.MessageFormat.MetadataGenerator/Jeffijoe.MessageFormat.MetadataGenerator.csproj
@@ -15,11 +15,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4">
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
     <PackageReference Include="PolySharp" Version="1.15.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Jeffijoe.MessageFormat.MetadataGenerator/Plural/PluralLanguagesGenerator.cs
+++ b/src/Jeffijoe.MessageFormat.MetadataGenerator/Plural/PluralLanguagesGenerator.cs
@@ -1,39 +1,30 @@
-﻿using Jeffijoe.MessageFormat.MetadataGenerator.Plural.Parsing;
+using Jeffijoe.MessageFormat.MetadataGenerator.Plural.Parsing;
 using Jeffijoe.MessageFormat.MetadataGenerator.Plural.SourceGeneration;
 
 using Microsoft.CodeAnalysis;
 
-using System;
 using System.IO;
 using System.Xml;
 
 namespace Jeffijoe.MessageFormat.MetadataGenerator.Plural;
 
 [Generator]
-public class PluralLanguagesGenerator : ISourceGenerator
+public class PluralLanguagesGenerator : IIncrementalGenerator
 {
-    public void Execute(GeneratorExecutionContext context)
+    public void Initialize(IncrementalGeneratorInitializationContext context)
     {
-        var excludeLocales = ReadExcludeLocales(context);
-        var rules = GetRules(excludeLocales);
-        var generator = new PluralRulesMetadataGenerator(rules);
-        var sourceCode = generator.GenerateClass();
-
-        context.AddSource("PluralRulesMetadata.Generated.cs", sourceCode);
-    }
-
-    private string[] ReadExcludeLocales(GeneratorExecutionContext context)
-    {
-        if(context.AnalyzerConfigOptions.GlobalOptions.TryGetValue($"build_property.PluralLanguagesMetadataExcludeLocales", out var value))
+        context.RegisterPostInitializationOutput(static spc =>
         {
-            var locales = value.Trim().Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-            return locales;
-        }
+            // Not currently excluding any locales.
+            var rules = GetRules(excludedLocales: []);
+            var generator = new PluralRulesMetadataGenerator(rules);
+            var sourceCode = generator.GenerateClass();
 
-        return Array.Empty<string>();
+            spc.AddSource("PluralRulesMetadata.Generated.cs", sourceCode);
+        });
     }
 
-    private PluralRuleSet GetRules(string[] excludedLocales)
+    private static PluralRuleSet GetRules(string[] excludedLocales)
     {
         PluralRuleSet ruleIndex = new();
         foreach (var ruleset in new[] { "plurals.xml", "ordinals.xml" })
@@ -49,14 +40,9 @@ public class PluralLanguagesGenerator : ISourceGenerator
         return ruleIndex;
     }
 
-
-    private Stream GetRulesContentStream(string cldrFileName)
+    private static Stream GetRulesContentStream(string cldrFileName)
     {
-        return typeof(PluralLanguagesGenerator).Assembly.GetManifestResourceStream($"Jeffijoe.MessageFormat.MetadataGenerator.data.{cldrFileName}")!;
-    }
-
-    public void Initialize(GeneratorInitializationContext context)
-    {
-            
+        return typeof(PluralLanguagesGenerator).Assembly
+            .GetManifestResourceStream($"Jeffijoe.MessageFormat.MetadataGenerator.data.{cldrFileName}")!;
     }
 }

--- a/src/Jeffijoe.MessageFormat.MetadataGenerator/Plural/SourceGeneration/PluralRulesMetadataGenerator.cs
+++ b/src/Jeffijoe.MessageFormat.MetadataGenerator/Plural/SourceGeneration/PluralRulesMetadataGenerator.cs
@@ -33,7 +33,6 @@ public class PluralRulesMetadataGenerator
         // Export a constant for the normalized root locale to match the logic we're using internally.
         // This way the rest of the lib's locale chaining can continue to work if we swap out
         // normalization internally.
-        var rootRules = _rules.RuleIndicesByLocale[PluralRuleSet.RootLocale];
         WriteLine($"public static readonly string RootLocale = \"{PluralRuleSet.RootLocale}\";");
 
         // Generate a method for each unique rule, by index, that chooses the plural form

--- a/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/DateFormatterTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/DateFormatterTests.cs
@@ -12,7 +12,7 @@ public class DateFormatterTests
     [InlineData("da-DK", "1994-09-06T15:00:00Z", "06.09.1994")]
     public void DateFormatter_Short(string locale, string dateStr, string expected)
     {
-        var mf = new MessageFormatter(locale: locale);
+        var mf = new MessageFormatter(culture: CultureInfo.GetCultureInfo(locale));
         var actual = mf.FormatMessage("{value, date}", new
         {
             value = DateTimeOffset.Parse(dateStr)
@@ -26,7 +26,7 @@ public class DateFormatterTests
     [InlineData("da-DK", "1994-09-06T15:00:00Z", "tirsdag den 6. september 1994")]
     public void DateFormatter_Full(string locale, string dateStr, string expected)
     {
-        var mf = new MessageFormatter(locale: locale);
+        var mf = new MessageFormatter(culture: CultureInfo.GetCultureInfo(locale));
         var actual = mf.FormatMessage("{value, date, full}", new
         {
             value = DateTimeOffset.Parse(dateStr)
@@ -58,7 +58,7 @@ public class DateFormatterTests
                 return true;
             }
         };
-        var mf = new MessageFormatter(locale: "en-US", customValueFormatter: formatter);
+        var mf = new MessageFormatter(culture: CultureInfo.GetCultureInfo("en-US"), customValueFormatter: formatter);
         var actual = mf.FormatMessage("{value, date, long}", new
         {
             value = DateTimeOffset.Parse("1994-09-06T15:00:00Z")

--- a/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/DateFormatterTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/DateFormatterTests.cs
@@ -7,16 +7,18 @@ namespace Jeffijoe.MessageFormat.Tests.Formatting.Formatters;
 
 public class DateFormatterTests
 {
+    private static readonly CultureInfo En = CultureInfo.GetCultureInfo("en");
+
     [Theory]
     [InlineData("en-US", "1994-09-06T15:00:00Z", "9/6/1994")]
     [InlineData("da-DK", "1994-09-06T15:00:00Z", "06.09.1994")]
     public void DateFormatter_Short(string locale, string dateStr, string expected)
     {
-        var mf = new MessageFormatter(culture: CultureInfo.GetCultureInfo(locale));
+        var mf = new MessageFormatter();
         var actual = mf.FormatMessage("{value, date}", new
         {
             value = DateTimeOffset.Parse(dateStr)
-        });
+        }, CultureInfo.GetCultureInfo(locale));
 
         Assert.Equal(expected, actual);
     }
@@ -26,11 +28,11 @@ public class DateFormatterTests
     [InlineData("da-DK", "1994-09-06T15:00:00Z", "tirsdag den 6. september 1994")]
     public void DateFormatter_Full(string locale, string dateStr, string expected)
     {
-        var mf = new MessageFormatter(culture: CultureInfo.GetCultureInfo(locale));
+        var mf = new MessageFormatter();
         var actual = mf.FormatMessage("{value, date, full}", new
         {
             value = DateTimeOffset.Parse(dateStr)
-        });
+        }, CultureInfo.GetCultureInfo(locale));
 
         Assert.Equal(expected, actual);
     }
@@ -45,24 +47,24 @@ public class DateFormatterTests
                 value = DateTimeOffset.UtcNow
             }));
     }
-        
+
     [Fact]
     public void DateFormatter_Custom()
     {
         var formatter = new CustomValueFormatters
         {
-            Date = (CultureInfo culture, object? value, string? _, out string? formatted) =>
+            Date = (culture, value, _, out formatted) =>
             {
                 // This is just a test, you probably shouldn't be doing this in real workloads.
                 formatted = ((FormattableString)$"{value:MMMM d 'in the year' yyyy}").ToString(culture);
                 return true;
             }
         };
-        var mf = new MessageFormatter(culture: CultureInfo.GetCultureInfo("en-US"), customValueFormatter: formatter);
+        var mf = new MessageFormatter(customValueFormatter: formatter);
         var actual = mf.FormatMessage("{value, date, long}", new
         {
             value = DateTimeOffset.Parse("1994-09-06T15:00:00Z")
-        });
+        }, En);
 
         Assert.Equal("September 6 in the year 1994", actual);
     }

--- a/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/NumberFormatterTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/NumberFormatterTests.cs
@@ -6,6 +6,8 @@ namespace Jeffijoe.MessageFormat.Tests.Formatting.Formatters;
 
 public class NumberFormatterTests
 {
+    private static readonly CultureInfo En = CultureInfo.GetCultureInfo("en");
+
     [Theory]
     [InlineData(69, "69")]
     [InlineData(69.420, "69.42")]
@@ -13,12 +15,12 @@ public class NumberFormatterTests
     [InlineData(1234567.1234567, "1,234,567.123")]
     public void NumberFormatter_Default(decimal number, string expected)
     {
-        var mf = new MessageFormatter(culture: CultureInfo.GetCultureInfo("en-US"));
+        var mf = new MessageFormatter();
         // NOTE: The whitespace at the end is on purpose to cover whitespace tolerance in parsing.
         var actual = mf.FormatMessage("{value, number }", new
         {
             value = number
-        });
+        }, En);
 
         Assert.Equal(expected, actual);
     }
@@ -30,18 +32,18 @@ public class NumberFormatterTests
     {
         var formatters = new CustomValueFormatters
         {
-            Number = (CultureInfo culture, object? value, string? style, out string? formatted) =>
+            Number = (culture, value, style, out formatted) =>
             {
                 formatted = string.Format(culture, $"{{0:{style}}}", value);
                 return true;
             }
         };
-        var mf = new MessageFormatter(culture: CultureInfo.GetCultureInfo("en-US"), customValueFormatter: formatters);
+        var mf = new MessageFormatter(customValueFormatter: formatters);
 
         var actual = mf.FormatMessage("{value, number, 0.0000}", new
         {
             value = number
-        });
+        }, En);
 
         Assert.Equal(expected, actual);
     }
@@ -52,13 +54,13 @@ public class NumberFormatterTests
     [InlineData(1234567.1234567, "123,456,712%")]
     public void NumberFormatter_Percent(decimal number, string expected)
     {
-        var mf = new MessageFormatter(culture: CultureInfo.GetCultureInfo("en-US"));
-            
+        var mf = new MessageFormatter();
+
         // NOTE: The inconsistent whitespace in the pattern is to cover whitespace tolerance in parsing.
         var actual = mf.FormatMessage("{value, number,percent}", new
         {
             value = number
-        });
+        }, En);
 
         Assert.Equal(expected, actual);
     }
@@ -72,11 +74,11 @@ public class NumberFormatterTests
     [InlineData(true, "True")]
     public void NumberFormatter_Integer(object? value, string expected)
     {
-        var mf = new MessageFormatter(culture: CultureInfo.GetCultureInfo("en-US"));
+        var mf = new MessageFormatter();
         var actual = mf.FormatMessage("{value, number, integer}", new
         {
             value
-        });
+        }, En);
 
         Assert.Equal(expected, actual);
     }
@@ -87,13 +89,13 @@ public class NumberFormatterTests
     [InlineData("da-DK", 99.99, "99,99 kr.")]
     public void NumberFormatter_Currency(string locale, decimal number, string expected)
     {
-        var mf = new MessageFormatter(culture: CultureInfo.GetCultureInfo(locale));
+        var mf = new MessageFormatter();
 
         // NOTE: The inconsistent whitespace in the pattern is to cover whitespace tolerance in parsing.
         var actual = mf.FormatMessage("{value, number, currency }", new
         {
             value = number
-        });
+        }, CultureInfo.GetCultureInfo(locale));
 
         Assert.Equal(expected, actual);
     }
@@ -102,13 +104,13 @@ public class NumberFormatterTests
     public void NumberFormatter_ThrowsIfStyleIsNotSupported()
     {
         const decimal Number = 12.34m;
-        var mf = new MessageFormatter(culture: CultureInfo.GetCultureInfo("en-US"));
+        var mf = new MessageFormatter();
         var ex = Assert.Throws<UnsupportedFormatStyleException>(() =>
             mf.FormatMessage($"{{value, number, wow}}",
                 new
                 {
                     value = Number
-                }));
+                }, En));
         Assert.Equal("value", ex.Variable);
         Assert.Equal("number", ex.Format);
         Assert.Equal("wow", ex.Style);
@@ -117,13 +119,13 @@ public class NumberFormatterTests
     [Fact]
     public void NumberFormatter_BadInput_FallsBackToRegularFormat()
     {
-        var mf = new MessageFormatter(culture: CultureInfo.GetCultureInfo("en-US"));
+        var mf = new MessageFormatter();
 
         {
             var actual = mf.FormatMessage($"{{value, number, currency}}", new
             {
                 value = "a lot of money"
-            });
+            }, En);
 
             Assert.Equal("a lot of money", actual);
         }
@@ -132,7 +134,7 @@ public class NumberFormatterTests
             var actual = mf.FormatMessage($"{{value, number, integer}}", new
             {
                 value = "a lot of money"
-            });
+            }, En);
 
             Assert.Equal("a lot of money", actual);
         }
@@ -141,7 +143,7 @@ public class NumberFormatterTests
             var actual = mf.FormatMessage($"{{value, number, integer}}", new
             {
                 value = true
-            });
+            }, En);
 
             Assert.Equal("True", actual);
         }

--- a/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/NumberFormatterTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/NumberFormatterTests.cs
@@ -13,7 +13,7 @@ public class NumberFormatterTests
     [InlineData(1234567.1234567, "1,234,567.123")]
     public void NumberFormatter_Default(decimal number, string expected)
     {
-        var mf = new MessageFormatter(locale: "en-US");
+        var mf = new MessageFormatter(culture: CultureInfo.GetCultureInfo("en-US"));
         // NOTE: The whitespace at the end is on purpose to cover whitespace tolerance in parsing.
         var actual = mf.FormatMessage("{value, number }", new
         {
@@ -36,7 +36,7 @@ public class NumberFormatterTests
                 return true;
             }
         };
-        var mf = new MessageFormatter(locale: "en-US", customValueFormatter: formatters);
+        var mf = new MessageFormatter(culture: CultureInfo.GetCultureInfo("en-US"), customValueFormatter: formatters);
 
         var actual = mf.FormatMessage("{value, number, 0.0000}", new
         {
@@ -52,7 +52,7 @@ public class NumberFormatterTests
     [InlineData(1234567.1234567, "123,456,712%")]
     public void NumberFormatter_Percent(decimal number, string expected)
     {
-        var mf = new MessageFormatter(locale: "en-US");
+        var mf = new MessageFormatter(culture: CultureInfo.GetCultureInfo("en-US"));
             
         // NOTE: The inconsistent whitespace in the pattern is to cover whitespace tolerance in parsing.
         var actual = mf.FormatMessage("{value, number,percent}", new
@@ -72,7 +72,7 @@ public class NumberFormatterTests
     [InlineData(true, "True")]
     public void NumberFormatter_Integer(object? value, string expected)
     {
-        var mf = new MessageFormatter(locale: "en-US");
+        var mf = new MessageFormatter(culture: CultureInfo.GetCultureInfo("en-US"));
         var actual = mf.FormatMessage("{value, number, integer}", new
         {
             value
@@ -87,7 +87,7 @@ public class NumberFormatterTests
     [InlineData("da-DK", 99.99, "99,99 kr.")]
     public void NumberFormatter_Currency(string locale, decimal number, string expected)
     {
-        var mf = new MessageFormatter(locale: locale);
+        var mf = new MessageFormatter(culture: CultureInfo.GetCultureInfo(locale));
 
         // NOTE: The inconsistent whitespace in the pattern is to cover whitespace tolerance in parsing.
         var actual = mf.FormatMessage("{value, number, currency }", new
@@ -102,7 +102,7 @@ public class NumberFormatterTests
     public void NumberFormatter_ThrowsIfStyleIsNotSupported()
     {
         const decimal Number = 12.34m;
-        var mf = new MessageFormatter(locale: "en-US");
+        var mf = new MessageFormatter(culture: CultureInfo.GetCultureInfo("en-US"));
         var ex = Assert.Throws<UnsupportedFormatStyleException>(() =>
             mf.FormatMessage($"{{value, number, wow}}",
                 new
@@ -117,7 +117,7 @@ public class NumberFormatterTests
     [Fact]
     public void NumberFormatter_BadInput_FallsBackToRegularFormat()
     {
-        var mf = new MessageFormatter(locale: "en-US");
+        var mf = new MessageFormatter(culture: CultureInfo.GetCultureInfo("en-US"));
 
         {
             var actual = mf.FormatMessage($"{{value, number, currency}}", new

--- a/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/SelectFormatterTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/SelectFormatterTests.cs
@@ -5,6 +5,7 @@
 // Copyright (C) Jeff Hansen 2015. All rights reserved.
 
 using System.Collections.Generic;
+using System.Globalization;
 using Jeffijoe.MessageFormat.Formatting;
 using Jeffijoe.MessageFormat.Formatting.Formatters;
 using Jeffijoe.MessageFormat.Parsing;
@@ -62,7 +63,7 @@ public class SelectFormatterTests
             "select",
             formatterArgs);
         var args = new Dictionary<string, object?> { { "gender", gender } };
-        var result = subject.Format("en", req, args, gender, messageFormatter);
+        var result = subject.Format(CultureInfo.GetCultureInfo("en"), req, args, gender, messageFormatter);
         Assert.Equal(expectedBlock, result);
     }
 
@@ -83,7 +84,7 @@ public class SelectFormatterTests
 
         Assert.Throws<MessageFormatterException>(() =>
         {
-            subject.Format("en", req, args, "non-binary", messageFormatter);
+            subject.Format(CultureInfo.GetCultureInfo("en"), req, args, "non-binary", messageFormatter);
         });
     }
 

--- a/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/TimeFormatterTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/TimeFormatterTests.cs
@@ -8,17 +8,18 @@ namespace Jeffijoe.MessageFormat.Tests.Formatting.Formatters;
 
 public partial class TimeFormatterTests
 {
+    private static readonly CultureInfo En = CultureInfo.GetCultureInfo("en");
 
     [Theory]
     [InlineData("en-US", "1994-09-06T15:01:23Z", "3:01 PM")]
     [InlineData("da-DK", "1994-09-06T15:01:23Z", "15.01")]
     public void TimeFormatter_Short(string locale, string dateStr, string expected)
     {
-        var mf = new MessageFormatter(culture: CultureInfo.GetCultureInfo(locale));
+        var mf = new MessageFormatter();
         var actual = mf.FormatMessage("{value, time, short}", new
         {
             value = DateTimeOffset.Parse(dateStr)
-        });
+        }, CultureInfo.GetCultureInfo(locale));
 
         // Replacing all whitespace due to a difference in formatting on macOS vs Linux.
         expected = Normalize(expected);
@@ -31,11 +32,11 @@ public partial class TimeFormatterTests
     [InlineData("da-DK", "1994-09-06T15:01:23Z", "15.01.23")]
     public void TimeFormatter_Default(string locale, string dateStr, string expected)
     {
-        var mf = new MessageFormatter(culture: CultureInfo.GetCultureInfo(locale));
+        var mf = new MessageFormatter();
         var actual = mf.FormatMessage("{value, time}", new
         {
             value = DateTimeOffset.Parse(dateStr)
-        });
+        }, CultureInfo.GetCultureInfo(locale));
 
         // Replacing all whitespace due to a difference in formatting on macOS vs Linux.
         expected = Normalize(expected);
@@ -53,23 +54,23 @@ public partial class TimeFormatterTests
                 value = DateTimeOffset.UtcNow
             }));
     }
-        
+
     [Fact]
     public void TimeFormatter_Custom()
     {
         var formatter = new CustomValueFormatters
         {
-            Time = (CultureInfo _, object? value, string? _, out string? formatted) =>
+            Time = (_, value, _, out formatted) =>
             {
                 formatted = $"{value:hmm} nice";
                 return true;
             }
         };
-        var mf = new MessageFormatter(culture: CultureInfo.GetCultureInfo("en-US"), customValueFormatter: formatter);
+        var mf = new MessageFormatter(customValueFormatter: formatter);
         var actual = mf.FormatMessage("{value, time, long}", new
         {
             value = DateTimeOffset.Parse("1994-09-06T16:20:09Z")
-        });
+        }, En);
 
         Assert.Equal("420 nice", actual);
     }

--- a/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/TimeFormatterTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/TimeFormatterTests.cs
@@ -14,7 +14,7 @@ public partial class TimeFormatterTests
     [InlineData("da-DK", "1994-09-06T15:01:23Z", "15.01")]
     public void TimeFormatter_Short(string locale, string dateStr, string expected)
     {
-        var mf = new MessageFormatter(locale: locale);
+        var mf = new MessageFormatter(culture: CultureInfo.GetCultureInfo(locale));
         var actual = mf.FormatMessage("{value, time, short}", new
         {
             value = DateTimeOffset.Parse(dateStr)
@@ -31,7 +31,7 @@ public partial class TimeFormatterTests
     [InlineData("da-DK", "1994-09-06T15:01:23Z", "15.01.23")]
     public void TimeFormatter_Default(string locale, string dateStr, string expected)
     {
-        var mf = new MessageFormatter(locale: locale);
+        var mf = new MessageFormatter(culture: CultureInfo.GetCultureInfo(locale));
         var actual = mf.FormatMessage("{value, time}", new
         {
             value = DateTimeOffset.Parse(dateStr)
@@ -65,7 +65,7 @@ public partial class TimeFormatterTests
                 return true;
             }
         };
-        var mf = new MessageFormatter(locale: "en-US", customValueFormatter: formatter);
+        var mf = new MessageFormatter(culture: CultureInfo.GetCultureInfo("en-US"), customValueFormatter: formatter);
         var actual = mf.FormatMessage("{value, time, long}", new
         {
             value = DateTimeOffset.Parse("1994-09-06T16:20:09Z")

--- a/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/VariableFormatterTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Formatting/Formatters/VariableFormatterTests.cs
@@ -5,6 +5,7 @@
 // Copyright (C) Jeff Hansen 2015. All rights reserved.
 
 using System.Collections.Generic;
+using System.Globalization;
 using Jeffijoe.MessageFormat.Formatting;
 using Jeffijoe.MessageFormat.Formatting.Formatters;
 using Jeffijoe.MessageFormat.Parsing;
@@ -57,7 +58,7 @@ public class VariableFormatterTests
         var req = CreateRequest();
         var args = new Dictionary<string, object?>();
 
-        Assert.Equal(string.Empty, this.subject.Format("en", req, args, null, this.formatter));
+        Assert.Equal(string.Empty, this.subject.Format(CultureInfo.GetCultureInfo("en"), req, args, null, this.formatter));
     }
 
     /// <summary>
@@ -69,7 +70,7 @@ public class VariableFormatterTests
         var req = CreateRequest();
         var args = new Dictionary<string, object?>();
 
-        Assert.Equal("is good", this.subject.Format("en", req, args, "is good", this.formatter));
+        Assert.Equal("is good", this.subject.Format(CultureInfo.GetCultureInfo("en"), req, args, "is good", this.formatter));
     }
 
     #endregion

--- a/src/Jeffijoe.MessageFormat.Tests/Jeffijoe.MessageFormat.Tests.csproj
+++ b/src/Jeffijoe.MessageFormat.Tests/Jeffijoe.MessageFormat.Tests.csproj
@@ -4,9 +4,9 @@
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>MessageFormat.snk</AssemblyOriginatorKeyFile>
 	<GenerateAssemblyInfo>False</GenerateAssemblyInfo>
-	<LangVersion>12</LangVersion>
+	<LangVersion>default</LangVersion>
 	<Nullable>enable</Nullable>
-	<TargetFramework>net8.0</TargetFramework>
+	<TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Jeffijoe.MessageFormat.Tests/Jeffijoe.MessageFormat.Tests.csproj
+++ b/src/Jeffijoe.MessageFormat.Tests/Jeffijoe.MessageFormat.Tests.csproj
@@ -10,14 +10,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
-    <PackageReference Include="xunit.assert" Version="2.9.2" />
-    <PackageReference Include="xunit.core" Version="2.9.2" />
-    <PackageReference Include="xunit.extensibility.core" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.assert" Version="2.9.3" />
+    <PackageReference Include="xunit.core" Version="2.9.3" />
+    <PackageReference Include="xunit.extensibility.core" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Jeffijoe.MessageFormat.Tests/MessageFormatterFullIntegrationTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/MessageFormatterFullIntegrationTests.cs
@@ -1,4 +1,4 @@
-﻿// MessageFormat for .NET
+// MessageFormat for .NET
 // - MessageFormatter_full_integration_tests.cs
 //
 // Author: Jeff Hansen <jeff@jeffijoe.com>
@@ -7,7 +7,6 @@
 using System.Collections.Generic;
 using System.Globalization;
 using Jeffijoe.MessageFormat.Formatting;
-using Jeffijoe.MessageFormat.Formatting.Formatters;
 using Jeffijoe.MessageFormat.Tests.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -20,6 +19,10 @@ namespace Jeffijoe.MessageFormat.Tests;
 public class MessageFormatterFullIntegrationTests
 {
     #region Fields
+
+    private static readonly CultureInfo En = CultureInfo.GetCultureInfo("en");
+    private static readonly CultureInfo EnUs = CultureInfo.GetCultureInfo("en-US");
+    private static readonly CultureInfo DaDk = CultureInfo.GetCultureInfo("da-DK");
 
     /// <summary>
     /// The output helper.
@@ -143,32 +146,32 @@ public class MessageFormatterFullIntegrationTests
     {
         get
         {
-            const string Case1 = @"{gender, select, 
+            const string Case1 = @"{gender, select,
                            male {He - '{'{name}'}' -}
                            female {She - '{'{name}'}' -}
                            other {They}
                       } said: You're pretty cool!";
-            const string Case2 = @"{gender, select, 
+            const string Case2 = @"{gender, select,
                            male {He - '{'{name}'}' -}
                            female {She - '{'{name}'}' -}
                            other {They}
-                      } said: You have {count, plural, 
+                      } said: You have {count, plural,
                             zero {no notifications}
                             one {just one notification}
                             =42 {a universal amount of notifications}
                             other {# notifications}
                       }. Have a nice day!";
-            const string Case3 = @"You have {count, plural, 
+            const string Case3 = @"You have {count, plural,
                             zero {no notifications}
                             one {just one notification}
                             =42 {a universal amount of notifications}
                             other {# notifications}
                       }. Have a nice day!";
-            const string Case4 = @"{gender, select, 
+            const string Case4 = @"{gender, select,
                            male {He}
                            female {She}
                            other {They}
-                      } said: You have {count, plural, 
+                      } said: You have {count, plural,
                             zero {no notifications}
                             one {just one notification}
                             =42 {a universal amount of notifications}
@@ -176,21 +179,21 @@ public class MessageFormatterFullIntegrationTests
                       }. Have a nice day!";
 
             // Please take the following sample in the spirit it was intended. :)
-            const string Case5 = @"{gender, select, 
-                           male {He (who has {genitals, plural, 
+            const string Case5 = @"{gender, select,
+                           male {He (who has {genitals, plural,
                                     zero {no testicles}
                                     one {just one testicle}
                                     =2 {a normal amount of testicles}
                                     other {the insane amount of # testicles}
                                 })}
-                           female {She (who has {genitals, plural, 
+                           female {She (who has {genitals, plural,
                                     zero {no boobies}
                                     one {just one boob}
                                     =2 {a pair of lovelies}
                                     other {the freakish amount of # boobies}
                                 })}
                            other {They}
-                      } said: You have {count, plural, 
+                      } said: You have {count, plural,
                             zero {no notifications}
                             one {just one notification}
                             =42 {a universal amount of notifications}
@@ -402,30 +405,22 @@ public class MessageFormatterFullIntegrationTests
     [MemberData(nameof(Tests))]
     public void FormatMessage(string source, Dictionary<string, object?> args, string expected)
     {
-        var subject = new MessageFormatter(useCache: false, culture: CultureInfo.GetCultureInfo("en"));
+        var subject = new MessageFormatter(useCache: false);
 
         // Historically these tests relied on a default English pluralizer that mapped
         // 0 to "zero"; adding that back in manually to ensure we maintain test coverage
         // for multiple forms.
-        subject.CardinalPluralizers!.Add("en", (number) =>
+        subject.CardinalPluralizers!.Add("en", number => number switch
         {
-            if (number == 0)
-            {
-                return "zero";
-            } else if (number == 1)
-            {
-                return "one";
-            }
-            else
-            {
-                return "other";
-            }
+            0 => "zero",
+            1 => "one",
+            _ => "other"
         });
 
         // Warmup
-        subject.FormatMessage(source, args);
+        subject.FormatMessage(source, args, En);
         Benchmark.Start("Formatting", this.outputHelper);
-        string result = subject.FormatMessage(source, args);
+        string result = subject.FormatMessage(source, args, En);
         Benchmark.End(this.outputHelper);
         Assert.Equal(expected, result);
         this.outputHelper.WriteLine(result);
@@ -450,11 +445,11 @@ public class MessageFormatterFullIntegrationTests
     [Fact]
     public void FormatMessage_debug()
     {
-        const string Source = @"{gender, select, 
+        const string Source = @"{gender, select,
                            male {He}
                            female {She}
                            other {They}
-                      } said: You have {count, plural, 
+                      } said: You have {count, plural,
                             zero {no notifications}
                             one {just one notification}
                             =42 {a universal amount of notifications}
@@ -487,8 +482,8 @@ public class MessageFormatterFullIntegrationTests
     public void FormatMessage_nesting_with_brace_escaping()
     {
         var subject = new MessageFormatter(false);
-        const string Pattern = @"{s1, select, 
-                                1 {{s2, select, 
+        const string Pattern = @"{s1, select,
+                                1 {{s2, select,
                                    2 {'{'}
                                 }}
                             }";
@@ -503,7 +498,7 @@ public class MessageFormatterFullIntegrationTests
     [Fact]
     public void FormatMessage_with_reflection_overload()
     {
-        var subject = new MessageFormatter(false);
+        var subject = new MessageFormatter(false, culture: EnUs);
         const string Pattern = "You have {UnreadCount, plural, "
                                + "=0 {no unread messages}"
                                + "one {just one unread message}" + "other {# unread messages}" + "} today.";
@@ -526,7 +521,7 @@ public class MessageFormatterFullIntegrationTests
     /// <summary>
     /// The read me_test_to_make_sure_ i_dont_look_like_a_fool.
     /// </summary>
-    [Fact]
+    [Fact, UseCulture("en")]
     public void ReadMe_test_to_make_sure_I_dont_look_like_a_fool()
     {
         {
@@ -546,7 +541,7 @@ public class MessageFormatterFullIntegrationTests
         {
             var mf = new MessageFormatter(false);
             const string Str = @"You {NUM_ADDS, plural, offset:1
-                              =0{didnt add this to your profile} 
+                              =0{didnt add this to your profile}
                               =1{added this to your profile}
                               one{and one other person added this to their profile}
                               other{and # others added this to their profiles}
@@ -654,7 +649,7 @@ public class MessageFormatterFullIntegrationTests
         }
 
         {
-            var mf = new MessageFormatter(useCache: true, culture: CultureInfo.GetCultureInfo("en"));
+            var mf = new MessageFormatter(useCache: true);
             mf.CardinalPluralizers!["en"] = n =>
             {
                 // ´n´ is the number being pluralized.
@@ -681,9 +676,50 @@ public class MessageFormatterFullIntegrationTests
             var actual =
                 mf.FormatMessage(
                     "You have {number, plural, thatsalot {a shitload of notifications} other {# notifications}}",
-                    new Dictionary<string, object?> { { "number", 1001 } });
+                    new Dictionary<string, object?> { { "number", 1001 } },
+                    En);
             Assert.Equal("You have a shitload of notifications", actual);
         }
+    }
+
+    [Fact]
+    public void FormatMessage_uses_constructor_culture_as_default()
+    {
+        var mf = new MessageFormatter(culture: DaDk);
+
+        // Should use da-DK formatting without specifying culture on FormatMessage.
+        var result = mf.FormatMessage("{value, number}", new Dictionary<string, object?> { { "value", 1234.5m } });
+        Assert.Equal("1.234,5", result);
+    }
+
+    [Fact]
+    public void FormatMessage_with_culture_override()
+    {
+        var mf = new MessageFormatter(culture: EnUs);
+
+        // Without override, uses the constructor culture (en-US).
+        var resultUs = mf.FormatMessage("{value, number}", new Dictionary<string, object?> { { "value", 1234.5m } });
+        Assert.Equal("1,234.5", resultUs);
+
+        // With override, uses da-DK formatting (period as thousands separator, comma as decimal).
+        var resultDk = mf.FormatMessage(
+            "{value, number}",
+            new Dictionary<string, object?> { { "value", 1234.5m } },
+            DaDk);
+        Assert.Equal("1.234,5", resultDk);
+    }
+
+    [Fact]
+    public void FormatMessage_culture_override_propagates_to_nested_formatting()
+    {
+        var mf = new MessageFormatter();
+
+        // The culture override should propagate through nested formatting (e.g. select -> number).
+        var result = mf.FormatMessage(
+            "{gender, select, male {He earned {amount, number}} other {They earned {amount, number}}}",
+            new Dictionary<string, object?> { { "gender", "male" }, { "amount", 1234.5m } },
+            DaDk);
+        Assert.Equal("He earned 1.234,5", result);
     }
 
     #endregion

--- a/src/Jeffijoe.MessageFormat.Tests/MessageFormatterFullIntegrationTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/MessageFormatterFullIntegrationTests.cs
@@ -5,6 +5,7 @@
 // Copyright (C) Jeff Hansen 2015. All rights reserved.
 
 using System.Collections.Generic;
+using System.Globalization;
 using Jeffijoe.MessageFormat.Formatting;
 using Jeffijoe.MessageFormat.Formatting.Formatters;
 using Jeffijoe.MessageFormat.Tests.TestHelpers;
@@ -401,7 +402,7 @@ public class MessageFormatterFullIntegrationTests
     [MemberData(nameof(Tests))]
     public void FormatMessage(string source, Dictionary<string, object?> args, string expected)
     {
-        var subject = new MessageFormatter(false);
+        var subject = new MessageFormatter(useCache: false, culture: CultureInfo.GetCultureInfo("en"));
 
         // Historically these tests relied on a default English pluralizer that mapped
         // 0 to "zero"; adding that back in manually to ensure we maintain test coverage
@@ -653,7 +654,7 @@ public class MessageFormatterFullIntegrationTests
         }
 
         {
-            var mf = new MessageFormatter(useCache: true, locale: "en");
+            var mf = new MessageFormatter(useCache: true, culture: CultureInfo.GetCultureInfo("en"));
             mf.CardinalPluralizers!["en"] = n =>
             {
                 // ´n´ is the number being pluralized.

--- a/src/Jeffijoe.MessageFormat.Tests/MessageFormatterIssues.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/MessageFormatterIssues.cs
@@ -1,6 +1,6 @@
-﻿// MessageFormat for .NET
+// MessageFormat for .NET
 // - MessageFormatter_full_integration_tests.cs
-// 
+//
 // Author: Jeff Hansen <jeff@jeffijoe.com>
 // Copyright (C) Jeff Hansen 2015. All rights reserved.
 
@@ -15,6 +15,8 @@ namespace Jeffijoe.MessageFormat.Tests;
 /// </summary>
 public class MessageFormatterIssues
 {
+    private static readonly CultureInfo En = CultureInfo.GetCultureInfo("en");
+
     [Fact]
     public void Issue13_Bad_escaping_on_pound_symbol()
     {
@@ -42,7 +44,7 @@ public class MessageFormatterIssues
     [Fact]
     public void Issue31_IDictionary_interface_support()
     {
-        var subject = new MessageFormatter(culture: CultureInfo.GetCultureInfo("en-US"));
+        var subject = new MessageFormatter();
 
         IDictionary<string, object> idict = new Dictionary<string, object>
         {
@@ -54,14 +56,14 @@ public class MessageFormatterIssues
             ["string"] = "value"
         };
 
-        Assert.Equal("value", subject.FormatMessage("{string}", idict));
-        Assert.Equal("value", subject.FormatMessage("{string}", idictNullable!));
+        Assert.Equal("value", subject.FormatMessage("{string}", idict, En));
+        Assert.Equal("value", subject.FormatMessage("{string}", idictNullable!, En));
     }
 
     [Fact]
     public void Issue34_Newlines_are_stripped()
     {
-        var subject = new MessageFormatter(culture: CultureInfo.GetCultureInfo("en-US"));
+        var subject = new MessageFormatter();
 
         const string Expected = "Single text which will not change.\nSummary:\nAccepted\nData:\n-X\n-Y\n-Z";
 
@@ -70,14 +72,14 @@ public class MessageFormatterIssues
             new
             {
                 acceptedData = "\n-X\n-Y\n-Z"
-            });
+            }, En);
         Assert.Equal(Expected, result);
     }
 
     [Fact]
     public void Issue45_Url_should_not_be_parsed_as_extension()
     {
-        var subject = new MessageFormatter(culture: CultureInfo.GetCultureInfo("en-US"));
+        var subject = new MessageFormatter();
 
         IDictionary<string, object> dict = new Dictionary<string, object>
         {
@@ -86,7 +88,7 @@ public class MessageFormatterIssues
 
         var result = subject.FormatMessage(
             "{cond, select, foo{https://www.google.com/} other{https://www.bing.com/}}",
-            dict);
+            dict, En);
         Assert.Equal("https://www.google.com/", result);
     }
 }

--- a/src/Jeffijoe.MessageFormat.Tests/MessageFormatterIssues.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/MessageFormatterIssues.cs
@@ -5,6 +5,7 @@
 // Copyright (C) Jeff Hansen 2015. All rights reserved.
 
 using System.Collections.Generic;
+using System.Globalization;
 using Xunit;
 
 namespace Jeffijoe.MessageFormat.Tests;
@@ -41,7 +42,7 @@ public class MessageFormatterIssues
     [Fact]
     public void Issue31_IDictionary_interface_support()
     {
-        var subject = new MessageFormatter(locale: "en-US");
+        var subject = new MessageFormatter(culture: CultureInfo.GetCultureInfo("en-US"));
 
         IDictionary<string, object> idict = new Dictionary<string, object>
         {
@@ -60,7 +61,7 @@ public class MessageFormatterIssues
     [Fact]
     public void Issue34_Newlines_are_stripped()
     {
-        var subject = new MessageFormatter(locale: "en-US");
+        var subject = new MessageFormatter(culture: CultureInfo.GetCultureInfo("en-US"));
 
         const string Expected = "Single text which will not change.\nSummary:\nAccepted\nData:\n-X\n-Y\n-Z";
 
@@ -76,7 +77,7 @@ public class MessageFormatterIssues
     [Fact]
     public void Issue45_Url_should_not_be_parsed_as_extension()
     {
-        var subject = new MessageFormatter(locale: "en-US");
+        var subject = new MessageFormatter(culture: CultureInfo.GetCultureInfo("en-US"));
 
         IDictionary<string, object> dict = new Dictionary<string, object>
         {

--- a/src/Jeffijoe.MessageFormat.Tests/MessageFormatterStringExtensionTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/MessageFormatterStringExtensionTests.cs
@@ -4,6 +4,7 @@
 // Author: Jeff Hansen <jeff@jeffijoe.com>
 // Copyright (C) Jeff Hansen 2015. All rights reserved.
 
+using System.Globalization;
 using System.Threading.Tasks;
 
 using Xunit;
@@ -26,12 +27,14 @@ public class MessageFormatterStringExtensionTests
     [Fact]
     public async Task FormatMessage_with_multiple_tasks()
     {
-        var pattern = "Copying {fileCount, plural, one {one file} other{# files}}.";
+        const string Pattern = "Copying {fileCount, plural, one {one file} other{# files}}.";
+        
+        var en = CultureInfo.GetCultureInfo("en");
 
         // 2 with the same message to test there are no issues with caching with multiple threads.
-        var t1 = Task.Run(() => MessageFormatter.Format(pattern, new { fileCount = 1 }));
-        var t2 = Task.Run(() => MessageFormatter.Format(pattern, new { fileCount = 1 }));
-        var t3 = Task.Run(() => MessageFormatter.Format(pattern, new { fileCount = 5 }));
+        var t1 = Task.Run(() => MessageFormatter.Format(Pattern, new { fileCount = 1 }, en));
+        var t2 = Task.Run(() => MessageFormatter.Format(Pattern, new { fileCount = 1 }, en));
+        var t3 = Task.Run(() => MessageFormatter.Format(Pattern, new { fileCount = 5 }, en));
         await Task.WhenAll(t1, t2, t3);
 
         Assert.Equal("Copying one file.", t1.Result);

--- a/src/Jeffijoe.MessageFormat.Tests/MessageFormatterStringExtensionTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/MessageFormatterStringExtensionTests.cs
@@ -37,9 +37,9 @@ public class MessageFormatterStringExtensionTests
         var t3 = Task.Run(() => MessageFormatter.Format(Pattern, new { fileCount = 5 }, en));
         await Task.WhenAll(t1, t2, t3);
 
-        Assert.Equal("Copying one file.", t1.Result);
-        Assert.Equal("Copying one file.", t2.Result);
-        Assert.Equal("Copying 5 files.", t3.Result);
+        Assert.Equal("Copying one file.", await t1);
+        Assert.Equal("Copying one file.", await t2);
+        Assert.Equal("Copying 5 files.", await t3);
     }
 
     #endregion

--- a/src/Jeffijoe.MessageFormat.Tests/MessageFormatterTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/MessageFormatterTests.cs
@@ -5,6 +5,7 @@
 // Copyright (C) Jeff Hansen 2015. All rights reserved.
 
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 
 using Jeffijoe.MessageFormat.Formatting;
@@ -110,7 +111,7 @@ public class MessageFormatterTests
 
         public bool CanFormat(FormatterRequest request) => request.FormatterName == this.formatterName;
 
-        public string Format(string locale, FormatterRequest request, IReadOnlyDictionary<string, object?> args, object? value,
+        public string Format(CultureInfo culture, FormatterRequest request, IReadOnlyDictionary<string, object?> args, object? value,
             IMessageFormatter messageFormatter)
         {
             return "formatted";

--- a/src/Jeffijoe.MessageFormat.Tests/MetadataGenerator/ParserTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/MetadataGenerator/ParserTests.cs
@@ -2,7 +2,6 @@
 using Jeffijoe.MessageFormat.MetadataGenerator.Plural.Parsing.AST;
 
 using System;
-using System.Collections.Generic;
 using System.Xml;
 
 using Xunit;

--- a/src/Jeffijoe.MessageFormat.Tests/Parsing/LiteralParserTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/Parsing/LiteralParserTests.cs
@@ -4,7 +4,6 @@
 // Author: Jeff Hansen <jeff@jeffijoe.com>
 // Copyright (C) Jeff Hansen 2015. All rights reserved.
 
-using System;
 using System.Linq;
 using System.Text;
 

--- a/src/Jeffijoe.MessageFormat.Tests/TestHelpers/FakeFormatter.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/TestHelpers/FakeFormatter.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Globalization;
 using Jeffijoe.MessageFormat.Formatting;
 
 namespace Jeffijoe.MessageFormat.Tests.TestHelpers;
@@ -43,7 +44,7 @@ internal class FakeFormatter : IFormatter
 
     /// <inheritdoc />
     public string Format(
-        string locale,
+        CultureInfo culture,
         FormatterRequest request,
         IReadOnlyDictionary<string, object?> args,
         object? value,

--- a/src/Jeffijoe.MessageFormat.Tests/TestHelpers/FakeMessageFormatter.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/TestHelpers/FakeMessageFormatter.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace Jeffijoe.MessageFormat.Tests.TestHelpers;
 
@@ -9,7 +10,7 @@ internal class FakeMessageFormatter : IMessageFormatter
 {
     public CustomValueFormatter? CustomValueFormatter { get; set; }
 
-    public string FormatMessage(string pattern, IReadOnlyDictionary<string, object?> argsMap) => pattern;
+    public string FormatMessage(string pattern, IReadOnlyDictionary<string, object?> argsMap, CultureInfo? culture = null) => pattern;
 
     public string FormatMessage(string pattern, object args) => pattern;
 }

--- a/src/Jeffijoe.MessageFormat.Tests/TestHelpers/UseCultureAttribute.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/TestHelpers/UseCultureAttribute.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Globalization;
+using System.Reflection;
+using System.Threading;
+using Xunit.Sdk;
+
+namespace Jeffijoe.MessageFormat.Tests.TestHelpers;
+
+/// <summary>
+/// Apply this attribute to your test method to replace the
+/// <see cref="Thread.CurrentThread" /> <see cref="CultureInfo.CurrentCulture" /> and
+/// <see cref="CultureInfo.CurrentUICulture" /> with another culture.
+/// </summary>
+/// <remarks>
+/// Replaces the culture and UI culture of the current thread with
+/// <paramref name="culture" /> and <paramref name="uiCulture" />
+/// </remarks>
+/// <param name="culture">The name of the culture.</param>
+/// <param name="uiCulture">The name of the UI culture.</param>
+[AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+public class UseCultureAttribute(string culture, string uiCulture) : BeforeAfterTestAttribute
+{
+    private readonly Lazy<CultureInfo> culture = new(() => new CultureInfo(culture, false));
+    private readonly Lazy<CultureInfo> uiCulture = new(() => new CultureInfo(uiCulture, false));
+
+    private CultureInfo? originalCulture;
+    private CultureInfo? originalUiCulture;
+
+    /// <summary>
+    /// Replaces the culture and UI culture of the current thread with
+    /// <paramref name="culture" />
+    /// </summary>
+    /// <param name="culture">The name of the culture.</param>
+    /// <remarks>
+    /// This constructor overload uses <paramref name="culture" /> for both Culture and UICulture.
+    /// </remarks>
+    public UseCultureAttribute(string culture)
+        : this(culture, culture) { }
+
+    /// <summary>
+    /// Stores the current <see cref="Thread.CurrentPrincipal" />
+    /// <see cref="CultureInfo.CurrentCulture" /> and <see cref="CultureInfo.CurrentUICulture" />
+    /// and replaces them with the new cultures defined in the constructor.
+    /// </summary>
+    /// <param name="methodUnderTest">The method under test</param>
+    public override void Before(MethodInfo methodUnderTest)
+    {
+        originalCulture = Thread.CurrentThread.CurrentCulture;
+        originalUiCulture = Thread.CurrentThread.CurrentUICulture;
+
+        Thread.CurrentThread.CurrentCulture = culture.Value;
+        Thread.CurrentThread.CurrentUICulture = uiCulture.Value;
+
+        CultureInfo.CurrentCulture.ClearCachedData();
+        CultureInfo.CurrentUICulture.ClearCachedData();
+    }
+
+    /// <summary>
+    /// Restores the original <see cref="CultureInfo.CurrentCulture" /> and
+    /// <see cref="CultureInfo.CurrentUICulture" /> to <see cref="Thread.CurrentPrincipal" />
+    /// </summary>
+    /// <param name="methodUnderTest">The method under test</param>
+    public override void After(MethodInfo methodUnderTest)
+    {
+        if (originalCulture is not null)
+            Thread.CurrentThread.CurrentCulture = originalCulture;
+        if (originalUiCulture is not null)
+            Thread.CurrentThread.CurrentUICulture = originalUiCulture;
+
+        CultureInfo.CurrentCulture.ClearCachedData();
+        CultureInfo.CurrentUICulture.ClearCachedData();
+    }
+}

--- a/src/Jeffijoe.MessageFormat/Formatting/Formatters/BaseValueFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/Formatters/BaseValueFormatter.cs
@@ -37,14 +37,13 @@ public abstract class BaseValueFormatter : BaseFormatter, IFormatter
 
     /// <inheritdoc />
     public string Format(
-        string locale,
+        CultureInfo culture,
         FormatterRequest request,
         IReadOnlyDictionary<string, object?> args,
         object? value,
         IMessageFormatter messageFormatter)
     {
         var formatterArgs = request.FormatterArguments!;
-        var culture = CultureInfo.GetCultureInfo(locale);
         return FormatValue(
             culture: culture,
             customValueFormatter: messageFormatter.CustomValueFormatter,

--- a/src/Jeffijoe.MessageFormat/Formatting/Formatters/PluralFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/Formatters/PluralFormatter.cs
@@ -7,6 +7,7 @@ using Jeffijoe.MessageFormat.Helpers;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Linq;
 
 namespace Jeffijoe.MessageFormat.Formatting.Formatters;
@@ -96,8 +97,8 @@ public class PluralFormatter : BaseFormatter, IFormatter
     ///     nested formatting. This is only called if <see cref="CanFormat" /> returns true.
     ///     The args will always contain the <see cref="FormatterRequest.Variable" />.
     /// </summary>
-    /// <param name="locale">
-    ///     The locale being used. It is up to the formatter what they do with this information.
+    /// <param name="culture">
+    ///     The culture being used. It is up to the formatter what they do with this information.
     /// </param>
     /// <param name="request">
     ///     The parameters.
@@ -115,7 +116,7 @@ public class PluralFormatter : BaseFormatter, IFormatter
     /// <exception cref="MessageFormatterException">
     ///     If <paramref name="request"/> does not specify a formatter name supported by <see cref="CanFormat(FormatterRequest)"/>.
     /// </exception>
-    public string Format(string locale,
+    public string Format(CultureInfo culture,
         FormatterRequest request,
         IReadOnlyDictionary<string, object?> args,
         object? value,
@@ -148,6 +149,7 @@ public class PluralFormatter : BaseFormatter, IFormatter
             throw new MessageFormatterException($"Unsupported plural formatter name: {request.FormatterName}");
         }
 
+        var locale = culture.Name;
         var ctx = CreatePluralContext(value, offset);
         var pluralized = this.Pluralize(
             locale,

--- a/src/Jeffijoe.MessageFormat/Formatting/Formatters/PluralFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/Formatters/PluralFormatter.cs
@@ -159,7 +159,7 @@ public class PluralFormatter : BaseFormatter, IFormatter
             ctx,
             offset);
         var result = this.ReplaceNumberLiterals(pluralized, ctx.Number);
-        var formatted = messageFormatter.FormatMessage(result, args);
+        var formatted = messageFormatter.FormatMessage(result, args, culture);
         return formatted;
     }
 

--- a/src/Jeffijoe.MessageFormat/Formatting/Formatters/PluralRulesMetadata.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/Formatters/PluralRulesMetadata.cs
@@ -1,6 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
-
-namespace Jeffijoe.MessageFormat.Formatting.Formatters;
+﻿namespace Jeffijoe.MessageFormat.Formatting.Formatters;
 
 [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal static partial class PluralRulesMetadata

--- a/src/Jeffijoe.MessageFormat/Formatting/Formatters/SelectFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/Formatters/SelectFormatter.cs
@@ -73,7 +73,7 @@ public class SelectFormatter : BaseFormatter, IFormatter
         {
             if (str == keyedBlock.Key)
             {
-                return messageFormatter.FormatMessage(keyedBlock.BlockText, args);
+                return messageFormatter.FormatMessage(keyedBlock.BlockText, args, culture);
             }
 
             if (keyedBlock.Key == OtherKey)
@@ -88,7 +88,7 @@ public class SelectFormatter : BaseFormatter, IFormatter
                 "'other' option not found in pattern, and variable was not present in collection.");
         }
 
-        return messageFormatter.FormatMessage(other.BlockText, args);
+        return messageFormatter.FormatMessage(other.BlockText, args, culture);
     }
 
     #endregion

--- a/src/Jeffijoe.MessageFormat/Formatting/Formatters/SelectFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/Formatters/SelectFormatter.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 
 namespace Jeffijoe.MessageFormat.Formatting.Formatters;
 
@@ -48,7 +49,7 @@ public class SelectFormatter : BaseFormatter, IFormatter
     /// nested formatting. This is only called if <see cref="CanFormat" /> returns true.
     /// The args will always contain the <see cref="FormatterRequest.Variable" />.
     /// </summary>
-    /// <param name="locale">The locale being used. It is up to the formatter what they do with this information.</param>
+    /// <param name="culture">The culture being used. It is up to the formatter what they do with this information.</param>
     /// <param name="request">The parameters.</param>
     /// <param name="args">The arguments.</param>
     /// <param name="value">The value of <see cref="FormatterRequest.Variable" /> from the given args dictionary. Can be null.</param>
@@ -59,7 +60,7 @@ public class SelectFormatter : BaseFormatter, IFormatter
     /// <exception cref="MessageFormatterException">'other' option not found in pattern, and variable was not present in collection.</exception>
     [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1126:PrefixCallsCorrectly",
         Justification = "Reviewed. Suppression is OK here.")]
-    public string Format(string locale,
+    public string Format(CultureInfo culture,
         FormatterRequest request,
         IReadOnlyDictionary<string, object?> args,
         object? value,

--- a/src/Jeffijoe.MessageFormat/Formatting/Formatters/VariableFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/Formatters/VariableFormatter.cs
@@ -1,10 +1,9 @@
-﻿// MessageFormat for .NET
+// MessageFormat for .NET
 // - VariableFormatter.cs
 // Author: Jeff Hansen <jeff@jeffijoe.com>
 // Copyright (C) Jeff Hansen 2014. All rights reserved.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 
@@ -15,21 +14,15 @@ namespace Jeffijoe.MessageFormat.Formatting.Formatters;
 /// </summary>
 public class VariableFormatter : IFormatter
 {
-    #region Fields
-
-    private readonly ConcurrentDictionary<string, CultureInfo> cultures = new ConcurrentDictionary<string, CultureInfo>();
-
-    #endregion
-
     #region Public Properties
 
     /// <summary>
     ///     This formatter requires the input variable to exist.
     /// </summary>
     public bool VariableMustExist => true;
-        
+
     #endregion
-        
+
     #region Public Methods and Operators
 
     /// <summary>
@@ -47,12 +40,12 @@ public class VariableFormatter : IFormatter
     }
 
     /// <summary>
-    /// Using the specified parameters and arguments, a formatted string shall be returned.
-    /// The <see cref="IMessageFormatter" /> is being provided as well, to enable
-    /// nested formatting. This is only called if <see cref="CanFormat" /> returns true.
-    /// The args will always contain the <see cref="FormatterRequest.Variable" />.
+    ///     Using the specified parameters and arguments, a formatted string shall be returned.
+    ///     The <see cref="IMessageFormatter" /> is being provided as well, to enable
+    ///     nested formatting. This is only called if <see cref="CanFormat" /> returns true.
+    ///     The args will always contain the <see cref="FormatterRequest.Variable" />.
     /// </summary>
-    /// <param name="locale">The locale being used. It is up to the formatter what they do with this information.</param>
+    /// <param name="culture">The culture being used. It is up to the formatter what they do with this information.</param>
     /// <param name="request">The parameters.</param>
     /// <param name="args">The arguments.</param>
     /// <param name="value">The value of <see cref="FormatterRequest.Variable" /> from the given args dictionary. Can be null.</param>
@@ -60,7 +53,7 @@ public class VariableFormatter : IFormatter
     /// <returns>
     /// The <see cref="string" />.
     /// </returns>
-    public string Format(string locale,
+    public string Format(CultureInfo culture,
         FormatterRequest request,
         IReadOnlyDictionary<string, object?> args,
         object? value,
@@ -69,26 +62,10 @@ public class VariableFormatter : IFormatter
         switch (value)
         {
             case IFormattable formattable:
-                return formattable.ToString(null, GetCultureInfo(locale));
+                return formattable.ToString(null, culture);
             default:
                 return value?.ToString() ?? string.Empty;
         }
-    }
-
-    /// <summary>
-    /// Get and cache the culture for a locale.
-    /// </summary>
-    /// <param name="locale">Locale for which to get the culture.</param>
-    /// <returns>
-    /// Culture of locale.
-    /// </returns>
-    private CultureInfo GetCultureInfo(string locale)
-    {
-        if (!this.cultures.ContainsKey(locale))
-        {
-            this.cultures[locale] = new CultureInfo(locale);
-        }
-        return this.cultures[locale];
     }
 
     #endregion

--- a/src/Jeffijoe.MessageFormat/Formatting/IFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/Formatting/IFormatter.cs
@@ -4,6 +4,7 @@
 // Copyright (C) Jeff Hansen 2014. All rights reserved.
 
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace Jeffijoe.MessageFormat.Formatting;
 
@@ -41,7 +42,7 @@ public interface IFormatter
     /// nested formatting. This is only called if <see cref="CanFormat" /> returns true.
     /// The args will always contain the <see cref="FormatterRequest.Variable" />.
     /// </summary>
-    /// <param name="locale">The locale being used. It is up to the formatter what they do with this information.</param>
+    /// <param name="culture">The culture being used. It is up to the formatter what they do with this information.</param>
     /// <param name="request">The parameters.</param>
     /// <param name="args">The arguments.</param>
     /// <param name="value">The value of <see cref="FormatterRequest.Variable"/> from the given args dictionary. Can be null.</param>
@@ -50,7 +51,7 @@ public interface IFormatter
     /// The <see cref="string" />.
     /// </returns>
     string Format(
-        string locale,
+        CultureInfo culture,
         FormatterRequest request,
         IReadOnlyDictionary<string, object?> args,
         object? value,

--- a/src/Jeffijoe.MessageFormat/IMessageFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/IMessageFormatter.cs
@@ -4,6 +4,7 @@
 // Copyright (C) Jeff Hansen 2014. All rights reserved.
 
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace Jeffijoe.MessageFormat;
 
@@ -32,10 +33,13 @@ public interface IMessageFormatter
     /// <param name="argsMap">
     ///     The arguments.
     /// </param>
+    /// <param name="culture">
+    ///     The culture to use, or <c>null</c> to use <see cref="CultureInfo.CurrentCulture"/>.
+    /// </param>
     /// <returns>
     ///     The <see cref="string" />.
     /// </returns>
-    string FormatMessage(string pattern, IReadOnlyDictionary<string, object?> argsMap);
+    string FormatMessage(string pattern, IReadOnlyDictionary<string, object?> argsMap, CultureInfo? culture = null);
 
     #endregion
 }

--- a/src/Jeffijoe.MessageFormat/Jeffijoe.MessageFormat.csproj
+++ b/src/Jeffijoe.MessageFormat/Jeffijoe.MessageFormat.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl>https://github.com/jeffijoe/messageformat.net</RepositoryUrl>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;netstandard2.0;netstandard2.1;net10.0</TargetFrameworks>
     <PolySharpIncludeRuntimeSupportedAttributes>true</PolySharpIncludeRuntimeSupportedAttributes>
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>

--- a/src/Jeffijoe.MessageFormat/Jeffijoe.MessageFormat.csproj
+++ b/src/Jeffijoe.MessageFormat/Jeffijoe.MessageFormat.csproj
@@ -35,8 +35,5 @@
     <ProjectReference Include="../Jeffijoe.MessageFormat.MetadataGenerator/Jeffijoe.MessageFormat.MetadataGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
-  <ItemGroup>
-    <CompilerVisibleProperty Include="PluralLanguagesMetadataExcludeLocales" />
-  </ItemGroup>
 
 </Project>

--- a/src/Jeffijoe.MessageFormat/Jeffijoe.MessageFormat.csproj
+++ b/src/Jeffijoe.MessageFormat/Jeffijoe.MessageFormat.csproj
@@ -20,8 +20,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="8.0.10" />
-    <PackageReference Include="MinVer" Version="6.0.0">
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="10.0.3" />
+    <PackageReference Include="MinVer" Version="7.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Jeffijoe.MessageFormat/MessageFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/MessageFormatter.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -64,19 +65,19 @@ public class MessageFormatter : IMessageFormatter
     /// <param name="useCache">
     ///     The use Cache.
     /// </param>
-    /// <param name="locale">
-    ///     The locale.
+    /// <param name="culture">
+    ///     The culture to use. Defaults to <see cref="CultureInfo.CurrentCulture"/> if not specified.
     /// </param>
     /// <param name="customValueFormatter">
     ///     The custom value formatter to use. Can be <c>null</c>.
     /// </param>
-    public MessageFormatter(bool useCache = true, string locale = "en",
+    public MessageFormatter(bool useCache = true, CultureInfo? culture = null,
         CustomValueFormatter? customValueFormatter = null)
         : this(
             patternParser: new PatternParser(new LiteralParser()),
             library: new FormatterLibrary(),
             useCache: useCache,
-            locale: locale,
+            culture: culture,
             customValueFormatter: customValueFormatter)
     {
     }
@@ -93,8 +94,8 @@ public class MessageFormatter : IMessageFormatter
     /// <param name="useCache">
     ///     if set to <c>true</c> uses the cache.
     /// </param>
-    /// <param name="locale">
-    ///     The locale to use. Formatters may need this.
+    /// <param name="culture">
+    ///     The culture to use. Formatters may need this. Defaults to <see cref="CultureInfo.CurrentCulture"/> if not specified.
     /// </param>
     /// <param name="customValueFormatter">
     ///     The custom value formatter to use. Can be <c>null</c>.
@@ -103,13 +104,13 @@ public class MessageFormatter : IMessageFormatter
         IPatternParser patternParser,
         IFormatterLibrary library,
         bool useCache,
-        string locale = "en",
+        CultureInfo? culture = null,
         CustomValueFormatter? customValueFormatter = null)
     {
         this.patternParser = patternParser ?? throw new ArgumentNullException("patternParser");
         this.library = library ?? throw new ArgumentNullException("library");
         this.CustomValueFormatter = customValueFormatter;
-        this.Locale = locale;
+        this.Culture = culture ?? CultureInfo.CurrentCulture;
         if (useCache)
         {
             this.cache = new ConcurrentDictionary<string, IFormatterRequestCollection>();
@@ -137,12 +138,12 @@ public class MessageFormatter : IMessageFormatter
     }
 
     /// <summary>
-    ///     Gets or sets the locale.
+    ///     Gets or sets the culture.
     /// </summary>
     /// <value>
-    ///     The locale.
+    ///     The culture.
     /// </value>
-    public string Locale { get; set; }
+    public CultureInfo Culture { get; set; }
 
     /// <summary>
     ///     Gets the custom cardinal pluralizers dictionary from the <see cref="PluralFormatter" />, if set. Key is the locale.
@@ -276,7 +277,7 @@ public class MessageFormatter : IMessageFormatter
                 }
 
                 // Double dispatch, yeah!
-                var result = formatter.Format(this.Locale, request, args, value, this);
+                var result = formatter.Format(this.Culture, request, args, value, this);
 
                 // First, we remove the literal from the source.
                 var sourceLiteral = request.SourceLiteral;

--- a/src/Jeffijoe.MessageFormat/MessageFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/MessageFormatter.cs
@@ -66,12 +66,13 @@ public class MessageFormatter : IMessageFormatter
     ///     The use Cache.
     /// </param>
     /// <param name="culture">
-    ///     The culture to use. Defaults to <see cref="CultureInfo.CurrentCulture"/> if not specified.
+    ///     The default culture to use, or <c>null</c> to use <see cref="CultureInfo.CurrentCulture"/>.
     /// </param>
     /// <param name="customValueFormatter">
     ///     The custom value formatter to use. Can be <c>null</c>.
     /// </param>
-    public MessageFormatter(bool useCache = true, CultureInfo? culture = null,
+    public MessageFormatter(bool useCache = true,
+        CultureInfo? culture = null,
         CustomValueFormatter? customValueFormatter = null)
         : this(
             patternParser: new PatternParser(new LiteralParser()),
@@ -95,7 +96,7 @@ public class MessageFormatter : IMessageFormatter
     ///     if set to <c>true</c> uses the cache.
     /// </param>
     /// <param name="culture">
-    ///     The culture to use. Formatters may need this. Defaults to <see cref="CultureInfo.CurrentCulture"/> if not specified.
+    ///     The default culture to use, or <c>null</c> to use <see cref="CultureInfo.CurrentCulture"/>.
     /// </param>
     /// <param name="customValueFormatter">
     ///     The custom value formatter to use. Can be <c>null</c>.
@@ -109,8 +110,8 @@ public class MessageFormatter : IMessageFormatter
     {
         this.patternParser = patternParser ?? throw new ArgumentNullException("patternParser");
         this.library = library ?? throw new ArgumentNullException("library");
+        this.Culture = culture;
         this.CustomValueFormatter = customValueFormatter;
-        this.Culture = culture ?? CultureInfo.CurrentCulture;
         if (useCache)
         {
             this.cache = new ConcurrentDictionary<string, IFormatterRequestCollection>();
@@ -120,6 +121,11 @@ public class MessageFormatter : IMessageFormatter
     #endregion
 
     #region Public Properties
+
+    /// <summary>
+    ///     The default culture to use for formatting, or <c>null</c> to use <see cref="CultureInfo.CurrentCulture"/>.
+    /// </summary>
+    public CultureInfo? Culture { get; }
 
     /// <summary>
     ///     The custom value formatter to use for formats like `number`, `date`, `time` etc.
@@ -136,14 +142,6 @@ public class MessageFormatter : IMessageFormatter
     {
         get { return this.library; }
     }
-
-    /// <summary>
-    ///     Gets or sets the culture.
-    /// </summary>
-    /// <value>
-    ///     The culture.
-    /// </value>
-    public CultureInfo Culture { get; set; }
 
     /// <summary>
     ///     Gets the custom cardinal pluralizers dictionary from the <see cref="PluralFormatter" />, if set. Key is the locale.
@@ -193,7 +191,7 @@ public class MessageFormatter : IMessageFormatter
     ///     Formats the specified pattern with the specified data.
     /// </summary>
     /// <remarks>
-    ///     This method calls <see cref="Format(string, IReadOnlyDictionary{string, object})"/>
+    ///     This method calls <see cref="FormatMessage(string, IReadOnlyDictionary{string, object}, CultureInfo)"/>
     ///     on a singleton instance using a lock.
     ///     Do not use in a tight loop, as a lock is being used to ensure thread safety.
     /// </remarks>
@@ -203,14 +201,17 @@ public class MessageFormatter : IMessageFormatter
     /// <param name="data">
     ///     The data.
     /// </param>
+    /// <param name="culture">
+    ///     The culture to use, or <c>null</c> to use <see cref="CultureInfo.CurrentCulture"/>.
+    /// </param>
     /// <returns>
     ///     The formatted message.
     /// </returns>
-    public static string Format(string pattern, IReadOnlyDictionary<string, object?> data)
+    public static string Format(string pattern, IReadOnlyDictionary<string, object?> data, CultureInfo? culture = null)
     {
         lock (Lock)
         {
-            return Instance.FormatMessage(pattern, data);
+            return Instance.FormatMessage(pattern, data, culture);
         }
     }
 
@@ -218,7 +219,7 @@ public class MessageFormatter : IMessageFormatter
     ///     Formats the specified pattern with the specified data.
     /// </summary>
     /// This method calls
-    /// <see cref="MessageFormatterExtensions.FormatMessage(Jeffijoe.MessageFormat.IMessageFormatter,string,object)" />
+    /// <see cref="MessageFormatterExtensions.FormatMessage(IMessageFormatter,string,object,CultureInfo)" />
     /// on a singleton instance using a lock.
     /// Do not use in a tight loop, as a lock is being used to ensure thread safety.
     /// <param name="pattern">
@@ -227,16 +228,19 @@ public class MessageFormatter : IMessageFormatter
     /// <param name="data">
     ///     The data.
     /// </param>
+    /// <param name="culture">
+    ///     The culture to use, or <c>null</c> to use <see cref="CultureInfo.CurrentCulture"/>.
+    /// </param>
     /// <returns>
     ///     The formatted message.
     /// </returns>
     [OverloadResolutionPriority(-1)]
     [RequiresUnreferencedCode("This method uses the FormatMessage extension which uses reflection to convert object into dictionary")]
-    public static string Format(string pattern, object data)
+    public static string Format(string pattern, object data, CultureInfo? culture = null)
     {
         lock (Lock)
         {
-            return Instance.FormatMessage(pattern, data);
+            return Instance.FormatMessage(pattern, data, culture);
         }
     }
 
@@ -249,15 +253,19 @@ public class MessageFormatter : IMessageFormatter
     /// <param name="args">
     ///     The arguments.
     /// </param>
+    /// <param name="culture">
+    ///     The culture to use, or <c>null</c> to use <see cref="CultureInfo.CurrentCulture"/>.
+    /// </param>
     /// <returns>
     ///     The <see cref="string" />.
     /// </returns>
-    public string FormatMessage(string pattern, IReadOnlyDictionary<string, object?> args)
+    public string FormatMessage(string pattern, IReadOnlyDictionary<string, object?> args, CultureInfo? culture = null)
     {
         /*
          * We are assuming the formatters are ordered correctly
          * - that is, from left to right, string-wise.
          */
+        var activeCulture = culture ?? this.Culture ?? CultureInfo.CurrentCulture;
         var sourceBuilder = StringBuilderPool.Get();
 
         try
@@ -277,7 +285,7 @@ public class MessageFormatter : IMessageFormatter
                 }
 
                 // Double dispatch, yeah!
-                var result = formatter.Format(this.Culture, request, args, value, this);
+                var result = formatter.Format(activeCulture, request, args, value, this);
 
                 // First, we remove the literal from the source.
                 var sourceLiteral = request.SourceLiteral;

--- a/src/Jeffijoe.MessageFormat/MessageFormatterExtensions.cs
+++ b/src/Jeffijoe.MessageFormat/MessageFormatterExtensions.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using Jeffijoe.MessageFormat.Helpers;
 
@@ -22,15 +23,19 @@ public static class MessageFormatterExtensions
     /// <param name="args">
     ///     The arguments.
     /// </param>
+    /// <param name="culture">
+    ///     The culture to use, or <c>null</c> to use <see cref="CultureInfo.CurrentCulture"/>.
+    /// </param>
     /// <returns>
     ///     The <see cref="string" />.
     /// </returns>
     public static string FormatMessage(
         this IMessageFormatter formatter,
         string pattern,
-        IDictionary<string, object> args)
+        IDictionary<string, object> args,
+        CultureInfo? culture = null)
     {
-        return formatter.FormatMessage(pattern, (IReadOnlyDictionary<string, object?>)args);
+        return formatter.FormatMessage(pattern, (IReadOnlyDictionary<string, object?>)args, culture);
     }
 
     /// <summary>
@@ -45,13 +50,16 @@ public static class MessageFormatterExtensions
     /// <param name="args">
     ///     The arguments.
     /// </param>
+    /// <param name="culture">
+    ///     The culture to use, or <c>null</c> to use <see cref="CultureInfo.CurrentCulture"/>.
+    /// </param>
     /// <returns>
     ///     The <see cref="string" />.
     /// </returns>
     [OverloadResolutionPriority(-1)]
     [RequiresUnreferencedCode("This method uses the ToDictionary extension which uses reflection to convert object into dictionary")]
-    public static string FormatMessage(this IMessageFormatter formatter, string pattern, object args)
+    public static string FormatMessage(this IMessageFormatter formatter, string pattern, object args, CultureInfo? culture = null)
     {
-        return formatter.FormatMessage(pattern, args.ToDictionary());
+        return formatter.FormatMessage(pattern, args.ToDictionary(), culture);
     }
 }


### PR DESCRIPTION
This PR changes the default culture to `CurrentCulture`, adds a `CultureInfo? culture = null`  parameter to `FormatMessage`, and upgrades the build targeting to `net10`, dropping `net6`. Also migrated from Source Generator to Incremental Generator API for the plural rules generator, as well as updated packages.

**These are all breaking changes.**

Closes #41